### PR TITLE
typing: make implicit optional types explicit optional

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -362,8 +362,8 @@ class AASXWriter:
 
         # Add referenced ConceptDescriptions to the AAS part
         for dictionary in aas.concept_dictionary:
-            for concept_rescription_ref in dictionary.concept_description:
-                objects_to_be_written.add(concept_rescription_ref.get_identifier())
+            for concept_description_ref in dictionary.concept_description:
+                objects_to_be_written.add(concept_description_ref.get_identifier())
 
         # Write submodels: Either create a split part for each of them or otherwise add them to objects_to_be_written
         aas_split_part_names: List[str] = []

--- a/basyx/aas/model/concept.py
+++ b/basyx/aas/model/concept.py
@@ -167,16 +167,16 @@ class IEC61360ConceptDescription(ConceptDescription):
                  category: Optional[str] = None,
                  description: Optional[base.LangStringSet] = None,
                  parent: Optional[base.Namespace] = None,
-                 administration: base.AdministrativeInformation = None,
+                 administration: Optional[base.AdministrativeInformation] = None,
                  unit: Optional[str] = None,
                  unit_id: Optional[base.Reference] = None,
                  source_of_definition: Optional[str] = None,
                  symbol: Optional[str] = None,
-                 value_format: base.DataTypeDef = None,
+                 value_format: Optional[base.DataTypeDef] = None,
                  value_list: Optional[base.ValueList] = None,
                  value: Optional[base.ValueDataType] = None,
                  value_id: Optional[base.Reference] = None,
-                 level_types: Set[IEC61360LevelType] = None,
+                 level_types: Optional[Set[IEC61360LevelType]] = None,
                  ):
         super().__init__(identification, is_case_of, id_short, category, description, parent, administration)
         self.preferred_name: base.LangStringSet = preferred_name


### PR DESCRIPTION
mypy prohibits implicit optional types since a recent version, so let's get rid of them.
This PR also upstreams a typo fix from @zrgt, that happened to sit around in our fork.