### PR TITLE
Update README and set PYTHONPATH in compliance tool tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
       run: |
         python test/_helper/setup_testdb.py -u "admin" -p "$COUCHDB_ADMIN_PASSWORD"
     - name: Test with coverage + unittest
-      # Add source directory to PYTHONPATH to allow testing our CLI scripts, which import our modules
       run: |
-        export PYTHONPATH=".:$PYTHONPATH"
         coverage run --source=basyx -m unittest
     - name: Report test coverage
       if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -130,10 +130,14 @@ For further examples and tutorials, check out the `basyx.aas.examples`-package. 
 * [`tutorial_backend_couchdb`](./basyx/aas/examples/tutorial_backend_couchdb.py): Use the *Backends* interface (`update()/commit()` methods) to manage and retrieve AAS objects in a CouchDB document database
 
 
+### Documentation
+
+A detailed, complete API documentation is available on Read the Docs: https://basyx-python-sdk.readthedocs.io
+
 ### Compliance Tool
 
 The Eclipse BaSyx Python SDK project contains a compliance tool for testing xml and json files is provided in the 
-`aas.compliance_tool`-package. Following functionalities are supported:
+`basyx.aas.compliance_tool`-package. Following functionalities are supported:
 
 * create an xml or json file compliant to the official schema containing example Asset Administration Shell elements
 * create an aasx file with xml or json files compliant to the official schema containing example Asset Administration 
@@ -143,11 +147,11 @@ Shell elements
 * check if the data in a given xml, json or aasx file is the same as the example data
 * check if two given xml, json or aasx files contain the same Asset Administration Shell elements in any order 
 
-Invoking should work with either `python -m aas.compliance_tool.cli` or (when installed correctly and PATH is set 
+Invoking should work with either `python -m basyx.aas.compliance_tool.cli` or (when installed correctly and PATH is set 
 correctly) with `aas-compliance-check` on the command line.
 
-For further usage information consider the `aas.compliance_tool`-package or invoke with 
-`python -m aas.compliance_tool.cli --help` respectively `aas-compliance-check --help`.
+For further usage information consider the `basyx.aas.compliance_tool`-package or invoke with 
+`python -m basyx.aas.compliance_tool.cli --help` respectively `aas-compliance-check --help`.
 
 ## Development
 
@@ -164,8 +168,8 @@ pip install mypy pycodestyle
 
 Running all checks:
 ```bash
-mypy aas test
-pycodestyle --max-line-length 120 aas test
+mypy basyx test
+pycodestyle --max-line-length 120 basyx test
 python -m unittest
 ```
 
@@ -173,6 +177,11 @@ We aim to cover our code with test by at least 80%. To check test coverage, you 
 
 ```bash
 pip install coverage
-coverage run --source aas --branch -m unittest
+coverage run --source basyx --branch -m unittest
 coverage report -m
 ```
+
+### Eclipse Contributor Agreement
+
+To contribute code to this project you need to sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).
+This is done by creating an Eclipse account for your git e-mail address and then submitting the following form: https://accounts.eclipse.org/user/eca

--- a/test/compliance_tool/test_aas_compliance_tool.py
+++ b/test/compliance_tool/test_aas_compliance_tool.py
@@ -23,128 +23,110 @@ from basyx.aas.examples.data import create_example
 from basyx.aas.examples.data._helper import AASDataChecker
 
 
+def _run_compliance_tool(*compliance_tool_args, **kwargs) -> subprocess.CompletedProcess:
+    """
+    This function runs the compliance tool using subprocess.run() while adjusting the PYTHONPATH environment variable
+    and setting the stdout and stderr parameters of subprocess.run() to PIPE.
+    Positional arguments are passed to the compliance tool, while keyword arguments are passed to subprocess.run().
+    """
+    env = os.environ.copy()
+    env['PYTHONPATH'] = "{}:{}".format(os.environ.get('PYTHONPATH', ''),
+                                       os.path.join(os.path.dirname(basyx.__file__), os.pardir))
+    compliance_tool_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
+    return subprocess.run([sys.executable, compliance_tool_path] + list(compliance_tool_args), stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, env=env, **kwargs)
+
+
 class ComplianceToolTest(unittest.TestCase):
     def test_parse_args(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
         # test schema check
-        output: subprocess.CompletedProcess = subprocess.run([sys.executable, file_path, "s"],
-                                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("s")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: the following arguments are required: file_1', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "s", os.path.join(test_file_path, "test_demo_full_example.json")],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("s", os.path.join(test_file_path, "test_demo_full_example.json"))
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
         # test deserialisation check
-        output = subprocess.run([sys.executable, file_path, "d"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: the following arguments are required: file_1', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "d", os.path.join(test_file_path, "test_demo_full_example.json")],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d", os.path.join(test_file_path, "test_demo_full_example.json"))
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "d", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
         # test example check
-        output = subprocess.run([sys.executable, file_path, "e"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: the following arguments are required: file_1', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json")],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"))
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
         # test file check
-        output = subprocess.run([sys.executable, file_path, "f"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: the following arguments are required: file_1', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.json")],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.json"))
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.json"), "--aasx")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.json"), "--json"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.json"), "--json")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: f or files requires two file path', str(output.stderr))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.json"),
-             os.path.join(test_file_path, "test_demo_full_example.json")],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.json"),
+                                      os.path.join(test_file_path, "test_demo_full_example.json"))
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: one of the arguments --json --xml is required', str(output.stderr))
 
         # test verbose
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json",
-             "-v"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json", "-v")
         self.assertEqual(0, output.returncode)
         self.assertNotIn('ERROR', str(output.stdout))
         self.assertNotIn('INFO', str(output.stdout))
 
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json",
-             "-v", "-v"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json", "-v",
+                                      "-v")
         self.assertEqual(0, output.returncode)
         self.assertNotIn('ERROR', str(output.stdout))
         self.assertIn('INFO', str(output.stdout))
 
         # test quite
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json",
-             "-q"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json", "-q")
         self.assertEqual(0, output.returncode)
         self.assertEqual("b''", str(output.stdout))
 
         # test logfile
-        output = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json",
-             "-l"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json", "-l")
         self.assertNotEqual(0, output.returncode)
         self.assertIn('error: argument -l/--logfile: expected one argument', str(output.stderr))
 
         # todo: add test for correct logfile
 
     def test_json_create_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
-
         file, filename = tempfile.mkstemp(suffix=".json")
         os.close(file)
-        output: subprocess.CompletedProcess = subprocess.run([sys.executable, file_path, "c", filename, "--json"],
-                                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("c", filename, "--json")
+
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Create example data', str(output.stdout))
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
@@ -158,36 +140,28 @@ class ComplianceToolTest(unittest.TestCase):
         os.unlink(filename)
 
     def test_json_deserialization(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "d", os.path.join(test_file_path, "test_demo_full_example.json"), "--json"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d", os.path.join(test_file_path, "test_demo_full_example.json"), "--json")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file and check if it is deserializable', str(output.stdout))
 
     def test_json_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file and check if it is deserializable', str(output.stdout))
         self.assertIn('SUCCESS:      Check if data is equal to example data', str(output.stdout))
 
     def test_json_file(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.json"),
-             os.path.join(test_file_path, "test_demo_full_example.json"), "--json"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.json"),
+                                      os.path.join(test_file_path, "test_demo_full_example.json"), "--json")
+
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open first file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file', str(output.stdout))
@@ -196,12 +170,9 @@ class ComplianceToolTest(unittest.TestCase):
         self.assertIn('SUCCESS:      Check if data in files are equal', str(output.stdout))
 
     def test_xml_create_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
-
         file, filename = tempfile.mkstemp(suffix=".xml")
         os.close(file)
-        output: subprocess.CompletedProcess = subprocess.run([sys.executable, file_path, "c", filename, "--xml"],
-                                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("c", filename, "--xml")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Create example data', str(output.stdout))
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
@@ -215,36 +186,27 @@ class ComplianceToolTest(unittest.TestCase):
         os.unlink(filename)
 
     def test_xml_deseralization(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "d", os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d", os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file and check if it is deserializable', str(output.stdout))
 
     def test_xml_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file and check if it is deserializable', str(output.stdout))
         self.assertIn('SUCCESS:      Check if data is equal to example data', str(output.stdout))
 
     def test_xml_file(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.xml"),
-             os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.xml"),
+                                      os.path.join(test_file_path, "test_demo_full_example.xml"), "--xml")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open first file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file', str(output.stdout))
@@ -253,12 +215,9 @@ class ComplianceToolTest(unittest.TestCase):
         self.assertIn('SUCCESS:      Check if data in files are equal', str(output.stdout))
 
     def test_aasx_create_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
-
         file, filename = tempfile.mkstemp(suffix=".aasx")
         os.close(file)
-        output: subprocess.CompletedProcess = subprocess.run([sys.executable, file_path, "c", filename, "--xml",
-                                                              "--aasx"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("c", filename, "--xml", "--aasx")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Create example data', str(output.stdout))
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
@@ -296,36 +255,29 @@ class ComplianceToolTest(unittest.TestCase):
         os.unlink(filename)
 
     def test_aasx_deseralization(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "d", os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml",
-             "--aasx"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("d", os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml",
+                                      "--aasx")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file', str(output.stdout))
 
     def test_aasx_example(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "e", os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml",
-             "--aasx"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml",
+                                      "--aasx")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file', str(output.stdout))
         # self.assertIn('SUCCESS:      Check if data is equal to example data', str(output.stdout))
 
     def test_aasx_file(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
         test_file_path = os.path.join(os.path.dirname(__file__), 'files')
 
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "f", os.path.join(test_file_path, "test_demo_full_example.aasx"),
-             os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml", "--aasx"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("f", os.path.join(test_file_path, "test_demo_full_example.aasx"),
+                                      os.path.join(test_file_path, "test_demo_full_example.aasx"), "--xml", "--aasx")
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Open first file', str(output.stdout))
         self.assertIn('SUCCESS:      Read file', str(output.stdout))
@@ -334,16 +286,11 @@ class ComplianceToolTest(unittest.TestCase):
         self.assertIn('SUCCESS:      Check if data in files are equal', str(output.stdout))
 
     def test_logfile(self) -> None:
-        file_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
-        test_file_path = os.path.join(os.path.dirname(__file__), 'files')
-
         file, filename = tempfile.mkstemp(suffix=".json")
         file2, filename2 = tempfile.mkstemp(suffix=".log")
         os.close(file)
         os.close(file2)
-        output: subprocess.CompletedProcess = subprocess.run(
-            [sys.executable, file_path, "c", filename, "--json", "-v", "-v", "-l", filename2],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = _run_compliance_tool("c", filename, "--json", "-v", "-v", "-l", filename2)
         self.assertEqual(0, output.returncode)
         self.assertIn('SUCCESS:      Create example data', str(output.stdout))
         self.assertIn('SUCCESS:      Open file', str(output.stdout))


### PR DESCRIPTION
Link documentation in README and state requirement of signing the ECA before contributing code to the project.
Also update some module names from "aas.*" to "basyx.aas.*" in the README.

Additionally this PR enables setting the `PYTHONPATH` when running the compliance tool in the tests. It is no longer required to manually set `PYTHONPATH` when running the tests with `python -m unittest` or `coverage`. Thus don't set `PYTHONPATH` in the CI script anymore.
Furthermore abstract running the compliance tool with a function, eliminating a lot of duplicate code.