### PR TITLE
ci: update python versions in strategy matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.10"]
+        python-version: ["3.7", "3.9", "3.11"]
     env:
       COUCHDB_ADMIN_PASSWORD: "yo0Quai3"
     services:


### PR DESCRIPTION
Python 3.11 has been released on 24.10.2022 and we should aim to be fully compatible, thus test on 3.11 instead of 3.10. Also test on 3.9 instead of 3.8, because 3.9 is more widespread than 3.8 (e.g. 3.9 is packaged for Debian 11 (bullseye), most other distributions either use 3.9 or a newer release as well) and so we're back to the (test, skip, test, skip, test) pattern, where we skip testing on 3.8 and 3.10.