### PR TITLE
Fixed xml deserialization for missing prefixes

### DIFF
--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -85,8 +85,9 @@ def _tag_replace_namespace(tag: str, nsmap: Dict[str, str]) -> str:
     """
     split = tag.split("}")
     for prefix, namespace in nsmap.items():
-        if namespace == split[0][1:]:
-            return prefix + ":" + split[1]
+        if prefix:
+            if namespace == split[0][1:]:
+                return prefix + ":" + split[1]
     return tag
 
 

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -85,9 +85,8 @@ def _tag_replace_namespace(tag: str, nsmap: Dict[str, str]) -> str:
     """
     split = tag.split("}")
     for prefix, namespace in nsmap.items():
-        if prefix:
-            if namespace == split[0][1:]:
-                return prefix + ":" + split[1]
+        if prefix and namespace == split[0][1:]:
+            return prefix + ":" + split[1]
     return tag
 
 


### PR DESCRIPTION
The xml deserialization fails when xml tags without prefixes are used.