### PR TITLE
readme: add dependencies for building the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Development/testing/example dependencies (see `requirements.txt`):
 * `jsonschema` and its dependencies (MIT License, Apache License, PSF License)
 * `psutil` (BSD 3-clause License)
 
+Dependencies for building the documentation:
+* `Sphinx` and its dependencies (BSD 2-clause License, MIT License, Apache License)
+* `sphinx-rtd-theme` and its dependencies (MIT License, PSF License)
+* `sphinx-argparse` (MIT License)
+
 
 ## Getting Started
 


### PR DESCRIPTION
This PR extends the readme by the sphinx dependencies required to build the documentation.