### PR TITLE
test.model: Rename `model.KeyElements` to `model.KeyTypes`

### DIFF
--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -856,18 +856,18 @@ class ModelReferenceTest(unittest.TestCase):
             ref6.resolve(DummyObjectProvider())
         self.assertIs(submodel, cm_6.exception.value)
 
-        with self.assertRaises(ValueError) as cm_5:
-            ref5 = model.ModelReference((), model.Submodel)
-        self.assertEqual('A reference must have at least one key!', str(cm_5.exception))
+        with self.assertRaises(ValueError) as cm_7:
+            ref7 = model.ModelReference((), model.Submodel)
+        self.assertEqual('A reference must have at least one key!', str(cm_7.exception))
 
-        ref6 = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:submodel"),
+        ref8 = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:submodel"),
                                      model.Key(model.KeyTypes.SUBMODEL_ELEMENT_COLLECTION, "collection"),
                                      model.Key(model.KeyTypes.PROPERTY, "prop_false")), model.Property)
 
-        with self.assertRaises(KeyError) as cm_6:
-            ref6.resolve(DummyObjectProvider())
+        with self.assertRaises(KeyError) as cm_8:
+            ref8.resolve(DummyObjectProvider())
             self.assertEqual("'Could not resolve id_short prop_false at Identifier(IRI=urn:x-test:submodel)'",
-                             str(cm_6.exception))
+                             str(cm_8.exception))
 
     def test_get_identifier(self) -> None:
         ref = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:x"),), model.Submodel)

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -860,12 +860,9 @@ class ModelReferenceTest(unittest.TestCase):
             ref5 = model.ModelReference((), model.Submodel)
         self.assertEqual('A reference must have at least one key!', str(cm_5.exception))
 
-        ref6 = model.ModelReference((model.Key(model.KeyElements.SUBMODEL, False, "urn:x-test:submodel",
-                                             model.KeyType.IRI),
-                                   model.Key(model.KeyElements.SUBMODEL_ELEMENT_COLLECTION, False, "collection",
-                                             model.KeyType.IDSHORT),
-                                   model.Key(model.KeyElements.PROPERTY, False, "prop_false",
-                                             model.KeyType.IDSHORT)), model.Property)
+        ref6 = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:submodel"),
+                                     model.Key(model.KeyTypes.SUBMODEL_ELEMENT_COLLECTION, "collection"),
+                                     model.Key(model.KeyTypes.PROPERTY, "prop_false")), model.Property)
 
         with self.assertRaises(KeyError) as cm_6:
             ref6.resolve(DummyObjectProvider())
@@ -979,8 +976,8 @@ class HasSemanticsTest(unittest.TestCase):
     def test_supplemental_semantic_id_constraint(self) -> None:
         extension = model.Extension(name='test')
         key: model.Key = model.Key(model.KeyTypes.GLOBAL_REFERENCE, "global_reference")
-        ref_sem_id: model.Reference = model.GlobalReference((key, ))
-        ref1: model.Reference = model.GlobalReference((key, ))
+        ref_sem_id: model.Reference = model.GlobalReference((key,))
+        ref1: model.Reference = model.GlobalReference((key,))
 
         with self.assertRaises(model.AASConstraintViolation) as cm:
             extension.supplemental_semantic_id.append(ref1)


### PR DESCRIPTION
Renamed `model.KeyElements` to `model.KeyTypes` as defined for V3.0RC02 and V3.0. Adapted to new constructor of `model.Key`
see: https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=171