### PR TITLE
`base.AssetKind`: Add newly introduced enum `NOTAPPLICABLE` and update description

### DIFF
--- a/basyx/aas/adapter/_generic.py
+++ b/basyx/aas/adapter/_generic.py
@@ -23,7 +23,7 @@ MODELING_KIND: Dict[model.ModelingKind, str] = {
 ASSET_KIND: Dict[model.AssetKind, str] = {
     model.AssetKind.TYPE: 'Type',
     model.AssetKind.INSTANCE: 'Instance',
-    model.AssetKind.NOTAPPLICABLE: 'NotApplicable'}
+    model.AssetKind.NOT_APPLICABLE: 'NotApplicable'}
 
 QUALIFIER_KIND: Dict[model.QualifierKind, str] = {
     model.QualifierKind.CONCEPT_QUALIFIER: 'ConceptQualifier',

--- a/basyx/aas/adapter/_generic.py
+++ b/basyx/aas/adapter/_generic.py
@@ -22,7 +22,8 @@ MODELING_KIND: Dict[model.ModelingKind, str] = {
 
 ASSET_KIND: Dict[model.AssetKind, str] = {
     model.AssetKind.TYPE: 'Type',
-    model.AssetKind.INSTANCE: 'Instance'}
+    model.AssetKind.INSTANCE: 'Instance',
+    model.AssetKind.NOTAPPLICABLE: 'NotApplicable'}
 
 QUALIFIER_KIND: Dict[model.QualifierKind, str] = {
     model.QualifierKind.CONCEPT_QUALIFIER: 'ConceptQualifier',

--- a/basyx/aas/adapter/json/aasJSONSchema.json
+++ b/basyx/aas/adapter/json/aasJSONSchema.json
@@ -105,7 +105,7 @@
           "$ref": "#/definitions/AssetKind"
         },
         "globalAssetId": {
-          "$ref": "#/definitions/Identifier"
+          "$ref": "#/definitions/Reference"
         },
         "specificAssetIds": {
           "type": "array",

--- a/basyx/aas/adapter/json/aasJSONSchema.json
+++ b/basyx/aas/adapter/json/aasJSONSchema.json
@@ -105,7 +105,7 @@
           "$ref": "#/definitions/AssetKind"
         },
         "globalAssetId": {
-          "$ref": "#/definitions/Reference"
+          "$ref": "#/definitions/Identifier"
         },
         "specificAssetIds": {
           "type": "array",

--- a/basyx/aas/adapter/json/aasJSONSchema.json
+++ b/basyx/aas/adapter/json/aasJSONSchema.json
@@ -126,7 +126,8 @@
       "type": "string",
       "enum": [
         "Instance",
-        "Type"
+        "Type",
+        "NotApplicable"
       ]
     },
     "BasicEventElement": {

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -963,6 +963,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="Type"/>
       <xs:enumeration value="Instance"/>
+      <xs:enumeration value="NotApplicable"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="dataTypeDefXsd_t">

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -203,21 +203,21 @@ class ModelingKind(Enum):
 @unique
 class AssetKind(Enum):
     """
-    Enumeration for denoting whether an element is a type or an instance.
+    Enumeration for denoting whether an asset is a type asset or an instance asset or whether this kind of
+    classification is not applicable.
     *Note:* :attr:`~.AssetKind.INSTANCE` becomes an individual entity of a type, for example a device, by defining
     specific property values.
 
     *Note:* In an object oriented view, an instance denotes an object of a class (of a type)
 
-    :cvar TYPE: hardware or software element which specifies the common attributes shared by all instances of the type
-    :cvar INSTANCE: concrete, clearly identifiable component of a certain type,
-                    *Note:* It becomes an individual entity of a type, for example a device, by defining specific
-                    property values.
-                    *Note:* In an object oriented view, an instance denotes an object of a class (of a type)
+    :cvar TYPE: Type asset
+    :cvar INSTANCE: Instance asset
+    :cvar NOTAPPLICABLE: Neither a type asset nor an instance asset
     """
 
     TYPE = 0
     INSTANCE = 1
+    NOTAPPLICABLE = 2
 
 
 class QualifierKind(Enum):

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -212,12 +212,12 @@ class AssetKind(Enum):
 
     :cvar TYPE: Type asset
     :cvar INSTANCE: Instance asset
-    :cvar NOTAPPLICABLE: Neither a type asset nor an instance asset
+    :cvar NOT_APPLICABLE: Neither a type asset nor an instance asset
     """
 
     TYPE = 0
     INSTANCE = 1
-    NOTAPPLICABLE = 2
+    NOT_APPLICABLE = 2
 
 
 class QualifierKind(Enum):


### PR DESCRIPTION
Version 3.0 of the specification introduces a new enum `NOTAPPLICABLE` in `base.AssetKind`.

Further, we update the description of  `AssetKind/Type` and `AssetKind/Instance` as specified in  IEC 63278-1.

`NOTAPPLICABLE` is also added to `_generic.ASSET_KIND` dictionary.

see:
https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=164
https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=166