### PR TITLE
setup.py: add missing comma to urllib3 dependency specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires=[
         'python-dateutil>=2.8,<3',
         'lxml>=4.2,<5',
-        'urllib3>=1.26<2.0',
+        'urllib3>=1.26,<2.0',
         'pyecma376-2>=0.2.4',
     ]
 )


### PR DESCRIPTION
Since a recent version, wheel requires a comma between lower and upper version bound.