### PR TITLE
test.compliance_tool: improve wrong_attribute test strictness

### DIFF
--- a/test/compliance_tool/test_compliance_check_aasx.py
+++ b/test/compliance_tool/test_compliance_check_aasx.py
@@ -61,9 +61,10 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[0].status)
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
-        self.assertIn('Attribute id_short of AssetAdministrationShell[Identifier(IRI=https://acplt.org/'
-                      'Test_AssetAdministrationShell)] must be == TestAssetAdministrationShell',
-                      manager.format_step(2, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell (value=\'TestAssetAdministrationShell2\')',
+                         manager.format_step(2, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[3].status)
 
     def test_check_aasx_files_equivalence(self) -> None:
@@ -113,10 +114,10 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
-        self.assertIn('Attribute id_short of AssetAdministrationShell'
-                      '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] must be ==',
-                      manager.format_step(4, verbose_level=1))
-        self.assertEqual(Status.FAILED, manager.steps[4].status)
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell2 (value=\'TestAssetAdministrationShell\')',
+                         manager.format_step(4, verbose_level=1))
 
         manager.steps = []
         compliance_tool.check_aasx_files_equivalence(file_path_4, file_path_3, manager)
@@ -126,9 +127,10 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
-        self.assertIn('Attribute id_short of AssetAdministrationShell'
-                      '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] must be ==',
-                      manager.format_step(4, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell (value=\'TestAssetAdministrationShell2\')',
+                         manager.format_step(4, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[5].status)
 
     @unittest.skipIf(sys.version_info < (3, 7), "The XML schema check fails for Python <= 3.6")

--- a/test/compliance_tool/test_compliance_check_json.py
+++ b/test/compliance_tool/test_compliance_check_json.py
@@ -128,9 +128,10 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[0].status)
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
-        self.assertIn('Attribute id_short of AssetAdministrationShell[Identifier(IRI=https://acplt.org/'
-                      'Test_AssetAdministrationShell)] must be == TestAssetAdministrationShell',
-                      manager.format_step(2, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
+                         manager.format_step(2, verbose_level=1))
 
     def test_check_json_files_equivalence(self) -> None:
         manager = ComplianceToolStateManager()
@@ -176,6 +177,10 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell123 (value=\'TestAssetAdministrationShell\')',
+                         manager.format_step(4, verbose_level=1))
 
         manager.steps = []
         compliance_tool.check_json_files_equivalence(file_path_4, file_path_3, manager)
@@ -185,6 +190,7 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
-        self.assertIn('Attribute id_short of AssetAdministrationShell'
-                      '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] must be ==',
-                      manager.format_step(4, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must be == TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
+                         manager.format_step(4, verbose_level=1))

--- a/test/compliance_tool/test_compliance_check_xml.py
+++ b/test/compliance_tool/test_compliance_check_xml.py
@@ -119,9 +119,12 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[0].status)
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
-        self.assertIn('Asset administration shell AssetAdministrationShell[Identifier(IRI=https://acplt.org/'
-                      'Test_AssetAdministrationShell)] must exist in given asset administrationshell list',
-                      manager.format_step(2, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Asset administration shell '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must exist in given asset administrationshell list ()\n - ERROR: Given asset administration '
+                         'shell list must not have extra asset administration shells (value={AssetAdministrationShell'
+                         '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell123)]})',
+                         manager.format_step(2, verbose_level=1))
 
     def test_check_xml_files_equivalence(self) -> None:
         manager = ComplianceToolStateManager()
@@ -167,6 +170,12 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Asset administration shell '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell123)] '
+                         'must exist in given asset administrationshell list ()\n - ERROR: Given asset administration '
+                         'shell list must not have extra asset administration shells (value={AssetAdministrationShell'
+                         '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)]})',
+                         manager.format_step(4, verbose_level=1))
 
         manager.steps = []
         compliance_tool.check_xml_files_equivalence(file_path_4, file_path_3, manager)
@@ -176,6 +185,9 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[2].status)
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
-        self.assertIn('Asset administration shell AssetAdministrationShell[Identifier(IRI=https://acplt.org/'
-                      'Test_AssetAdministrationShell)] must exist in given asset administrationshell list',
-                      manager.format_step(4, verbose_level=1))
+        self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Asset administration shell '
+                         'AssetAdministrationShell[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell)] '
+                         'must exist in given asset administrationshell list ()\n - ERROR: Given asset administration '
+                         'shell list must not have extra asset administration shells (value={AssetAdministrationShell'
+                         '[Identifier(IRI=https://acplt.org/Test_AssetAdministrationShell123)]})',
+                         manager.format_step(4, verbose_level=1))


### PR DESCRIPTION
Improve strictness of wrong_attribute tests by checking the whole error message instead just for a single error, which previously disregarded any additional errors.