### PR TITLE
Prepare 1.0.0 release (docs, Readme, release workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Create source and wheel dist
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_ORG_TOKEN }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+   configuration: docs/source/conf.py
+
+python:
+   install:
+   - requirements: requirements.txt
+   - requirements: docs/add-requirements.txt

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Shell elements
 * check if two given xml, json or aasx files contain the same Asset Administration Shell elements in any order 
 
 Invoking should work with either `python -m aas.compliance_tool.cli` or (when installed correctly and PATH is set 
-correctly) with `aas_compliance_check` on the command line.
+correctly) with `aas-compliance-check` on the command line.
 
 For further usage information consider the `aas.compliance_tool`-package or invoke with 
-`python -m aas.compliance_tool.cli --help` respectively `aas_compliance_check --help`.
+`python -m aas.compliance_tool.cli --help` respectively `aas-compliance-check --help`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -122,18 +122,13 @@ with open('Simple_Submodel.xml', 'w', encoding='utf-8') as f:
 
 ### Examples and Tutorials
 
-For further examples and tutorials, check out the `aas.examples`-package. Here is a quick overview:
+For further examples and tutorials, check out the `basyx.aas.examples`-package. Here is a quick overview:
 
-* `aas.examples.tutorial_create_simple_aas`: Create an Asset Administration Shell, including an Asset object and a 
-  Submodel
-* `aas.examples.tutorial_storage`: Manage a larger number of Asset Administration Shells in an ObjectStore and resolve
-  references
-* `aas.examples.tutorial_serialization_deserialization`: Use the JSON and XML serialization/deserialization for
-  single objects or full standard-compliant files 
-* `aas.examples.tutorial_aasx`: Export Asset Administration Shells with related objects and auxiliary files to AASX 
-  package files
-* `aas.examples.tutorial_backend_couchdb`: Use the *Backends* interface (`update()/commit()` methods) to manage and
-  retrieve AAS objects in a CouchDB document database 
+* [`tutorial_create_simple_aas`](./basyx/aas/examples/tutorial_create_simple_aas.py): Create an Asset Administration Shell, including an Asset object and a Submodel
+* [`tutorial_storage`](./basyx/aas/examples/tutorial_storage.py): Manage a larger number of Asset Administration Shells in an ObjectStore and resolve references
+* [`tutorial_serialization_deserialization`](./basyx/aas/examples/tutorial_serialization_deserialization.py): Use the JSON and XML serialization/deserialization for single objects or full standard-compliant files
+* [`tutorial_aasx`](./basyx/aas/examples/tutorial_aasx.py): Export Asset Administration Shells with related objects and auxiliary files to AASX package files
+* [`tutorial_backend_couchdb`](./basyx/aas/examples/tutorial_backend_couchdb.py): Use the *Backends* interface (`update()/commit()` methods) to manage and retrieve AAS objects in a CouchDB document database
 
 
 ### Compliance Tool

--- a/README.md
+++ b/README.md
@@ -145,10 +145,7 @@ correctly) with `aas_compliance_check` on the command line.
 For further usage information consider the `aas.compliance_tool`-package or invoke with 
 `python -m aas.compliance_tool.cli --help` respectively `aas_compliance_check --help`.
 
-## Contributing
-
-TBD
-
+## Development
 
 ### Codestyle and Testing
 
@@ -175,8 +172,3 @@ pip install coverage
 coverage run --source aas --branch -m unittest
 coverage report -m
 ```
-
-
-### Contribute Code/Patches
-
-TBD

--- a/README.md
+++ b/README.md
@@ -63,7 +63,17 @@ Development/testing/example dependencies (see `requirements.txt`):
 
 ### Installation
 
-TBD
+Eclipse BaSyx Python SDK can be installed from PyPI, the Python Package Index, just as nearly every other Python package:
+```bash
+pip install basyx-python-sdk
+``` 
+
+For working with the current development version, you can also install the package directly from GitHub, using Pip's Git feature:
+```bash
+pip install git+https://github.com/eclipse-basyx/basyx-python-sdk.git@main
+```
+
+You may want to use a Python's `venv` or a similar tool to install BaSyx Python SDK and its dependencies only in a project-specific local environment. 
 
 
 ### Example

--- a/basyx/aas/adapter/__init__.py
+++ b/basyx/aas/adapter/__init__.py
@@ -2,8 +2,8 @@
 This package contains different kinds of adapters.
 
 * :ref:`json <adapter.json.__init__>`: This package offers an adapter for serialization and deserialization of BaSyx
-Python SDK objects to/from JSON.
+  Python SDK objects to/from JSON.
 * :ref:`xml <adapter.xml.__init__>`: This package offers an adapter for serialization and deserialization of BaSyx
-Python SDK objects to/from XML.
+  Python SDK objects to/from XML.
 * :ref:`aasx <adapter.aasx>`: This package offers functions for reading and writing AASX-files.
 """

--- a/basyx/aas/compliance_tool/cli.py
+++ b/basyx/aas/compliance_tool/cli.py
@@ -53,7 +53,7 @@ def parse_cli_arguments() -> argparse.ArgumentParser:
                     'xml (--xml).\n'
                     'All features except "schema" support reading/writing AASX packages instead of plain XML or JSON '
                     'files via the --aasx option.\n\n'
-                    'Additionally, the tool offers some extra features for more convenient usage:\n'
+                    'Additionally, the tool offers some extra features for more convenient usage:\n\n'
                     'a. Different levels of verbosity:\n'
                     '   Default output is just the status for each step performed. With -v or --verbose, additional '
                     'information in case of status = FAILED will be provided. With one more -v or --verbose, additional'

--- a/docs/add-requirements.txt
+++ b/docs/add-requirements.txt
@@ -1,0 +1,4 @@
+# Additional requirements for building the docs
+sphinx~=4.4
+sphinx-rtd-theme~=1.0
+sphinx-argparse~=0.3.1

--- a/docs/source/adapter/aasx.rst
+++ b/docs/source/adapter/aasx.rst
@@ -1,5 +1,5 @@
 adapter.aasx - Read and write AASX-files
 ========================================
 
-.. automodule:: aas.adapter.aasx
+.. automodule:: basyx.aas.adapter.aasx
       :members:

--- a/docs/source/adapter/index.rst
+++ b/docs/source/adapter/index.rst
@@ -1,7 +1,7 @@
 adapter: Adapter of AAS-objects from and to different file-formats
 ==================================================================
 
-.. automodule:: aas.adapter.__init__
+.. automodule:: basyx.aas.adapter.__init__
       :members:
 
 .. toctree::

--- a/docs/source/adapter/json.rst
+++ b/docs/source/adapter/json.rst
@@ -1,19 +1,19 @@
 adapter.json - JSON serialization and deserialization
 =====================================================
 
-.. automodule:: aas.adapter.json.__init__
+.. automodule:: basyx.aas.adapter.json.__init__
       :members:
 
 
 adapter.json.json_serialization: JSON serialization of AAS objects
 ##################################################################
 
-.. automodule:: aas.adapter.json.json_serialization
+.. automodule:: basyx.aas.adapter.json.json_serialization
       :members:
 
 
 adapter.json.json_deserialization: JSON deserialization into AAS objects
 ########################################################################
 
-.. automodule:: aas.adapter.json.json_deserialization
+.. automodule:: basyx.aas.adapter.json.json_deserialization
       :members:

--- a/docs/source/adapter/xml.rst
+++ b/docs/source/adapter/xml.rst
@@ -1,31 +1,31 @@
 adapter.xml - XML serialization and deserialization
 ===================================================
 
-.. automodule:: aas.adapter.xml.__init__
+.. automodule:: basyx.aas.adapter.xml.__init__
       :members:
 
 adapter.xml.xml_serialization - Serialization from AAS-objects to XML
 #####################################################################
 
-.. automodule:: aas.adapter.xml.xml_serialization
+.. automodule:: basyx.aas.adapter.xml.xml_serialization
 
-.. autofunction:: aas.adapter.xml.xml_serialization.write_aas_xml_file
+.. autofunction:: basyx.aas.adapter.xml.xml_serialization.write_aas_xml_file
 
 adapter.xml.xml_deserialization - Deserialization from XML to AAS-objects
 #########################################################################
 
-.. automodule:: aas.adapter.xml.xml_deserialization
+.. automodule:: basyx.aas.adapter.xml.xml_deserialization
 
-.. autoclass:: aas.adapter.xml.xml_deserialization.AASFromXmlDecoder
+.. autoclass:: basyx.aas.adapter.xml.xml_deserialization.AASFromXmlDecoder
 
-.. autoclass:: aas.adapter.xml.xml_deserialization.StrictAASFromXmlDecoder
+.. autoclass:: basyx.aas.adapter.xml.xml_deserialization.StrictAASFromXmlDecoder
 
-.. autoclass:: aas.adapter.xml.xml_deserialization.StrippedAASFromXmlDecoder
+.. autoclass:: basyx.aas.adapter.xml.xml_deserialization.StrippedAASFromXmlDecoder
 
-.. autoclass:: aas.adapter.xml.xml_deserialization.StrictStrippedAASFromXmlDecoder
+.. autoclass:: basyx.aas.adapter.xml.xml_deserialization.StrictStrippedAASFromXmlDecoder
 
-.. autofunction:: aas.adapter.xml.xml_deserialization.read_aas_xml_file
+.. autofunction:: basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file
 
-.. autofunction:: aas.adapter.xml.xml_deserialization.read_aas_xml_file_into
+.. autofunction:: basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into
 
-.. autofunction:: aas.adapter.xml.xml_deserialization.read_aas_xml_element
+.. autofunction:: basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_element

--- a/docs/source/backend/backends.rst
+++ b/docs/source/backend/backends.rst
@@ -1,5 +1,5 @@
 aas.backend.backends - Base class and functionality for Backends
 ================================================================
 
-.. automodule:: aas.backend.backends
+.. automodule:: basyx.aas.backend.backends
       :members:

--- a/docs/source/backend/couchdb.rst
+++ b/docs/source/backend/couchdb.rst
@@ -2,5 +2,5 @@ aas.backend.couchdb - Store and Retrieve AAS-objects in an CouchDB Backend
 ==========================================================================
 
 
-.. automodule:: aas.backend.couchdb
+.. automodule:: basyx.aas.backend.couchdb
       :members:

--- a/docs/source/backend/index.rst
+++ b/docs/source/backend/index.rst
@@ -1,7 +1,7 @@
 aas.backend - Storing and Retrieving of AAS-objects in Backends
 ===============================================================
 
-.. automodule:: aas.backend.__init__
+.. automodule:: basyx.aas.backend.__init__
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/compliance_tool/compliance_check_aasx.rst
+++ b/docs/source/compliance_tool/compliance_check_aasx.rst
@@ -1,6 +1,6 @@
 aas.compliance_tool.compliance_check_aasx - Check AASX-File compliance
 ======================================================================
 
-.. automodule:: aas.compliance_tool.compliance_check_aasx
+.. automodule:: basyx.aas.compliance_tool.compliance_check_aasx
       :members:
 

--- a/docs/source/compliance_tool/compliance_check_json.rst
+++ b/docs/source/compliance_tool/compliance_check_json.rst
@@ -1,6 +1,6 @@
 aas.compliance_tool.compliance_check_json - Check JSON-File compliance
 ======================================================================
 
-.. automodule:: aas.compliance_tool.compliance_check_json
+.. automodule:: basyx.aas.compliance_tool.compliance_check_json
       :members:
 

--- a/docs/source/compliance_tool/compliance_check_xml.rst
+++ b/docs/source/compliance_tool/compliance_check_xml.rst
@@ -1,6 +1,6 @@
 aas.compliance_tool.compliance_check_xml - Check XML-File compliance
 ====================================================================
 
-.. automodule:: aas.compliance_tool.compliance_check_xml
+.. automodule:: basyx.aas.compliance_tool.compliance_check_xml
       :members:
 

--- a/docs/source/compliance_tool/index.rst
+++ b/docs/source/compliance_tool/index.rst
@@ -2,7 +2,7 @@ aas.compliance_tool - Tool for Creating and Checking JSON, XML and AASX Files' c
 =========================================================================================
 
 .. argparse::
-    :module: aas.compliance_tool.cli
+    :module: basyx.aas.compliance_tool.cli
     :func: parse_cli_arguments
     :prog: cli
 

--- a/docs/source/compliance_tool/state_manager.rst
+++ b/docs/source/compliance_tool/state_manager.rst
@@ -1,5 +1,5 @@
 aas.compliance_tool.state_manager - Store LogRecords in a Compliance Check of the Compliance Tool
 =================================================================================================
 
-.. automodule:: aas.compliance_tool.state_manager
+.. automodule:: basyx.aas.compliance_tool.state_manager
       :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,6 @@ import os
 import sys
 import datetime
 
-import sphinx_rtd_theme
-
 
 sys.path.insert(0, os.path.abspath('../..'))
 

--- a/docs/source/examples/example_aas.rst
+++ b/docs/source/examples/example_aas.rst
@@ -1,5 +1,5 @@
 aas.examples.data.example_aas - Create an example model.AssetAdministrationShell object
 =======================================================================================
 
-.. automodule:: aas.examples.data.example_aas
+.. automodule:: basyx.aas.examples.data.example_aas
       :members:

--- a/docs/source/examples/example_aas_mandatory_attributes.rst
+++ b/docs/source/examples/example_aas_mandatory_attributes.rst
@@ -1,6 +1,6 @@
 aas.examples.data.example_aas_mandatory_attributes - AAS-objects that only contain mandatory attributes
 =======================================================================================================
 
-.. automodule:: aas.examples.data.example_aas_mandatory_attributes
+.. automodule:: basyx.aas.examples.data.example_aas_mandatory_attributes
       :members:
 

--- a/docs/source/examples/example_aas_missing_attributes.rst
+++ b/docs/source/examples/example_aas_missing_attributes.rst
@@ -1,6 +1,6 @@
 aas.examples.data.example_aas_missing_attributes - AAS-objects containing non-mandatory attributes
 ==================================================================================================
 
-.. automodule:: aas.examples.data.example_aas_missing_attributes
+.. automodule:: basyx.aas.examples.data.example_aas_missing_attributes
       :members:
 

--- a/docs/source/examples/example_concept_description.rst
+++ b/docs/source/examples/example_concept_description.rst
@@ -1,5 +1,5 @@
 aas.examples.data.example_concept_description - Create an example ConceptDescription
 ====================================================================================
 
-.. automodule:: aas.examples.data.example_concept_description
+.. automodule:: basyx.aas.examples.data.example_concept_description
       :members:

--- a/docs/source/examples/example_submodel_template.rst
+++ b/docs/source/examples/example_submodel_template.rst
@@ -1,5 +1,5 @@
 aas.examples.data.example_submodel_template - Create an Example Submodel Template
 =================================================================================
 
-.. automodule:: aas.examples.data.example_submodel_template
+.. automodule:: basyx.aas.examples.data.example_submodel_template
       :members:

--- a/docs/source/model/aas.rst
+++ b/docs/source/model/aas.rst
@@ -1,5 +1,5 @@
 aas.model.aas - High-level structures
 =====================================
 
-.. automodule:: aas.model.aas
+.. automodule:: basyx.aas.model.aas
       :members:

--- a/docs/source/model/base.rst
+++ b/docs/source/model/base.rst
@@ -1,7 +1,7 @@
 aas.model.base - Abstract Classes and Basic Structures
 ======================================================
 
-.. automodule:: aas.model.base
+.. automodule:: basyx.aas.model.base
       :members:
 
 .. class:: LangStringSet

--- a/docs/source/model/concept.rst
+++ b/docs/source/model/concept.rst
@@ -1,5 +1,5 @@
 aas.model.concept - ConceptDescription and Dictionary
 =====================================================
 
-.. automodule:: aas.model.concept
+.. automodule:: basyx.aas.model.concept
       :members:

--- a/docs/source/model/datatypes.rst
+++ b/docs/source/model/datatypes.rst
@@ -1,5 +1,5 @@
 aas.model.datatypes - Native Python Datatypes for Simple XSD-types
 ==================================================================
 
-.. automodule:: aas.model.datatypes
+.. automodule:: basyx.aas.model.datatypes
       :members:

--- a/docs/source/model/index.rst
+++ b/docs/source/model/index.rst
@@ -1,7 +1,7 @@
 aas.model - Python Model of the AssetAdministrationShell Metamodel
 ==================================================================
 
-.. automodule:: aas.model.__init__
+.. automodule:: basyx.aas.model.__init__
       :members:
 
 *Note:* Since the Class-Attributes usually have the same names as the `__init__`-constructor

--- a/docs/source/model/provider.rst
+++ b/docs/source/model/provider.rst
@@ -1,5 +1,5 @@
 aas.model.provider - Providers for storing and retrieving AAS-objects
 =====================================================================
 
-.. automodule:: aas.model.provider
+.. automodule:: basyx.aas.model.provider
       :members:

--- a/docs/source/model/security.rst
+++ b/docs/source/model/security.rst
@@ -1,5 +1,5 @@
 aas.model.security - Security model of the AAS (currently not existing)
 =======================================================================
 
-.. automodule:: aas.model.security
+.. automodule:: basyx.aas.model.security
       :members:

--- a/docs/source/model/submodel.rst
+++ b/docs/source/model/submodel.rst
@@ -1,5 +1,5 @@
 aas.model.submodel - Meta-model of the submodels and events
 ===========================================================
 
-.. automodule:: aas.model.submodel
+.. automodule:: basyx.aas.model.submodel
       :members:

--- a/docs/source/tutorials/tutorial_aasx.rst
+++ b/docs/source/tutorials/tutorial_aasx.rst
@@ -3,5 +3,5 @@ Tutorial: AASX
 
 .. _tutorial_aasx:
 
-.. literalinclude:: ../../../aas/examples/tutorial_aasx.py
+.. literalinclude:: ../../../basyx/aas/examples/tutorial_aasx.py
   :language: python

--- a/docs/source/tutorials/tutorial_backend_couchdb.rst
+++ b/docs/source/tutorials/tutorial_backend_couchdb.rst
@@ -3,5 +3,5 @@ Tutorial: Backend Couchdb
 
 .. _tutorial_backend_couchdb:
 
-.. literalinclude:: ../../../aas/examples/tutorial_backend_couchdb.py
+.. literalinclude:: ../../../basyx/aas/examples/tutorial_backend_couchdb.py
   :language: python

--- a/docs/source/tutorials/tutorial_create_simple_aas.rst
+++ b/docs/source/tutorials/tutorial_create_simple_aas.rst
@@ -3,5 +3,5 @@ Tutorial: Create a Simple AAS
 
 .. _tutorial_create_simple_aas:
 
-.. literalinclude:: ../../../aas/examples/tutorial_create_simple_aas.py
+.. literalinclude:: ../../../basyx/aas/examples/tutorial_create_simple_aas.py
   :language: python

--- a/docs/source/tutorials/tutorial_serialization_deserialization.rst
+++ b/docs/source/tutorials/tutorial_serialization_deserialization.rst
@@ -3,5 +3,5 @@ Tutorial: Serialization Deserialization
 
 .. _tutorial_serialization_deserialization:
 
-.. literalinclude:: ../../../aas/examples/tutorial_serialization_deserialization.py
+.. literalinclude:: ../../../basyx/aas/examples/tutorial_serialization_deserialization.py
   :language: python

--- a/docs/source/tutorials/tutorial_storage.rst
+++ b/docs/source/tutorials/tutorial_storage.rst
@@ -3,5 +3,5 @@ Tutorial: Storage
 
 .. _tutorial_storage:
 
-.. literalinclude:: ../../../aas/examples/tutorial_storage.py
+.. literalinclude:: ../../../basyx/aas/examples/tutorial_storage.py
   :language: python

--- a/docs/source/util/identification.rst
+++ b/docs/source/util/identification.rst
@@ -1,5 +1,5 @@
 aas.util.identification - Generate Identifiers
 ==============================================
 
-.. automodule:: aas.util.identification
+.. automodule:: basyx.aas.util.identification
       :members:

--- a/docs/source/util/index.rst
+++ b/docs/source/util/index.rst
@@ -1,7 +1,7 @@
 aas.util - Provide helpful utilities
 ====================================
 
-.. automodule:: aas.util.__init__
+.. automodule:: basyx.aas.util.__init__
       :members:
 
 .. toctree::

--- a/docs/source/util/traversal.rst
+++ b/docs/source/util/traversal.rst
@@ -2,5 +2,5 @@ aas.util.traversal - Functions for Traversing AAS Object structures
 ===================================================================
 
 
-.. automodule:: aas.util.traversal
+.. automodule:: basyx.aas.util.traversal
       :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ lxml>=4.2,<5
 python-dateutil>=2.8,<3.0
 types-python-dateutil
 pyecma376-2>=0.2.4
-psutil>=5.6
+psutil>=5.4.8
 urllib3>=1.26<2.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     ],
     entry_points={
         'console_scripts': [
-            "aas_compliance_check = basyx.aas.compliance_tool.cli:main"
+            "aas-compliance-check = basyx.aas.compliance_tool.cli:main"
         ]
     },
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
                 "systems",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/eclipse-basyx/basyx-java-sdk",
+    url="https://github.com/eclipse-basyx/basyx-python-sdk",
     packages=setuptools.find_packages(exclude=["test", "test.*"]),
     zip_safe=False,
     package_data={

--- a/test/adapter/json/test_json_deserialization.py
+++ b/test/adapter/json/test_json_deserialization.py
@@ -33,7 +33,7 @@ class JsonDeserializationTest(unittest.TestCase):
             read_aas_json_file(io.StringIO(data), failsafe=False)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             read_aas_json_file(io.StringIO(data), failsafe=True)
-        self.assertIn("submodels", cm.output[0])
+        self.assertIn("submodels", cm.output[0])  # type: ignore
 
     def test_file_format_wrong_list(self) -> None:
         data = """
@@ -58,8 +58,8 @@ class JsonDeserializationTest(unittest.TestCase):
             read_aas_json_file(io.StringIO(data), failsafe=False)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             read_aas_json_file(io.StringIO(data), failsafe=True)
-        self.assertIn("submodels", cm.output[0])
-        self.assertIn("Asset", cm.output[0])
+        self.assertIn("submodels", cm.output[0])  # type: ignore
+        self.assertIn("Asset", cm.output[0])  # type: ignore
 
     def test_file_format_unknown_object(self) -> None:
         data = """
@@ -75,8 +75,8 @@ class JsonDeserializationTest(unittest.TestCase):
             read_aas_json_file(io.StringIO(data), failsafe=False)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             read_aas_json_file(io.StringIO(data), failsafe=True)
-        self.assertIn("submodels", cm.output[0])
-        self.assertIn("'foo'", cm.output[0])
+        self.assertIn("submodels", cm.output[0])  # type: ignore
+        self.assertIn("'foo'", cm.output[0])  # type: ignore
 
     def test_broken_asset(self) -> None:
         data = """
@@ -103,7 +103,7 @@ class JsonDeserializationTest(unittest.TestCase):
         # In failsafe mode, we should get a log entry and the first Asset entry should be returned as untouched dict
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             parsed_data = json.loads(data, cls=AASFromJsonDecoder)
-        self.assertIn("identification", cm.output[0])
+        self.assertIn("identification", cm.output[0])  # type: ignore
         self.assertIsInstance(parsed_data, list)
         self.assertEqual(3, len(parsed_data))
 
@@ -142,15 +142,15 @@ class JsonDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             with self.assertRaisesRegex(TypeError, r"SubmodelElement.*Asset"):
                 json.loads(data, cls=StrictAASFromJsonDecoder)
-        self.assertIn("modelType", cm.output[0])
+        self.assertIn("modelType", cm.output[0])  # type: ignore
 
         # In failsafe mode, we should get a log entries for the broken object and the wrong type of the first two
         #   submodelElements
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as cm:
             parsed_data = json.loads(data, cls=AASFromJsonDecoder)
-        self.assertGreaterEqual(len(cm.output), 3)
-        self.assertIn("SubmodelElement", cm.output[1])
-        self.assertIn("SubmodelElement", cm.output[2])
+        self.assertGreaterEqual(len(cm.output), 3)  # type: ignore
+        self.assertIn("SubmodelElement", cm.output[1])  # type: ignore
+        self.assertIn("SubmodelElement", cm.output[2])  # type: ignore
 
         self.assertIsInstance(parsed_data[0], model.Submodel)
         self.assertEqual(1, len(parsed_data[0].submodel_element))
@@ -183,7 +183,7 @@ class JsonDeserializationTest(unittest.TestCase):
         string_io = io.StringIO(data)
         with self.assertLogs(logging.getLogger(), level=logging.ERROR) as cm:
             read_aas_json_file(string_io, failsafe=True)
-        self.assertIn("duplicate identifier", cm.output[0])
+        self.assertIn("duplicate identifier", cm.output[0])  # type: ignore
         string_io.seek(0)
         with self.assertRaisesRegex(KeyError, r"duplicate identifier"):
             read_aas_json_file(string_io, failsafe=False)
@@ -224,7 +224,7 @@ class JsonDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.INFO) as log_ctx:
             identifiers = read_aas_json_file_into(object_store, string_io, replace_existing=False, ignore_existing=True)
         self.assertEqual(len(identifiers), 0)
-        self.assertIn("already exists in the object store", log_ctx.output[0])
+        self.assertIn("already exists in the object store", log_ctx.output[0])  # type: ignore
         submodel = object_store.pop()
         self.assertIsInstance(submodel, model.Submodel)
         self.assertEqual(submodel.id_short, "test123")

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -55,7 +55,7 @@ class XmlDeserializationTest(unittest.TestCase):
             read_aas_xml_file(bytes_io, failsafe=False)
         cause = _root_cause(err_ctx.exception)
         for s in strings:
-            self.assertIn(s, log_ctx.output[0])
+            self.assertIn(s, log_ctx.output[0])  # type: ignore
             self.assertIn(s, str(cause))
 
     def test_malformed_xml(self) -> None:
@@ -182,7 +182,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
         for s in ("GLOBAL_REFERENCE", "IRI=http://acplt.org/test_ref", "Asset"):
-            self.assertIn(s, context.output[0])
+            self.assertIn(s, context.output[0])  # type: ignore
 
     def test_invalid_submodel_element(self) -> None:
         # TODO: simplify this should our suggestion regarding the XML schema get accepted
@@ -270,7 +270,7 @@ class XmlDeserializationTest(unittest.TestCase):
         """)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
-        self.assertIn("aas:value", context.output[0])
+        self.assertIn("aas:value", context.output[0])  # type: ignore
 
     def test_duplicate_identifier(self) -> None:
         xml = _xml_wrap("""
@@ -324,7 +324,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.INFO) as log_ctx:
             identifiers = read_aas_xml_file_into(object_store, bytes_io, replace_existing=False, ignore_existing=True)
         self.assertEqual(len(identifiers), 0)
-        self.assertIn("already exists in the object store", log_ctx.output[0])
+        self.assertIn("already exists in the object store", log_ctx.output[0])  # type: ignore
         submodel = object_store.pop()
         self.assertIsInstance(submodel, model.Submodel)
         self.assertEqual(submodel.id_short, "test123")


### PR DESCRIPTION
This PR contributes some final preparations for the 1.0.0 release of Eclipse BaSyx Python SDK:

- Fix Sphinx documentation (missing requirements, wrong imports caused by rebranding)
- Add configuration file for readthedocs.org
- Add GitHub Actions workflow for automated publishing of Releases' Python distributions to PyPI
- Improve README.md
- Change entrypoint (executable name) of the compliance check cli tool

The GitHub Actions `release` workflow may require to allow execution of the external official PyPI upload Action `pypa/gh-action-pypi-publish`.

Open tasks for the release:
- Bump version number in `setup.py` and `docs/source/conf.py`
