### PR TITLE
add whitespace after assert keyword

### DIFF
--- a/basyx/aas/compliance_tool/compliance_check_aasx.py
+++ b/basyx/aas/compliance_tool/compliance_check_aasx.py
@@ -215,7 +215,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
 
     checker2 = DataChecker(raise_immediately=False)
     try:
-        assert(isinstance(cp_new.created, datetime.datetime))
+        assert isinstance(cp_new.created, datetime.datetime)
         checker2.check(isinstance(cp_new.created, datetime.datetime), "core property created must be of type datetime",
                        created=type(cp_new.created))
         duration = cp_new.created - cp.created
@@ -230,7 +230,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
     checker2.check(cp_new.lastModifiedBy == cp.lastModifiedBy, "lastModifiedBy must be {}".format(cp.lastModifiedBy),
                    lastModifiedBy=cp_new.lastModifiedBy)
     try:
-        assert(isinstance(cp_new.modified, datetime.datetime))
+        assert isinstance(cp_new.modified, datetime.datetime)
         checker2.check(isinstance(cp_new.modified, datetime.datetime), "modified bust be of type datetime",
                        modified=type(cp_new.modified))
         duration = cp_new.modified - cp.modified

--- a/basyx/aas/examples/tutorial_backend_couchdb.py
+++ b/basyx/aas/examples/tutorial_backend_couchdb.py
@@ -96,7 +96,7 @@ example_submodel1.update()
 
 # Make some changes to a Property within the submodel
 prop = example_submodel1.get_referable('ManufacturerName')
-assert(isinstance(prop, basyx.aas.model.Property))
+assert isinstance(prop, basyx.aas.model.Property)
 
 prop.value = "RWTH Aachen"
 

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -156,4 +156,4 @@ with open('data.xml', 'rb') as xml_file:
 # For more information on the availiable techniques, see `tutorial_storage.py`.
 submodel_from_xml = xml_file_data.get_identifiable(model.Identifier('https://acplt.org/Simple_Submodel',
                                                                     model.IdentifierType.IRI))
-assert(isinstance(submodel_from_xml, model.Submodel))
+assert isinstance(submodel_from_xml, model.Submodel)

--- a/basyx/aas/examples/tutorial_storage.py
+++ b/basyx/aas/examples/tutorial_storage.py
@@ -86,7 +86,7 @@ obj_store.add(aas)
 tmp_submodel = obj_store.get_identifiable(
     model.Identifier('https://acplt.org/Simple_Submodel', model.IdentifierType.IRI))
 
-assert(submodel is tmp_submodel)
+assert submodel is tmp_submodel
 
 
 ########################################################
@@ -99,7 +99,7 @@ submodels = [reference.resolve(obj_store)
              for reference in aas.submodel]
 
 # The first (and only) element of this list should be our example submodel:
-assert(submodel is tmp_submodel)
+assert submodel is tmp_submodel
 
 # Now, let's manually create a reference to the Property within the submodel. The reference uses two keys, the first one
 # identifying the submodel by its identification, the second one resolving to the Property within the submodel by its
@@ -123,4 +123,4 @@ property_reference = model.AASReference(
 # The `resolve()` method will fetch the Submodel object from the ObjectStore, traverse down to the included Property
 # object and return this object.
 tmp_property = property_reference.resolve(obj_store)
-assert(prop is tmp_property)
+assert prop is tmp_property

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -521,7 +521,7 @@ class Referable(metaclass=abc.ABCMeta):
                 relative_path.reverse()
                 return referable, relative_path
             if referable.parent:
-                assert(isinstance(referable.parent, Referable))
+                assert isinstance(referable.parent, Referable)
                 referable = referable.parent
                 relative_path.append(referable.id_short)
                 continue
@@ -560,7 +560,7 @@ class Referable(metaclass=abc.ABCMeta):
         relative_path: List[str] = [self.id_short]
         # Commit to all ancestors with sources
         while current_ancestor:
-            assert(isinstance(current_ancestor, Referable))
+            assert isinstance(current_ancestor, Referable)
             if current_ancestor.source != "":
                 backends.get_backend(current_ancestor.source).commit_object(committed_object=self,
                                                                             store_object=current_ancestor,

--- a/test/adapter/aasx/test_aasx.py
+++ b/test/adapter/aasx/test_aasx.py
@@ -103,9 +103,9 @@ class AASXWriterTest(unittest.TestCase):
                     example_aas.check_full_example(checker, new_data)
 
                     # Check core properties
-                    assert(isinstance(cp.created, datetime.datetime))  # to make mypy happy
+                    assert isinstance(cp.created, datetime.datetime)  # to make mypy happy
                     self.assertIsInstance(new_cp.created, datetime.datetime)
-                    assert(isinstance(new_cp.created, datetime.datetime))  # to make mypy happy
+                    assert isinstance(new_cp.created, datetime.datetime)  # to make mypy happy
                     self.assertAlmostEqual(new_cp.created, cp.created, delta=datetime.timedelta(milliseconds=20))
                     self.assertEqual(new_cp.creator, "Eclipse BaSyx Python Testing Framework")
                     self.assertIsNone(new_cp.lastModifiedBy)

--- a/test/adapter/json/test_json_serialization.py
+++ b/test/adapter/json/test_json_serialization.py
@@ -30,7 +30,7 @@ class JsonSerializationTest(unittest.TestCase):
         aas_identifier = model.Identifier("AAS1", model.IdentifierType.CUSTOM)
         submodel_key = (model.Key(model.KeyElements.SUBMODEL, True, "SM1", model.KeyType.CUSTOM),)
         submodel_identifier = submodel_key[0].get_identifier()
-        assert(submodel_identifier is not None)
+        assert submodel_identifier is not None
         submodel_reference = model.AASReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier)
         test_aas = model.AssetAdministrationShell(asset_reference, aas_identifier, submodel={submodel_reference})
@@ -52,7 +52,7 @@ class JsonSerializationSchemaTest(unittest.TestCase):
         aas_identifier = model.Identifier("AAS1", model.IdentifierType.CUSTOM)
         submodel_key = (model.Key(model.KeyElements.SUBMODEL, True, "SM1", model.KeyType.CUSTOM),)
         submodel_identifier = submodel_key[0].get_identifier()
-        assert(submodel_identifier is not None)
+        assert submodel_identifier is not None
         submodel_reference = model.AASReference(submodel_key, model.Submodel)
         # The JSONSchema expects every object with HasSemnatics (like Submodels) to have a `semanticId` Reference, which
         # must be a Reference. (This seems to be a bug in the JSONSchema.)

--- a/test/adapter/json/test_json_serialization_deserialization.py
+++ b/test/adapter/json/test_json_serialization_deserialization.py
@@ -24,7 +24,7 @@ class JsonSerializationDeserializationTest(unittest.TestCase):
         aas_identifier = model.Identifier("AAS1", model.IdentifierType.CUSTOM)
         submodel_key = (model.Key(model.KeyElements.SUBMODEL, True, "SM1", model.KeyType.CUSTOM),)
         submodel_identifier = submodel_key[0].get_identifier()
-        assert(submodel_identifier is not None)
+        assert submodel_identifier is not None
         submodel_reference = model.AASReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier)
         test_aas = model.AssetAdministrationShell(asset_reference, aas_identifier, submodel={submodel_reference})

--- a/test/adapter/xml/test_xml_serialization.py
+++ b/test/adapter/xml/test_xml_serialization.py
@@ -51,7 +51,7 @@ class XMLSerializationSchemaTest(unittest.TestCase):
         aas_identifier = model.Identifier("AAS1", model.IdentifierType.CUSTOM)
         submodel_key = (model.Key(model.KeyElements.SUBMODEL, True, "SM1", model.KeyType.CUSTOM),)
         submodel_identifier = submodel_key[0].get_identifier()
-        assert(submodel_identifier is not None)
+        assert submodel_identifier is not None
         submodel_reference = model.AASReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier, semantic_id=model.Reference((),))
         test_aas = model.AssetAdministrationShell(asset_reference, aas_identifier, submodel={submodel_reference})

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -403,7 +403,7 @@ class ModelNamespaceTest(unittest.TestCase):
         # Check that Prop3 got added correctly
         prop3_new = namespace1.set1.get_referable("Prop3")
         self.assertIs(prop3_new.parent, namespace1)
-        assert(isinstance(prop3_new, model.Property))
+        assert isinstance(prop3_new, model.Property)
         self.assertEqual(prop3_new.value, 2)
         # Check that Prop2 got removed correctly
         self.assertNotIn("Prop2", namespace1.set1)


### PR DESCRIPTION
Since version 2.9.0, pycodestyle requires a whitespace after every keyword.