### PR TITLE
requirements: update jsonschema to 4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema>=3.2,<4.0
+jsonschema~=4.7
 lxml>=4.2,<5
 python-dateutil>=2.8,<3.0
 types-python-dateutil


### PR DESCRIPTION
This dependency is updated to fix a DeprecationWarning when running the unittests:

```
DeprecationWarning: The metaschema specified by $schema was not found.
Using the latest draft to validate, but this will raise an error in the future
```

This warning was logged because jsonschema didn't have support for
schema version 2019-09 in versions <4.

This requires #40 to be merged.