### PR TITLE
adapter.xml.xml_deserialization: be more forgiving with invalid input

### DIFF
--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -449,9 +449,8 @@ class AASFromXmlDecoder:
                     continue
                 if len(constraint) > 1:
                     logger.warning(f"{_element_pretty_identifier(constraint)} has more than one constraint, "
-                                   "using the first one...")
-                constructed = _failsafe_construct(constraint[0], cls.construct_constraint, cls.failsafe)
-                if constructed is not None:
+                                   "which is invalid! Deserializing all constraints anyways...")
+                for constructed in _failsafe_construct_multiple(constraint, cls.construct_constraint, cls.failsafe):
                     obj.qualifier.add(constructed)
 
     @classmethod
@@ -729,9 +728,8 @@ class AASFromXmlDecoder:
                     raise KeyError(f"{_element_pretty_identifier(data_element)} has no data element!")
                 if len(data_element) > 1:
                     logger.warning(f"{_element_pretty_identifier(data_element)} has more than one data element, "
-                                   "using the first one...")
-                constructed = _failsafe_construct(data_element[0], cls.construct_data_element, cls.failsafe)
-                if constructed is not None:
+                                   "which is invalid! Deserializing all data elements anyways...")
+                for constructed in _failsafe_construct_multiple(data_element, cls.construct_data_element, cls.failsafe):
                     annotated_relationship_element.annotation.add(constructed)
         return annotated_relationship_element
 
@@ -787,9 +785,9 @@ class AASFromXmlDecoder:
                     raise KeyError(f"{_element_pretty_identifier(submodel_element)} has no submodel element!")
                 if len(submodel_element) > 1:
                     logger.warning(f"{_element_pretty_identifier(submodel_element)} has more than one submodel element,"
-                                   " using the first one...")
-                constructed = _failsafe_construct(submodel_element[0], cls.construct_submodel_element, cls.failsafe)
-                if constructed is not None:
+                                   " which is invalid! Deserializing all submodel elements anyways...")
+                for constructed in _failsafe_construct_multiple(submodel_element, cls.construct_submodel_element,
+                                                                cls.failsafe):
                     entity.statement.add(constructed)
         cls._amend_abstract_attributes(entity, element)
         return entity
@@ -912,9 +910,9 @@ class AASFromXmlDecoder:
                     raise KeyError(f"{_element_pretty_identifier(submodel_element)} has no submodel element!")
                 if len(submodel_element) > 1:
                     logger.warning(f"{_element_pretty_identifier(submodel_element)} has more than one submodel element,"
-                                   " using the first one...")
-                constructed = _failsafe_construct(submodel_element[0], cls.construct_submodel_element, cls.failsafe)
-                if constructed is not None:
+                                   " which is invalid! Deserializing all submodel elements anyways...")
+                for constructed in _failsafe_construct_multiple(submodel_element, cls.construct_submodel_element,
+                                                                cls.failsafe):
                     collection.value.add(constructed)
         cls._amend_abstract_attributes(collection, element)
         return collection
@@ -985,9 +983,9 @@ class AASFromXmlDecoder:
                     raise KeyError(f"{_element_pretty_identifier(submodel_element)} has no submodel element!")
                 if len(submodel_element) > 1:
                     logger.warning(f"{_element_pretty_identifier(submodel_element)} has more than one submodel element,"
-                                   " using the first one...")
-                constructed = _failsafe_construct(submodel_element[0], cls.construct_submodel_element, cls.failsafe)
-                if constructed is not None:
+                                   " which is invalid! Deserializing all submodel elements anyways...")
+                for constructed in _failsafe_construct_multiple(submodel_element, cls.construct_submodel_element,
+                                                                cls.failsafe):
                     submodel.submodel_element.add(constructed)
         cls._amend_abstract_attributes(submodel, element)
         return submodel


### PR DESCRIPTION
When deserializing XML we would previously only have a look at the first child of an unnecessary wrapper element and ignore additional elements. However, since some implemenetations like the AASX Package Explorer generate schema-incompatible XML, this behavior is changed in a way such that additional elements are no longer ignored, but also parsed instead.

Fix #71