### PR TITLE
backend.couchdb: remove usage of deprecated HTTPResponse.getheader()

### DIFF
--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -156,7 +156,7 @@ class CouchDBBackend(backends.Backend):
         if method == 'HEAD':
             return response.headers
 
-        if response.getheader('Content-type') != 'application/json':
+        if response.headers.get('Content-type') != 'application/json':
             raise CouchDBResponseError("Unexpected Content-type header")
         try:
             data = json.loads(response.data.decode('utf-8'), cls=json_deserialization.AASFromJsonDecoder)


### PR DESCRIPTION
DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTResponse.headers.get(name, default).
Same as #44, CI fails until #43 is merged.