### PR TITLE
model.submodel: remove Optional[] from parameter annotation of Annota…

### DIFF
--- a/basyx/aas/examples/data/example_submodel_template.py
+++ b/basyx/aas/examples/data/example_submodel_template.py
@@ -169,7 +169,7 @@ def create_example_submodel_template() -> model.Submodel:
                                              value='ExampleProperty',
                                              id_type=model.KeyType.IDSHORT),),
                                   model.Property),
-        annotation=None,
+        annotation=(),
         category='PARAMETER',
         description={'en-us': 'Example AnnotatedRelationshipElement object',
                      'de': 'Beispiel AnnotatedRelationshipElement Element'},

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -665,7 +665,7 @@ class AnnotatedRelationshipElement(RelationshipElement, base.Namespace):
                  id_short: str,
                  first: base.AASReference,
                  second: base.AASReference,
-                 annotation: Optional[Iterable[DataElement]] = None,
+                 annotation: Iterable[DataElement] = (),
                  category: Optional[str] = None,
                  description: Optional[base.LangStringSet] = None,
                  parent: Optional[base.Namespace] = None,
@@ -677,10 +677,7 @@ class AnnotatedRelationshipElement(RelationshipElement, base.Namespace):
         """
 
         super().__init__(id_short, first, second, category, description, parent, semantic_id, qualifier, kind)
-        if annotation is None:
-            self.annotation: base.NamespaceSet[DataElement] = base.NamespaceSet(self)
-        else:
-            self.annotation = base.NamespaceSet(self, annotation)
+        self.annotation = base.NamespaceSet(self, annotation)
 
 
 class OperationVariable:


### PR DESCRIPTION
…tedRelationshipElement.__init__ to remove the ambiguity between passing `None` and an empty Iterable.