### PR TITLE
model.base: fix AASReference.resolve() error messages

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -713,6 +713,7 @@ class AASReference(Reference, Generic[_RT]):
             except KeyError as e:
                 raise KeyError("Could not resolve id_short {} at {}".format(key.value, " / ".join(resolved_keys)))\
                     from e
+            resolved_keys.append(item.id_short)
 
         # Check type
         if not isinstance(item, self.type):

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -525,8 +525,8 @@ class AASReferenceTest(unittest.TestCase):
                                   model.Property)
         with self.assertRaises(TypeError) as cm:
             ref2.resolve(DummyObjectProvider())
-        self.assertEqual("Object retrieved at Identifier(IRI=urn:x-test:submodel) is not a Namespace",
-                         str(cm.exception))
+        self.assertEqual("Object retrieved at Identifier(IRI=urn:x-test:submodel) / collection / prop is not a "
+                         "Namespace", str(cm.exception))
 
         with self.assertRaises(AttributeError) as cm_2:
             ref1.key[2].value = "prop1"


### PR DESCRIPTION
Previously resolved keys beside the identifier of the identifiable weren't added to the `resolved_keys` list. This fixes this issue, similar to how it's done on the improve/V30RC02 branch. CI checks fail because of #43.