### PR TITLE
Rename `base.AASReference` to `ModelReference`

### DIFF
--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -557,12 +557,12 @@ class AASReferenceTest(unittest.TestCase):
             ref4.resolve(DummyObjectProvider())
         self.assertIs(submodel, cm_4.exception.value)
 
-        ref5 = model.AASReference((), model.Submodel)
+        ref5 = model.ModelReference((), model.Submodel)
         with self.assertRaises(IndexError) as cm_5:
             ref5.resolve(DummyObjectProvider())
         self.assertEqual('List of keys is empty', str(cm_5.exception))
 
-        ref6 = model.AASReference((model.Key(model.KeyElements.SUBMODEL, False, "urn:x-test:submodel",
+        ref6 = model.ModelReference((model.Key(model.KeyElements.SUBMODEL, False, "urn:x-test:submodel",
                                              model.KeyType.IRI),
                                    model.Key(model.KeyElements.SUBMODEL_ELEMENT_COLLECTION, False, "collection",
                                              model.KeyType.IDSHORT),

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -557,10 +557,9 @@ class AASReferenceTest(unittest.TestCase):
             ref4.resolve(DummyObjectProvider())
         self.assertIs(submodel, cm_4.exception.value)
 
-        ref5 = model.ModelReference((), model.Submodel)
-        with self.assertRaises(IndexError) as cm_5:
-            ref5.resolve(DummyObjectProvider())
-        self.assertEqual('List of keys is empty', str(cm_5.exception))
+        with self.assertRaises(ValueError) as cm_5:
+            ref5 = model.ModelReference((), model.Submodel)
+        self.assertEqual('A reference must have at least one key!', str(cm_5.exception))
 
         ref6 = model.ModelReference((model.Key(model.KeyElements.SUBMODEL, False, "urn:x-test:submodel",
                                              model.KeyType.IRI),

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -356,8 +356,6 @@ class ModelNamespaceTest(unittest.TestCase):
         self.assertIsNone(self.prop1.parent)
         self.namespace.set1.discard(self.prop1)
 
-        self.assertFalse([1] in self.namespace.set1)
-
     def test_Namespace(self) -> None:
         with self.assertRaises(KeyError) as cm:
             namespace_test = ExampleNamespace([self.prop1, self.prop2, self.prop1alt])
@@ -377,7 +375,8 @@ class ModelNamespaceTest(unittest.TestCase):
             self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm2.exception))
 
         with self.assertRaises(KeyError) as cm3:
-            namespace.remove_referable("Prob2")
+            namespace.remove_referable("Prop2")
+            self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm3.exception))
 
     def test_renaming(self) -> None:
         self.namespace.set1.add(self.prop1)


### PR DESCRIPTION
This PR renames `base.AASReference` to `base.ModelReference` to suit V3.0