### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.10"]
+        python-version: ["3.7", "3.8", "3.10"]
     env:
       COUCHDB_ADMIN_PASSWORD: "yo0Quai3"
     services:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
             "aas-compliance-check = basyx.aas.compliance_tool.cli:main"
         ]
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'python-dateutil>=2.8,<3',
         'lxml>=4.2,<5',

--- a/test/compliance_tool/test_compliance_check_aasx.py
+++ b/test/compliance_tool/test_compliance_check_aasx.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: MIT
 import os
 import unittest
-import sys
 
 from basyx.aas.compliance_tool import compliance_check_aasx as compliance_tool
 from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
@@ -131,7 +130,6 @@ class ComplianceToolAASXTest(unittest.TestCase):
                       manager.format_step(4, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[5].status)
 
-    @unittest.skipIf(sys.version_info < (3, 7), "The XML schema check fails for Python <= 3.6")
     def test_check_schema(self):
         manager = ComplianceToolStateManager()
         script_dir = os.path.dirname(__file__)


### PR DESCRIPTION
In order to update the dependency on jsonschema (https://github.com/eclipse-basyx/basyx-python-sdk/commit/80913ef9ad5dc1bbf673b84acbc54dbfc1a3915f), Python 3.6 must be dropped. Python 3.6 is EOL since 23.12.2021 and all major distributions have updated to more recent releases.
Also disable skipping of a unit test on Python versions < 3.7, since this is no longer supported and tested anyways.
This PR is required by #24.