### PR TITLE
Add a local file backend

### DIFF
--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -201,20 +201,9 @@ class LocalFileObjectStore(model.AbstractObjectStore):
         This method returns an iterator, containing only a list of all identifiers in the database and retrieving
         the identifiable objects on the fly.
         """
-        # Iterator class storing the list of ids and fetching Identifiable objects on the fly
-        class FileIdentifiableIterator(Iterator[model.Identifiable]):
-            def __init__(self, store: LocalFileObjectStore, ids: Iterable[str]):
-                self._iter = iter(ids)
-                self._store = store
-
-            def __next__(self):
-                next_id = next(self._iter)
-                return self._store.get_identifiable(next_id)
-
-        # Fetch a list of all ids and construct Iterator object
-        logger.debug("Creating iterator over objects in database ...")
-        data = [x.rstrip(".json") for x in os.listdir(self.directory_path)]
-        return FileIdentifiableIterator(self, data)
+        logger.debug("Iterating over objects in database ...")
+        for name in os.listdir(self.directory_path):
+            yield self.get_identifiable(name.rstrip(".json"))
 
     @staticmethod
     def _transform_id(identifier: model.Identifier) -> str:

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2020 the Eclipse BaSyx Authors
 #
-# This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0 which is available
-# at https://www.apache.org/licenses/LICENSE-2.0.
+# This program and the accompanying materials are made available under the terms of the MIT License, available in
+# the LICENSE file of this project.
 #
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+# SPDX-License-Identifier: MIT
 """
 This module adds the functionality of storing and retrieving :class:`~aas.model.base.Identifiable` objects in local
 files.

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2020 the Eclipse BaSyx Authors
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0 which is available
+# at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+"""
+This module adds the functionality of storing and retrieving :class:`~aas.model.base.Identifiable` objects in local
+files.
+
+The :class:`~.FileBackend` takes care of updating and committing objects from and to the files, while the
+:class:`~FileObjectStore` handles adding, deleting and otherwise managing the AAS objects in a specific Directory.
+"""
+from typing import List, Iterator, Iterable, Union
+import logging
+import json
+import os
+import urllib.parse
+
+from . import backends
+from ..adapter.json import json_serialization, json_deserialization
+from basyx.aas import model
+
+
+logger = logging.getLogger(__name__)
+
+
+class LocalFileBackend(backends.Backend):
+    """
+    This Backend stores each Identifiable object as a single JSON document as a local file in a directory.
+    Each document's id is build from the object's identifier using the pattern {idtype}-{idvalue}; the document's
+    contents comprise a single property "data", containing the JSON serialization of the BaSyx Python SDK object. The
+    :ref:`adapter.json <adapter.json.__init__>` package is used for serialization and deserialization of objects.
+    """
+
+    @classmethod
+    def update_object(cls,
+                      updated_object: model.Referable,
+                      store_object: model.Referable,
+                      relative_path: List[str]) -> None:
+
+        if not isinstance(store_object, model.Identifiable):
+            raise FileBackendSourceError("The given store_object is not Identifiable, therefore cannot be found "
+                                         "in the FileBackend")
+        with open(store_object.source, "r") as file:
+            data = json.load(file, cls=json_deserialization.AASFromJsonDecoder)
+            updated_store_object = data["data"]
+            store_object.update_from(updated_store_object)
+
+    @classmethod
+    def commit_object(cls,
+                      committed_object: model.Referable,
+                      store_object: model.Referable,
+                      relative_path: List[str]) -> None:
+        if not isinstance(store_object, model.Identifiable):
+            raise FileBackendSourceError("The given store_object is not Identifiable, therefore cannot be found "
+                                         "in the FileBackend")
+        with open(store_object.source, "w") as file:
+            json.dump({'data': store_object}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
+
+
+backends.register_backend("file", LocalFileBackend)
+
+
+class LocalFileObjectStore(model.AbstractObjectStore):
+    """
+    An ObjectStore implementation for :class:`~aas.model.base.Identifiable` BaSyx Python SDK objects backed by a local
+    file based local backend
+    """
+    def __init__(self, directory_path: str):
+        """
+        Initializer of class LocalFileObjectStore
+
+        :param directory_path: Path to the local file backend (the path where you want to store your AAS JSON files)
+        """
+        super().__init__()
+        self.directory_path: str = directory_path.rstrip("/")
+
+    def check_directory(self, create=False):
+        """
+        Check if the directory exists and created it if not (and requested to do so)
+
+        :param create: If True and the database does not exist, try to create it
+        """
+        if not os.path.exists(self.directory_path):
+            if not create:
+                raise FileNotFoundError("The given directory ({}) does not exist".format(self.directory_path))
+            # Create directory
+            os.mkdir(self.directory_path)
+            logger.info("Creating directory {}".format(self.directory_path))
+
+    def get_identifiable(self, identifier: Union[str, model.Identifier]) -> model.Identifiable:
+        """
+        Retrieve an AAS object from the local file by its :class:`~aas.model.base.Identifier`
+
+        If the :class:`~.aas.model.base.Identifier` is a string, it is assumed that the string is a correct
+        local-file-ID-string (according to the
+        internal conversion rules, see LocalFileObjectStore._transform_id() )
+
+        :raises FileNotFoundError: If the respective file could not be found
+        """
+        if isinstance(identifier, model.Identifier):
+            identifier = self._transform_id(identifier, False)
+
+        # Try to get the correct file
+        with open("{}/{}".format(self.directory_path, identifier), "r") as file:
+            data = json.load(file, cls=json_deserialization.AASFromJsonDecoder)
+            obj = data["data"]
+            return obj
+
+    def add(self, x: model.Identifiable) -> None:
+        """
+        Add an object to the store
+
+        :raises KeyError: If an object with the same id exists already in the object store
+        """
+        logger.debug("Adding object %s to Local File Store ...", repr(x))
+        if os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(x.identification))):
+            raise KeyError("The given object already exists in the object store. Get it using store.get_identifiable()")
+        with open("{}/{}.json".format(self.directory_path, self._transform_id(x.identification)), "w") as file:
+            json.dump({"data": x}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
+            self.generate_source(x)  # Set the source of the object
+
+    def discard(self, x: model.Identifiable) -> None:
+        """
+        Delete an :class:`~aas.model.base.Identifiable` AAS object from the local file store
+
+        :param x: The object to be deleted
+        :raises KeyError: If the object does not exist in the database  # todo: Check what happens
+        """
+        logger.debug("Deleting object %s from Local File Store database ...", repr(x))
+        os.remove("{}/{}.json".format(self.directory_path, self._transform_id(x.identification)))
+        x.source = ""
+
+    def __contains__(self, x: object) -> bool:
+        """
+        Check if an object with the given :class:`~aas.model.base.Identifier` or the same
+        :class:`~aas.model.base.Identifier` as the given object is contained in the local file database
+
+        :param x: AAS object :class:`~aas.model.base.Identifier` or :class:`~aas.model.base.Identifiable` AAS object
+        :return: `True` if such an object exists in the database, `False` otherwise
+        """
+        if isinstance(x, model.Identifier):
+            identifier = x
+        elif isinstance(x, model.Identifiable):
+            identifier = x.identification
+        else:
+            return False
+        logger.debug("Checking existence of object with id %s in database ...", repr(x))
+        return os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(identifier)))
+
+    def __len__(self) -> int:
+        """
+        Retrieve the number of objects in the local file database
+
+        :return: The number of objects (determined from the number of documents)
+        """
+        logger.debug("Fetching number of documents from database ...")
+        return len(os.listdir(self.directory_path))
+
+    def __iter__(self) -> Iterator[model.Identifiable]:
+        """
+        Iterate all :class:`~aas.model.base.Identifiable` objects in the CouchDB database.
+
+        This method returns an iterator, containing only a list of all identifiers in the database and retrieving
+        the identifiable objects on the fly.
+        """
+        # Iterator class storing the list of ids and fetching Identifiable objects on the fly
+        class FileIdentifiableIterator(Iterator[model.Identifiable]):
+            def __init__(self, store: LocalFileObjectStore, ids: Iterable[str]):
+                self._iter = iter(ids)
+                self._store = store
+
+            def __next__(self):
+                next_id = next(self._iter)
+                return self._store.get_identifiable(next_id)
+
+        # Fetch a list of all ids and construct Iterator object
+        logger.debug("Creating iterator over objects in database ...")
+        data = os.listdir(self.directory_path)
+        return FileIdentifiableIterator(self, data)
+
+    @staticmethod
+    def _transform_id(identifier: model.Identifier, url_quote=True) -> str:
+        """
+        Helper method to represent an ASS Identifier as a string to be used as CouchDB document id
+
+        :param url_quote: If True, the result id string is url-encoded to be used in a HTTP request URL
+        """
+        result = "{}-{}".format(identifier.id_type.name, identifier.id)
+        if url_quote:
+            result = urllib.parse.quote(result, safe='')
+        return result
+
+    def generate_source(self, identifiable: model.Identifiable) -> str:
+        """
+        Generates the source string for an :class:`~aas.model.base.Identifiable` object that is backed by the File
+
+        :param identifiable: Identifiable object
+        """
+        source: str = "file://localhost/{}/{}.json".format(
+            self.directory_path,
+            self._transform_id(identifiable.identification)
+        )
+        identifiable.source = source
+        return source
+
+
+class FileBackendSourceError(Exception):
+    """
+    Raised, if the given object's source is not resolvable as a local file
+    """
+    pass

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2022 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -46,8 +46,7 @@ class LocalFileBackend(backends.Backend):
         if not isinstance(store_object, model.Identifiable):
             raise FileBackendSourceError("The given store_object is not Identifiable, therefore cannot be found "
                                          "in the FileBackend")
-        file_name: str = store_object.source.removeprefix("file://localhost/")  # type: ignore
-        # Known bug in mypy v0.761: Does not know of the str.removeprefix() function
+        file_name: str = store_object.source.replace("file://localhost/", "")
         with open(file_name, "r") as file:
             data = json.load(file, cls=json_deserialization.AASFromJsonDecoder)
             updated_store_object = data["data"]
@@ -61,8 +60,7 @@ class LocalFileBackend(backends.Backend):
         if not isinstance(store_object, model.Identifiable):
             raise FileBackendSourceError("The given store_object is not Identifiable, therefore cannot be found "
                                          "in the FileBackend")
-        file_name: str = store_object.source.removeprefix("file://localhost/")  # type: ignore
-        # Known bug in mypy v0.761: Does not know of the str.removeprefix() function
+        file_name: str = store_object.source.replace("file://localhost/", "")
         with open(file_name, "w") as file:
             json.dump({'data': store_object}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
 

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2020 the Eclipse BaSyx Authors
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0 which is available
+# at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+import os
+import unittest
+import unittest.mock
+
+from basyx.aas.backend import local_file
+from basyx.aas.examples.data.example_aas import *
+
+
+source_core: str = "file://localhost/{}/local_file_test_folder/".format(os.getcwd())
+
+
+class LocalFileBackendTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.object_store = local_file.LocalFileObjectStore("{}/local_file_test_folder/".format(os.getcwd()))
+        self.object_store.check_directory(create=True)
+
+    def tearDown(self) -> None:
+        self.object_store.clear()
+        os.removedirs("{}/local_file_test_folder/".format(os.getcwd()))
+
+    def test_object_store_add(self):
+        test_object = create_example_submodel()
+        self.object_store.add(test_object)
+        self.assertEqual(test_object.source, source_core+"IRI-https%3A%2F%2Facplt.org%2FTest_Submodel.json")
+
+    def test_retrieval(self):
+        test_object = create_example_submodel()
+        self.object_store.add(test_object)
+
+        # When retrieving the object, we should get the *same* instance as we added
+        test_object_retrieved = self.object_store.get_identifiable(
+            model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
+        self.assertIs(test_object, test_object_retrieved)
+
+        # When retrieving it again, we should still get the same object
+        del test_object
+        test_object_retrieved_again = self.object_store.get_identifiable(
+            model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
+        self.assertIs(test_object_retrieved, test_object_retrieved_again)
+
+        # However, a changed source should invalidate the cached object, so we should get a new copy
+        test_object_retrieved.source = "couchdb://example.com/example/IRI-https%3A%2F%2Facplt.org%2FTest_Submodel"
+        test_object_retrieved_third = self.object_store.get_identifiable(
+            model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
+        self.assertIsNot(test_object_retrieved, test_object_retrieved_third)
+
+    # def test_example_submodel_storing(self) -> None:
+    #     example_submodel = create_example_submodel()
+    #
+    #     # Add exmaple submodel
+    #     self.object_store.add(example_submodel)
+    #     self.assertEqual(1, len(self.object_store))
+    #     self.assertIn(example_submodel, self.object_store)
+    #
+    #     # Restore example submodel and check data
+    #     submodel_restored = self.object_store.get_identifiable(
+    #         model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
+    #     assert (isinstance(submodel_restored, model.Submodel))
+    #     checker = AASDataChecker(raise_immediately=True)
+    #     check_example_submodel(checker, submodel_restored)
+    #
+    #     # Delete example submodel
+    #     self.object_store.discard(submodel_restored)
+    #     self.assertNotIn(example_submodel, self.object_store)
+    #
+    # def test_iterating(self) -> None:
+    #     example_data = create_full_example()
+    #
+    #     # Add all objects
+    #     for item in example_data:
+    #         self.object_store.add(item)
+    #
+    #     self.assertEqual(6, len(self.object_store))
+    #
+    #     # Iterate objects, add them to a DictObjectStore and check them
+    #     retrieved_data_store: model.provider.DictObjectStore[model.Identifiable] = model.provider.DictObjectStore()
+    #     for item in self.object_store:
+    #         retrieved_data_store.add(item)
+    #     checker = AASDataChecker(raise_immediately=True)
+    #     check_full_example(checker, retrieved_data_store)
+    #
+    # def test_key_errors(self) -> None:
+    #     # Double adding an object should raise a KeyError
+    #     example_submodel = create_example_submodel()
+    #     self.object_store.add(example_submodel)
+    #     with self.assertRaises(KeyError) as cm:
+    #         self.object_store.add(example_submodel)
+    #     self.assertEqual("'Identifiable with id Identifier(IRI=https://acplt.org/Test_Submodel) already exists in "
+    #                      "CouchDB database'", str(cm.exception))
+    #
+    #     # Querying a deleted object should raise a KeyError
+    #     retrieved_submodel = self.object_store.get_identifiable(
+    #         model.Identifier('https://acplt.org/Test_Submodel', model.IdentifierType.IRI))
+    #     self.object_store.discard(example_submodel)
+    #     with self.assertRaises(KeyError) as cm:
+    #         self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel',
+    #                                                             model.IdentifierType.IRI))
+    #     self.assertEqual("'No Identifiable with id IRI-https://acplt.org/Test_Submodel found in CouchDB database'",
+    #                      str(cm.exception))
+    #
+    #     # Double deleting should also raise a KeyError
+    #     with self.assertRaises(KeyError) as cm:
+    #         self.object_store.discard(retrieved_submodel)
+    #     self.assertEqual("'No AAS object with id Identifier(IRI=https://acplt.org/Test_Submodel) exists in "
+    #                      "CouchDB database'", str(cm.exception))
+    #
+    # def test_conflict_errors(self):
+    #     # Preperation: add object and retrieve it from the database
+    #     example_submodel = create_example_submodel()
+    #     self.object_store.add(example_submodel)
+    #     retrieved_submodel = self.object_store.get_identifiable(
+    #         model.Identifier('https://acplt.org/Test_Submodel', model.IdentifierType.IRI))
+    #
+    #     # Simulate a concurrent modification (Commit submodel, while preventing that the couchdb revision store is
+    #     # updated)
+    #     with unittest.mock.patch("basyx.aas.backend.couchdb.set_couchdb_revision"):
+    #         retrieved_submodel.commit()
+    #
+    #     # Committing changes to the retrieved object should now raise a conflict error
+    #     retrieved_submodel.id_short = "myOtherNewIdShort"
+    #     with self.assertRaises(couchdb.CouchDBConflictError) as cm:
+    #         retrieved_submodel.commit()
+    #     self.assertEqual("Could not commit changes to id Identifier(IRI=https://acplt.org/Test_Submodel) due to a "
+    #                      "concurrent modification in the database.", str(cm.exception))
+    #
+    #     # Deleting the submodel with safe_delete should also raise a conflict error. Deletion without safe_delete should
+    #     # work
+    #     with self.assertRaises(couchdb.CouchDBConflictError) as cm:
+    #         self.object_store.discard(retrieved_submodel, True)
+    #     self.assertEqual("Object with id Identifier(IRI=https://acplt.org/Test_Submodel) has been modified in the "
+    #                      "database since the version requested to be deleted.", str(cm.exception))
+    #     self.object_store.discard(retrieved_submodel, False)
+    #     self.assertEqual(0, len(self.object_store))
+    #
+    #     # Committing after deletion should not raise a conflict error due to removal of the source attribute
+    #     retrieved_submodel.commit()
+    #
+    # def test_editing(self):
+    #     test_object = create_example_submodel()
+    #     self.object_store.add(test_object)
+    #
+    #     # Test if commit uploads changes
+    #     test_object.id_short = "SomeNewIdShort"
+    #     test_object.commit()
+    #
+    #     # Test if update restores changes
+    #     test_object.id_short = "AnotherIdShort"
+    #     test_object.update()
+    #     self.assertEqual("SomeNewIdShort", test_object.id_short)

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -4,7 +4,8 @@
 # the LICENSE file of this project.
 #
 # SPDX-License-Identifier: MIT
-import os
+import os.path
+import sys
 import shutil
 import unittest
 import unittest.mock
@@ -13,19 +14,21 @@ from basyx.aas.backend import local_file
 from basyx.aas.examples.data.example_aas import *
 
 
-source_core: str = "file://localhost/{}/local_file_test_folder/".format(os.getcwd())
+store_path: str = os.path.abspath(__file__).rstrip("test_local_file.py") + "local_file_test_folder"
+# todo: Adapt to file name changes
+source_core: str = "file://localhost/{}/".format(store_path)
 
 
 class LocalFileBackendTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.object_store = local_file.LocalFileObjectStore("{}/local_file_test_folder/".format(os.getcwd()))
+        self.object_store = local_file.LocalFileObjectStore(store_path)
         self.object_store.check_directory(create=True)
 
     def tearDown(self) -> None:
         try:
             self.object_store.clear()
         finally:
-            shutil.rmtree("{}/local_file_test_folder/".format(os.getcwd()))
+            shutil.rmtree(store_path)
 
     def test_object_store_add(self):
         test_object = create_example_submodel()

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2020 the Eclipse BaSyx Authors
 #
-# This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0 which is available
-# at https://www.apache.org/licenses/LICENSE-2.0.
+# This program and the accompanying materials are made available under the terms of the MIT License, available in
+# the LICENSE file of this project.
 #
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+# SPDX-License-Identifier: MIT
 import os
 import unittest
 import unittest.mock

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: MIT
 import os.path
-import sys
 import shutil
 import unittest
 import unittest.mock
@@ -14,8 +13,7 @@ from basyx.aas.backend import local_file
 from basyx.aas.examples.data.example_aas import *
 
 
-store_path: str = os.path.abspath(__file__).rstrip("test_local_file.py") + "local_file_test_folder"
-# todo: Adapt to file name changes
+store_path: str = os.path.dirname(__file__) + "/local_file_test_folder"
 source_core: str = "file://localhost/{}/".format(store_path)
 
 

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 import os
+import shutil
 import unittest
 import unittest.mock
 
@@ -21,8 +22,10 @@ class LocalFileBackendTest(unittest.TestCase):
         self.object_store.check_directory(create=True)
 
     def tearDown(self) -> None:
-        self.object_store.clear()
-        os.removedirs("{}/local_file_test_folder/".format(os.getcwd()))
+        try:
+            self.object_store.clear()
+        finally:
+            shutil.rmtree("{}/local_file_test_folder/".format(os.getcwd()))
 
     def test_object_store_add(self):
         test_object = create_example_submodel()

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2022 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -28,7 +28,10 @@ class LocalFileBackendTest(unittest.TestCase):
     def test_object_store_add(self):
         test_object = create_example_submodel()
         self.object_store.add(test_object)
-        self.assertEqual(test_object.source, source_core+"IRI-https%3A%2F%2Facplt.org%2FTest_Submodel.json")
+        self.assertEqual(
+            test_object.source,
+            source_core+"bfe69a634a188d106286585170ba06dfbbd26dd000c641cab5b0f374e94c9611.json"
+        )
 
     def test_retrieval(self):
         test_object = create_example_submodel()
@@ -51,106 +54,76 @@ class LocalFileBackendTest(unittest.TestCase):
             model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
         self.assertIsNot(test_object_retrieved, test_object_retrieved_third)
 
-    # def test_example_submodel_storing(self) -> None:
-    #     example_submodel = create_example_submodel()
-    #
-    #     # Add exmaple submodel
-    #     self.object_store.add(example_submodel)
-    #     self.assertEqual(1, len(self.object_store))
-    #     self.assertIn(example_submodel, self.object_store)
-    #
-    #     # Restore example submodel and check data
-    #     submodel_restored = self.object_store.get_identifiable(
-    #         model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
-    #     assert (isinstance(submodel_restored, model.Submodel))
-    #     checker = AASDataChecker(raise_immediately=True)
-    #     check_example_submodel(checker, submodel_restored)
-    #
-    #     # Delete example submodel
-    #     self.object_store.discard(submodel_restored)
-    #     self.assertNotIn(example_submodel, self.object_store)
-    #
-    # def test_iterating(self) -> None:
-    #     example_data = create_full_example()
-    #
-    #     # Add all objects
-    #     for item in example_data:
-    #         self.object_store.add(item)
-    #
-    #     self.assertEqual(6, len(self.object_store))
-    #
-    #     # Iterate objects, add them to a DictObjectStore and check them
-    #     retrieved_data_store: model.provider.DictObjectStore[model.Identifiable] = model.provider.DictObjectStore()
-    #     for item in self.object_store:
-    #         retrieved_data_store.add(item)
-    #     checker = AASDataChecker(raise_immediately=True)
-    #     check_full_example(checker, retrieved_data_store)
-    #
-    # def test_key_errors(self) -> None:
-    #     # Double adding an object should raise a KeyError
-    #     example_submodel = create_example_submodel()
-    #     self.object_store.add(example_submodel)
-    #     with self.assertRaises(KeyError) as cm:
-    #         self.object_store.add(example_submodel)
-    #     self.assertEqual("'Identifiable with id Identifier(IRI=https://acplt.org/Test_Submodel) already exists in "
-    #                      "CouchDB database'", str(cm.exception))
-    #
-    #     # Querying a deleted object should raise a KeyError
-    #     retrieved_submodel = self.object_store.get_identifiable(
-    #         model.Identifier('https://acplt.org/Test_Submodel', model.IdentifierType.IRI))
-    #     self.object_store.discard(example_submodel)
-    #     with self.assertRaises(KeyError) as cm:
-    #         self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel',
-    #                                                             model.IdentifierType.IRI))
-    #     self.assertEqual("'No Identifiable with id IRI-https://acplt.org/Test_Submodel found in CouchDB database'",
-    #                      str(cm.exception))
-    #
-    #     # Double deleting should also raise a KeyError
-    #     with self.assertRaises(KeyError) as cm:
-    #         self.object_store.discard(retrieved_submodel)
-    #     self.assertEqual("'No AAS object with id Identifier(IRI=https://acplt.org/Test_Submodel) exists in "
-    #                      "CouchDB database'", str(cm.exception))
-    #
-    # def test_conflict_errors(self):
-    #     # Preperation: add object and retrieve it from the database
-    #     example_submodel = create_example_submodel()
-    #     self.object_store.add(example_submodel)
-    #     retrieved_submodel = self.object_store.get_identifiable(
-    #         model.Identifier('https://acplt.org/Test_Submodel', model.IdentifierType.IRI))
-    #
-    #     # Simulate a concurrent modification (Commit submodel, while preventing that the couchdb revision store is
-    #     # updated)
-    #     with unittest.mock.patch("basyx.aas.backend.couchdb.set_couchdb_revision"):
-    #         retrieved_submodel.commit()
-    #
-    #     # Committing changes to the retrieved object should now raise a conflict error
-    #     retrieved_submodel.id_short = "myOtherNewIdShort"
-    #     with self.assertRaises(couchdb.CouchDBConflictError) as cm:
-    #         retrieved_submodel.commit()
-    #     self.assertEqual("Could not commit changes to id Identifier(IRI=https://acplt.org/Test_Submodel) due to a "
-    #                      "concurrent modification in the database.", str(cm.exception))
-    #
-    #     # Deleting the submodel with safe_delete should also raise a conflict error. Deletion without safe_delete should
-    #     # work
-    #     with self.assertRaises(couchdb.CouchDBConflictError) as cm:
-    #         self.object_store.discard(retrieved_submodel, True)
-    #     self.assertEqual("Object with id Identifier(IRI=https://acplt.org/Test_Submodel) has been modified in the "
-    #                      "database since the version requested to be deleted.", str(cm.exception))
-    #     self.object_store.discard(retrieved_submodel, False)
-    #     self.assertEqual(0, len(self.object_store))
-    #
-    #     # Committing after deletion should not raise a conflict error due to removal of the source attribute
-    #     retrieved_submodel.commit()
-    #
-    # def test_editing(self):
-    #     test_object = create_example_submodel()
-    #     self.object_store.add(test_object)
-    #
-    #     # Test if commit uploads changes
-    #     test_object.id_short = "SomeNewIdShort"
-    #     test_object.commit()
-    #
-    #     # Test if update restores changes
-    #     test_object.id_short = "AnotherIdShort"
-    #     test_object.update()
-    #     self.assertEqual("SomeNewIdShort", test_object.id_short)
+    def test_example_submodel_storing(self) -> None:
+        example_submodel = create_example_submodel()
+
+        # Add exmaple submodel
+        self.object_store.add(example_submodel)
+        self.assertEqual(1, len(self.object_store))
+        self.assertIn(example_submodel, self.object_store)
+
+        # Restore example submodel and check data
+        submodel_restored = self.object_store.get_identifiable(
+            model.Identifier(id_='https://acplt.org/Test_Submodel', id_type=model.IdentifierType.IRI))
+        assert (isinstance(submodel_restored, model.Submodel))
+        checker = AASDataChecker(raise_immediately=True)
+        check_example_submodel(checker, submodel_restored)
+
+        # Delete example submodel
+        self.object_store.discard(submodel_restored)
+        self.assertNotIn(example_submodel, self.object_store)
+
+    def test_iterating(self) -> None:
+        example_data = create_full_example()
+
+        # Add all objects
+        for item in example_data:
+            self.object_store.add(item)
+
+        self.assertEqual(6, len(self.object_store))
+
+        # Iterate objects, add them to a DictObjectStore and check them
+        retrieved_data_store: model.provider.DictObjectStore[model.Identifiable] = model.provider.DictObjectStore()
+        for item in self.object_store:
+            retrieved_data_store.add(item)
+        checker = AASDataChecker(raise_immediately=True)
+        check_full_example(checker, retrieved_data_store)
+
+    def test_key_errors(self) -> None:
+        # Double adding an object should raise a KeyError
+        example_submodel = create_example_submodel()
+        self.object_store.add(example_submodel)
+        with self.assertRaises(KeyError) as cm:
+            self.object_store.add(example_submodel)
+        self.assertEqual("'Identifiable with id Identifier(IRI=https://acplt.org/Test_Submodel) already exists in "
+                         "local file database'", str(cm.exception))
+
+        # Querying a deleted object should raise a KeyError
+        retrieved_submodel = self.object_store.get_identifiable(
+            model.Identifier('https://acplt.org/Test_Submodel', model.IdentifierType.IRI))
+        self.object_store.discard(example_submodel)
+        with self.assertRaises(KeyError) as cm:
+            self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel',
+                                                                model.IdentifierType.IRI))
+        self.assertEqual("'No Identifiable with id Identifier(IRI=https://acplt.org/Test_Submodel) "
+                         "found in local file database'",
+                         str(cm.exception))
+
+        # Double deleting should also raise a KeyError
+        with self.assertRaises(KeyError) as cm:
+            self.object_store.discard(retrieved_submodel)
+        self.assertEqual("'No AAS object with id Identifier(IRI=https://acplt.org/Test_Submodel) exists in "
+                         "local file database'", str(cm.exception))
+
+    def test_editing(self):
+        test_object = create_example_submodel()
+        self.object_store.add(test_object)
+
+        # Test if commit uploads changes
+        test_object.id_short = "SomeNewIdShort"
+        test_object.commit()
+
+        # Test if update restores changes
+        test_object.id_short = "AnotherIdShort"
+        test_object.update()
+        self.assertEqual("SomeNewIdShort", test_object.id_short)


### PR DESCRIPTION
This PR adds a local file backend, which stores `Identifiable` objects as JSON files on the local machine. 
The functionality is pretty much copied from the `backend.couchdb`, with the CouchDB revision conflict checking removed, therefore, there is no way of conflict handling with this backend (e.g. every commit actually overwrites the JSON file)

As a file name, I decided to use the SHA256 sum of the Identifier (since URIs like for the CouchDB make for bad file names in most OSs).

The `source` attribute is a valid URI, following the schema: 

```
file://localhost/path/to/folder/<sha256sum>.json
```