### PR TITLE
Various minor fixes

### DIFF
--- a/basyx/aas/adapter/json/json_serialization.py
+++ b/basyx/aas/adapter/json/json_serialization.py
@@ -714,9 +714,9 @@ def _create_dict(data: model.AbstractObjectStore) -> dict:
             assets.append(obj)
         if isinstance(obj, model.AssetAdministrationShell):
             asset_administration_shells.append(obj)
-        if isinstance(obj, model.Submodel):
+        elif isinstance(obj, model.Submodel):
             submodels.append(obj)
-        if isinstance(obj, model.ConceptDescription):
+        elif isinstance(obj, model.ConceptDescription):
             concept_descriptions.append(obj)
     dict_ = {
         'assetAdministrationShells': asset_administration_shells,

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -870,9 +870,9 @@ def write_aas_xml_file(file: IO,
             assets.append(obj)
         if isinstance(obj, model.AssetAdministrationShell):
             asset_administration_shells.append(obj)
-        if isinstance(obj, model.Submodel):
+        elif isinstance(obj, model.Submodel):
             submodels.append(obj)
-        if isinstance(obj, model.ConceptDescription):
+        elif isinstance(obj, model.ConceptDescription):
             concept_descriptions.append(obj)
 
     # serialize objects to XML

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -325,6 +325,8 @@ class AdministrativeInformation:
             self._revision = revision
 
     def __eq__(self, other) -> bool:
+        if not isinstance(other, AdministrativeInformation):
+            return NotImplemented
         return self.version == other.version and self._revision == other._revision
 
     def __repr__(self) -> str:

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -28,7 +28,7 @@ class AbstractObjectProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_identifiable(self, identifier: Identifier) -> Identifiable:
         """
-        Find an :class:`~aas.model.base.Identifiable` by its `id_short` attribute
+        Find an :class:`~aas.model.base.Identifiable` by its :class:`~aas.model.base.Identifier`
 
         This may include looking up the object's endpoint in a registry and fetching it from an HTTP server or a
         database.

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -65,11 +65,7 @@ class XmlDeserializationTest(unittest.TestCase):
             _xml_wrap("<aas:submodels><aas:submodel/>")
         )
         for s in xml:
-            bytes_io = io.BytesIO(s.encode("utf-8"))
-            with self.assertRaises(etree.XMLSyntaxError):
-                read_aas_xml_file(bytes_io, failsafe=False)
-            with self.assertLogs(logging.getLogger(), level=logging.ERROR):
-                read_aas_xml_file(bytes_io, failsafe=True)
+            self._assertInExceptionAndLog(s, [], etree.XMLSyntaxError, logging.ERROR)
 
     def test_invalid_list_name(self) -> None:
         xml = _xml_wrap("<aas:invalidList></aas:invalidList>")


### PR DESCRIPTION
This PR provides various minor fixes and codestyle improvements:
- fix a minor docstring error for `get_identifiable()` of `model.provider.AbstractObjectProvider`
- fix `AdministrativeInformation.__eq__` to return `NotImplemented` if other object isn't of type `AdministrativeInformation`
- replace `if` with `elif` in XML and JSON serialization to avoid unnecessary checks
- shorten XML deserialization test a bit