### PR TITLE
WIP: `BasicEventElement.message_topic`: Change type to newly introduced `MessageTopicType`

### DIFF
--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -646,7 +646,7 @@ def create_example_submodel() -> model.Submodel:
                                       model.Property),
         direction=model.Direction.OUTPUT,
         state=model.StateOfEvent.ON,
-        message_topic='ExampleTopic',
+        message_topic=model.datatypes.MessageTopicType('ExampleTopic'),
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
                                                        "http://acplt.org/ExampleMessageBroker"),),
                                             model.Submodel),

--- a/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -246,7 +246,7 @@ def create_example_submodel() -> model.Submodel:
                                       model.Property),
         direction=model.Direction.OUTPUT,
         state=model.StateOfEvent.ON,
-        message_topic='ExampleTopic',
+        message_topic=model.datatypes.MessageTopicType('ExampleTopic'),
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
                                                        "http://acplt.org/ExampleMessageBroker"),),
                                             model.Submodel),

--- a/basyx/aas/examples/data/example_submodel_template.py
+++ b/basyx/aas/examples/data/example_submodel_template.py
@@ -206,7 +206,7 @@ def create_example_submodel_template() -> model.Submodel:
                                       model.Property),
         direction=model.Direction.OUTPUT,
         state=model.StateOfEvent.ON,
-        message_topic='ExampleTopic',
+        message_topic=model.datatypes.MessageTopicType('ExampleTopic'),
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
                                                        "http://acplt.org/ExampleMessageBroker"),),
                                             model.Submodel),

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -382,6 +382,16 @@ AnyXSDType = Union[
     AnyURI, String, NormalizedString]
 
 
+class MessageTopicType(str):
+    def __new__(cls, *args, **kwargs):
+        res = str.__new__(cls, *args, **kwargs)
+        if res == 'None':
+            return None
+        if len(res) > 255:
+            raise ValueError("MessageTopicType has a maximum of 255 characters")
+        return res
+
+
 XSD_TYPE_NAMES: Dict[Type[AnyXSDType], str] = {k: "xs:" + v for k, v in {
     Duration: "duration",
     DayTimeDuration: "dayTimeDuration",

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -1240,7 +1240,7 @@ class BasicEventElement(EventElement):
                  observed: base.ModelReference[Union["aas.AssetAdministrationShell", Submodel, SubmodelElement]],
                  direction: base.Direction,
                  state: base.StateOfEvent,
-                 message_topic: Optional[str] = None,
+                 message_topic: Optional[datatypes.MessageTopicType] = None,
                  message_broker: Optional[base.ModelReference[Union[Submodel, SubmodelElementList,
                                                                     SubmodelElementCollection, Entity]]] = None,
                  last_update: Optional[datatypes.DateTime] = None,
@@ -1267,7 +1267,7 @@ class BasicEventElement(EventElement):
         self.max_interval: Optional[datatypes.Duration] = None
         self.direction: base.Direction = direction
         self.state: base.StateOfEvent = state
-        self.message_topic: Optional[str] = message_topic
+        self.message_topic: Optional[datatypes.MessageTopicType] = message_topic
         self.message_broker: Optional[base.ModelReference[Union[Submodel, SubmodelElementList,
                                                                 SubmodelElementCollection, Entity]]] = message_broker
         self.last_update: Optional[datatypes.DateTime] = last_update

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -87,6 +87,13 @@ class TestStringTypes(unittest.TestCase):
         self.assertEqual("abc", model.datatypes.xsd_repr(model.datatypes.String("abc")))
         self.assertEqual("abc", model.datatypes.xsd_repr(model.datatypes.NormalizedString("abc")))
 
+    def test_message_topic_type(self) -> None:
+        self.assertEqual("abc", model.datatypes.MessageTopicType("abc"))
+        self.assertEqual(None, model.datatypes.MessageTopicType(None))
+        with self.assertRaises(ValueError) as cm:
+            model.datatypes.MessageTopicType('a'*256)
+        self.assertEqual("MessageTopicType has a maximum of 255 characters", str(cm.exception))
+
 
 class TestDateTimeTypes(unittest.TestCase):
     def test_parse_duration(self) -> None:


### PR DESCRIPTION
Version 3.0 of the specification introduces a MessageTopicType,
a constrained string type.

We introduce this new type and implement its occurrences in
BasicEventElement.message_topic.

Furthermore, we add a unittest to test the new type.

see: https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=164