### PR TITLE
WIP: `model.datatypes.py`: Add newly introduced elements that enforce constraints.

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -256,7 +256,7 @@ class AASXReader:
                 logger.debug("Reading supplementary file {} from AASX package ...".format(absolute_name))
                 with self.reader.open_part(absolute_name) as p:
                     final_name = file_store.add_file(absolute_name, p, self.reader.get_content_type(absolute_name))
-                element.value = final_name
+                element.value = model.Identifier(final_name)
 
 
 class AASXWriter:
@@ -512,7 +512,7 @@ class AASXWriter:
             if isinstance(the_object, model.Submodel):
                 for element in traversal.walk_submodel(the_object):
                     if isinstance(element, model.File):
-                        file_name = element.value
+                        file_name = str(element.value)
                         # Skip File objects with empty value URI references that are considered to be no local file
                         # (absolute URIs or network-path URI references)
                         if file_name is None or file_name.startswith('//') or ':' in file_name.split('/')[0]:

--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -485,7 +485,7 @@ class CouchDBObjectStore(model.AbstractObjectStore):
         :param url_quote: If True, the result id string is url-encoded to be used in a HTTP request URL
         """
         if url_quote:
-            identifier = urllib.parse.quote(identifier, safe='')
+            identifier = model.Identifier(urllib.parse.quote(identifier, safe=''))
         return identifier
 
     def generate_source(self, identifiable: model.Identifiable):

--- a/basyx/aas/compliance_tool/compliance_check_aasx.py
+++ b/basyx/aas/compliance_tool/compliance_check_aasx.py
@@ -244,10 +244,10 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
 
     # Check if file in file object is the same
     list_of_id_shorts = ["ExampleSubmodelCollection", "ExampleFile"]
-    obj = example_data.get_identifiable("https://acplt.org/Test_Submodel")
+    obj = example_data.get_identifiable(model.Identifier("https://acplt.org/Test_Submodel"))
     for id_short in list_of_id_shorts:
         obj = obj.get_referable(id_short)
-    obj2 = obj_store.get_identifiable("https://acplt.org/Test_Submodel")
+    obj2 = obj_store.get_identifiable(model.Identifier("https://acplt.org/Test_Submodel"))
     for id_short in list_of_id_shorts:
         obj2 = obj2.get_referable(id_short)
     try:

--- a/basyx/aas/examples/data/__init__.py
+++ b/basyx/aas/examples/data/__init__.py
@@ -55,12 +55,12 @@ def create_example_aas_binding() -> model.DictObjectStore:
     obj_store.update(example_aas_missing_attributes.create_full_example())
     obj_store.add(example_submodel_template.create_example_submodel_template())
 
-    aas = obj_store.get_identifiable('https://acplt.org/Test_AssetAdministrationShell')
-    sm = obj_store.get_identifiable('https://acplt.org/Test_Submodel_Template')
+    aas = obj_store.get_identifiable(model.Identifier('https://acplt.org/Test_AssetAdministrationShell'))
+    sm = obj_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel_Template'))
     assert (isinstance(aas, model.aas.AssetAdministrationShell))  # make mypy happy
     assert (isinstance(sm, model.submodel.Submodel))  # make mypy happy
     aas.submodel.add(model.ModelReference.from_referable(sm))
 
-    cd = obj_store.get_identifiable('https://acplt.org/Test_ConceptDescription_Mandatory')
+    cd = obj_store.get_identifiable(model.Identifier('https://acplt.org/Test_ConceptDescription_Mandatory'))
     assert (isinstance(cd, model.concept.ConceptDescription))  # make mypy happy
     return obj_store

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -98,7 +98,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
 
     """
     qualifier = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier',
+        type_=model.datatypes.NameType('http://acplt.org/Qualifier/ExampleQualifier'),
         value_type=model.datatypes.Int,
         value=100,
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
@@ -106,7 +106,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         kind=model.QualifierKind.CONCEPT_QUALIFIER)
 
     qualifier2 = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier2',
+        type_=model.datatypes.NameType('http://acplt.org/Qualifier/ExampleQualifier2'),
         value_type=model.datatypes.Int,
         value=50,
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
@@ -114,7 +114,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         kind=model.QualifierKind.TEMPLATE_QUALIFIER)
 
     qualifier3 = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier3',
+        type_=model.datatypes.NameType('http://acplt.org/Qualifier/ExampleQualifier3'),
         value_type=model.datatypes.DateTime,
         value=model.datatypes.DateTime(2023, 4, 7, 16, 59, 54, 870123),
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
@@ -186,7 +186,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
 
     # asset identification submodel which will be included in the asset object
     identification_submodel = model.Submodel(
-        id_='http://acplt.org/Submodels/Assets/TestAsset/Identification',
+        id_=model.Identifier('http://acplt.org/Submodels/Assets/TestAsset/Identification'),
         submodel_element=(identification_submodel_element_manufacturer_name,
                           identification_submodel_element_instance_id),
         id_short='Identification',
@@ -194,8 +194,8 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         description=model.LangStringSet({'en-US': 'An example asset identification submodel for the test application',
                                          'de': 'Ein Beispiel-Identifikations-Submodel für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
                                                     value='http://acplt.org/SubmodelTemplates/AssetIdentification'),),
                                          model.Submodel),
@@ -312,7 +312,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
 
     # bill of material submodel which will be included in the asset object
     bill_of_material = model.Submodel(
-        id_='http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial',
+        id_=model.Identifier('http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial'),
         submodel_element=(entity,
                           entity_2),
         id_short='BillOfMaterial',
@@ -320,7 +320,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         description=model.LangStringSet({'en-US': 'An example bill of material submodel for the test application',
                                          'de': 'Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1')),
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
                                                     value='http://acplt.org/SubmodelTemplates/BillOfMaterial'),),
                                          model.Submodel),
@@ -432,7 +432,7 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_blob = model.Blob(
         id_short='ExampleBlob',
-        content_type='application/pdf',
+        content_type=model.ContentType('application/pdf'),
         value=bytes(b'\x01\x02\x03\x04\x05'),
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example Blob object',
@@ -449,8 +449,8 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_file = model.File(
         id_short='ExampleFile',
-        content_type='application/pdf',
-        value='/TestFile.pdf',
+        content_type=model.ContentType('application/pdf'),
+        value=model.Identifier('/TestFile.pdf'),
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example File object',
                                          'de': 'Beispiel File Element'}),
@@ -466,9 +466,9 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_file_uri = model.File(
         id_short='ExampleFileURI',
-        content_type='application/pdf',
-        value='https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/Details-of-the-Asset-'
-              'Administration-Shell-Part1.pdf?__blob=publicationFile&v=5',
+        content_type=model.ContentType('application/pdf'),
+        value=model.Identifier('https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/'
+                               'Details-of-the-Asset-Administration-Shell-Part1.pdf?__blob=publicationFile&v=5'),
         category='CONSTANT',
         description=model.LangStringSet({'en-US': 'Details of the Asset Administration Shell — An example for an '
                                                   'external file reference',
@@ -713,7 +713,7 @@ def create_example_submodel() -> model.Submodel:
     )
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel',
+        id_=model.Identifier('https://acplt.org/Test_Submodel'),
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -725,8 +725,8 @@ def create_example_submodel() -> model.Submodel:
         description=model.LangStringSet({'en-US': 'An example submodel for the test application',
                                          'de': 'Ein Beispiel-Teilmodell für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         semantic_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
@@ -746,7 +746,7 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription',
+        id_=model.Identifier('https://acplt.org/Test_ConceptDescription'),
         is_case_of={model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/DataSpecifications/'
                                                            'ConceptDescriptions/TestConceptDescription'),))},
@@ -755,7 +755,8 @@ def create_example_concept_description() -> model.ConceptDescription:
         description=model.LangStringSet({'en-US': 'An example concept description for the test application',
                                          'de': 'Ein Beispiel-ConceptDescription für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9', revision='0',
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1'),
                                                        embedded_data_specifications=(
                                                            _embedded_data_specification_iec61360,
                                                        )),
@@ -787,21 +788,21 @@ def create_example_asset_administration_shell() -> \
                                                      "http://acplt.org/SpecificAssetId/"
                                                  ),)))},
         default_thumbnail=model.Resource(
-            "file:///path/to/thumbnail.png",
-            "image/png"
+            model.Identifier("file:///path/to/thumbnail.png"),
+            model.ContentType("image/png")
         )
     )
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell',
+        id_=model.Identifier('https://acplt.org/Test_AssetAdministrationShell'),
         id_short='TestAssetAdministrationShell',
         category=None,
         description=model.LangStringSet({'en-US': 'An Example Asset Administration Shell for the test application',
                                          'de': 'Ein Beispiel-Verwaltungsschale für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
                                                   value='https://acplt.org/Test_Submodel'),),
                                        model.Submodel,

--- a/basyx/aas/examples/data/example_aas_mandatory_attributes.py
+++ b/basyx/aas/examples/data/example_aas_mandatory_attributes.py
@@ -63,11 +63,11 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_blob = model.Blob(
         id_short='ExampleBlob',
-        content_type='application/pdf')
+        content_type=model.ContentType('application/pdf'))
 
     submodel_element_file = model.File(
         id_short='ExampleFile',
-        content_type='application/pdf')
+        content_type=model.ContentType('application/pdf'))
 
     submodel_element_reference_element = model.ReferenceElement(
         category="PARAMETER",
@@ -137,7 +137,7 @@ def create_example_submodel() -> model.Submodel:
         value=())
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Mandatory',
+        id_=model.Identifier('https://acplt.org/Test_Submodel_Mandatory'),
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -155,7 +155,7 @@ def create_example_empty_submodel() -> model.Submodel:
     :return: example submodel
     """
     return model.Submodel(
-        id_='https://acplt.org/Test_Submodel2_Mandatory')
+        id_=model.Identifier('https://acplt.org/Test_Submodel2_Mandatory'))
 
 
 def create_example_concept_description() -> model.ConceptDescription:
@@ -165,7 +165,7 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription_Mandatory')
+        id_=model.Identifier('https://acplt.org/Test_ConceptDescription_Mandatory'))
     return concept_description
 
 
@@ -184,7 +184,7 @@ def create_example_asset_administration_shell() -> \
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell_Mandatory',
+        id_=model.Identifier('https://acplt.org/Test_AssetAdministrationShell_Mandatory'),
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
                                                   value='https://acplt.org/Test_Submodel_Mandatory'),),
                                        model.Submodel),
@@ -203,7 +203,7 @@ def create_example_empty_asset_administration_shell() -> model.AssetAdministrati
     """
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=model.AssetInformation(),
-        id_='https://acplt.org/Test_AssetAdministrationShell2_Mandatory')
+        id_=model.Identifier('https://acplt.org/Test_AssetAdministrationShell2_Mandatory'))
     return asset_administration_shell
 
 

--- a/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -40,7 +40,7 @@ def create_example_submodel() -> model.Submodel:
     :return: example submodel
     """
     qualifier = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier',
+        type_=model.datatypes.NameType('http://acplt.org/Qualifier/ExampleQualifier'),
         value_type=model.datatypes.String)
 
     submodel_element_property = model.Property(
@@ -88,7 +88,7 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_blob = model.Blob(
         id_short='ExampleBlob',
-        content_type='application/pdf',
+        content_type=model.ContentType('application/pdf'),
         value=bytearray(b'\x01\x02\x03\x04\x05'),
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example Blob object',
@@ -101,8 +101,8 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_file = model.File(
         id_short='ExampleFile',
-        content_type='application/pdf',
-        value='/TestFile.pdf',
+        content_type=model.ContentType('application/pdf'),
+        value=model.Identifier('/TestFile.pdf'),
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example File object',
                                          'de': 'Beispiel File Element'}),
@@ -282,7 +282,7 @@ def create_example_submodel() -> model.Submodel:
         kind=model.ModelingKind.INSTANCE)
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Missing',
+        id_=model.Identifier('https://acplt.org/Test_Submodel_Missing'),
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -294,8 +294,8 @@ def create_example_submodel() -> model.Submodel:
         description=model.LangStringSet({'en-US': 'An example submodel for the test application',
                                          'de': 'Ein Beispiel-Teilmodell für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         semantic_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
@@ -311,15 +311,15 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription_Missing',
+        id_=model.Identifier('https://acplt.org/Test_ConceptDescription_Missing'),
         is_case_of=None,
         id_short='TestConceptDescription',
         category=None,
         description=model.LangStringSet({'en-US': 'An example concept description for the test application',
                                          'de': 'Ein Beispiel-ConceptDescription für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'))
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')))
     return concept_description
 
 
@@ -332,8 +332,8 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
     """
 
     resource = model.Resource(
-        content_type='application/pdf',
-        path='file:///TestFile.pdf')
+        content_type=model.ContentType('application/pdf'),
+        path=model.Identifier('file:///TestFile.pdf'))
 
     asset_information = model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
@@ -347,14 +347,14 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell_Missing',
+        id_=model.Identifier('https://acplt.org/Test_AssetAdministrationShell_Missing'),
         id_short='TestAssetAdministrationShell',
         category=None,
         description=model.LangStringSet({'en-US': 'An Example Asset Administration Shell for the test application',
                                          'de': 'Ein Beispiel-Verwaltungsschale für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
                                                   value='https://acplt.org/Test_Submodel_Missing'),),
                                        model.Submodel)},

--- a/basyx/aas/examples/data/example_submodel_template.py
+++ b/basyx/aas/examples/data/example_submodel_template.py
@@ -84,7 +84,7 @@ def create_example_submodel_template() -> model.Submodel:
 
     submodel_element_blob = model.Blob(
         id_short='ExampleBlob',
-        content_type='application/pdf',
+        content_type=model.ContentType('application/pdf'),
         value=None,
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example Blob object',
@@ -97,7 +97,7 @@ def create_example_submodel_template() -> model.Submodel:
 
     submodel_element_file = model.File(
         id_short='ExampleFile',
-        content_type='application/pdf',
+        content_type=model.ContentType('application/pdf'),
         value=None,
         category='PARAMETER',
         description=model.LangStringSet({'en-US': 'Example File object',
@@ -293,7 +293,7 @@ def create_example_submodel_template() -> model.Submodel:
         kind=model.ModelingKind.TEMPLATE)
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Template',
+        id_=model.Identifier('https://acplt.org/Test_Submodel_Template'),
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -306,8 +306,8 @@ def create_example_submodel_template() -> model.Submodel:
         description=model.LangStringSet({'en-US': 'An example submodel for the test application',
                                          'de': 'Ein Beispiel-Teilmodell für eine Test-Anwendung'}),
         parent=None,
-        administration=model.AdministrativeInformation(version='0.9',
-                                                       revision='0'),
+        administration=model.AdministrativeInformation(version=model.datatypes.VersionType('1'),
+                                                       revision=model.datatypes.RevisionType('1')),
         semantic_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),

--- a/basyx/aas/examples/tutorial_aasx.py
+++ b/basyx/aas/examples/tutorial_aasx.py
@@ -30,10 +30,10 @@ from basyx.aas.adapter import aasx
 # See `tutorial_create_simple_aas.py` for more details.
 
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel'
+    id_=model.Identifier('https://acplt.org/Simple_Submodel')
 )
 aas = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_=model.Identifier('https://acplt.org/Simple_AAS'),
     asset_information=model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
         global_asset_id=model.GlobalReference((model.Key(
@@ -47,7 +47,7 @@ aas = model.AssetAdministrationShell(
 
 # Another submodel, which is not related to the AAS:
 unrelated_submodel = model.Submodel(
-    id_='https://acplt.org/Unrelated_Submodel'
+    id_=model.Identifier('https://acplt.org/Unrelated_Submodel')
 )
 
 # We add these objects to an ObjectStore for easy retrieval by id.
@@ -82,8 +82,8 @@ with open(Path(__file__).parent / 'data' / 'TestFile.pdf', 'rb') as f:
 
 submodel.submodel_element.add(
     model.File(id_short="documentationFile",
-               content_type="application/pdf",
-               value=actual_file_name))
+               content_type=model.ContentType("application/pdf"),
+               value=model.Identifier(actual_file_name)))
 
 
 ######################################################################
@@ -106,7 +106,7 @@ with aasx.AASXWriter("MyAASXPackage.aasx") as writer:
     # ATTENTION: As of Version 3.0 RC01 of Details of the Asset Administration Shell, it is not longer valid to add more
     # than one "aas-spec" part (JSON/XML part with AAS objects) to an AASX package. Thus, `write_aas` MUST
     # only be called once per AASX package!
-    writer.write_aas(aas_ids=['https://acplt.org/Simple_AAS'],
+    writer.write_aas(aas_ids=[model.Identifier('https://acplt.org/Simple_AAS')],
                      object_store=object_store,
                      file_store=file_store)
 
@@ -156,6 +156,6 @@ with aasx.AASXReader("MyAASXPackage.aasx") as reader:
 
 
 # Some quick checks to make sure, reading worked as expected
-assert 'https://acplt.org/Simple_Submodel' in new_object_store
+assert model.Identifier('https://acplt.org/Simple_Submodel') in new_object_store
 assert actual_file_name in new_file_store
 assert new_meta_data.creator == "Chair of Process Control Engineering"

--- a/basyx/aas/examples/tutorial_create_simple_aas.py
+++ b/basyx/aas/examples/tutorial_create_simple_aas.py
@@ -35,7 +35,7 @@ asset_information = model.AssetInformation(
 )
 
 # step 1.2: create the Asset Administration Shell
-identifier = 'https://acplt.org/Simple_AAS'
+identifier = model.Identifier('https://acplt.org/Simple_AAS')
 aas = model.AssetAdministrationShell(
     id_=identifier,  # set identifier
     asset_information=asset_information
@@ -47,7 +47,7 @@ aas = model.AssetAdministrationShell(
 #############################################################
 
 # Step 2.1: create the Submodel object
-identifier = 'https://acplt.org/Simple_Submodel'
+identifier = model.Identifier('https://acplt.org/Simple_Submodel')
 submodel = model.Submodel(
     id_=identifier
 )
@@ -60,10 +60,10 @@ aas.submodel.add(model.ModelReference.from_referable(submodel))
 # ALTERNATIVE: step 1 and 2 can alternatively be done in one step
 # In this version, the Submodel reference is passed to the Asset Administration Shell's constructor.
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel'
+    id_=model.Identifier('https://acplt.org/Simple_Submodel')
 )
 aas = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_=model.Identifier('https://acplt.org/Simple_AAS'),
     asset_information=asset_information,
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -98,7 +98,7 @@ submodel.submodel_element.add(property_)
 # ALTERNATIVE: step 2 and 3 can also be combined in a single statement:
 # Again, we pass the Property to the Submodel's constructor instead of adding it afterwards.
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_=model.Identifier('https://acplt.org/Simple_Submodel'),
     submodel_element={
         model.Property(
             id_short='ExampleProperty',

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -32,7 +32,7 @@ import basyx.aas.adapter.xml
 # For more details, take a look at `tutorial_create_simple_aas.py`
 
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_=model.Identifier('https://acplt.org/Simple_Submodel'),
     submodel_element={
         model.Property(
             id_short='ExampleProperty',
@@ -46,7 +46,7 @@ submodel = model.Submodel(
         )}
 )
 aashell = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_=model.Identifier('https://acplt.org/Simple_AAS'),
     asset_information=model.AssetInformation(),
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -145,5 +145,5 @@ with open('data.xml', 'rb') as xml_file:
 
 # step 5.3: Retrieving the objects from the ObjectStore
 # For more information on the availiable techniques, see `tutorial_storage.py`.
-submodel_from_xml = xml_file_data.get_identifiable('https://acplt.org/Simple_Submodel')
+submodel_from_xml = xml_file_data.get_identifiable(model.Identifier('https://acplt.org/Simple_Submodel'))
 assert isinstance(submodel_from_xml, model.Submodel)

--- a/basyx/aas/examples/tutorial_storage.py
+++ b/basyx/aas/examples/tutorial_storage.py
@@ -51,11 +51,11 @@ prop = model.Property(
     )
 )
 submodel = Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_=model.Identifier('https://acplt.org/Simple_Submodel'),
     submodel_element={prop}
 )
 aas = AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_=model.Identifier('https://acplt.org/Simple_AAS'),
     asset_information=asset_information,
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -87,7 +87,7 @@ obj_store.add(aas)
 #################################################################
 
 tmp_submodel = obj_store.get_identifiable(
-    'https://acplt.org/Simple_Submodel')
+    model.Identifier('https://acplt.org/Simple_Submodel'))
 
 assert submodel is tmp_submodel
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 DataTypeDefXsd = Type[datatypes.AnyXSDType]
 ValueDataType = datatypes.AnyXSDType  # any xsd atomic type (from .datatypes)
 BlobType = bytes
-ContentType = str  # any mimetype as in RFC2046
 PathType = str
 QualifierType = str
 Identifier = str
@@ -161,6 +160,15 @@ class KeyTypes(Enum):
     @property
     def is_globally_identifiable(self) -> bool:
         return self.is_aas_identifiable or self.is_generic_globally_identifiable
+
+
+class ContentType(str):
+    def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("ContentType has a minimum of 1 character")
+        if len(value) > 100:
+            raise ValueError("ContentType has a maximum of 100 characters")
+        return super().__new__(cls, value)
 
 
 @unique

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -28,7 +28,6 @@ ValueDataType = datatypes.AnyXSDType  # any xsd atomic type (from .datatypes)
 BlobType = bytes
 PathType = str
 QualifierType = str
-Identifier = str
 ValueList = Set["ValueReferencePair"]
 
 
@@ -168,6 +167,15 @@ class ContentType(str):
             raise ValueError("ContentType has a minimum of 1 character")
         if len(value) > 100:
             raise ValueError("ContentType has a maximum of 100 characters")
+        return super().__new__(cls, value)
+
+
+class Identifier(str):
+    def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("Identifier has a minimum of 1 character")
+        if len(value) > 2000:
+            raise ValueError("Identifier has a maximum of 2000 characters")
         return super().__new__(cls, value)
 
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1099,8 +1099,8 @@ class AdministrativeInformation(HasDataSpecification):
     """
 
     def __init__(self,
-                 version: Optional[str] = None,
-                 revision: Optional[str] = None,
+                 version: Optional[datatypes.VersionType] = None,
+                 revision: Optional[datatypes.RevisionType] = None,
                  embedded_data_specifications: Iterable[EmbeddedDataSpecification] = ()):
         """
         Initializer of AdministrativeInformation
@@ -1110,16 +1110,16 @@ class AdministrativeInformation(HasDataSpecification):
         TODO: Add instruction what to do after construction
         """
         super().__init__()
-        self._version: Optional[str]
+        self._version: Optional[datatypes.VersionType]
         self.version = version
-        self._revision: Optional[str]
+        self._revision: Optional[datatypes.RevisionType]
         self.revision = revision
         self.embedded_data_specifications: List[EmbeddedDataSpecification] = list(embedded_data_specifications)
 
     def _get_version(self):
         return self._version
 
-    def _set_version(self, version: str):
+    def _set_version(self, version: datatypes.VersionType):
         if version == "":
             raise ValueError("version is not allowed to be an empty string")
         self._version = version
@@ -1129,7 +1129,7 @@ class AdministrativeInformation(HasDataSpecification):
     def _get_revision(self):
         return self._revision
 
-    def _set_revision(self, revision: str):
+    def _set_revision(self, revision: datatypes.RevisionType):
         if revision == "":
             raise ValueError("revision is not allowed to be an empty string")
         if self.version is None and revision:

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -378,7 +378,7 @@ class Key:
         """
         if not self.type.is_aas_identifiable:
             return None
-        return self.value
+        return Identifier(self.value)
 
     @staticmethod
     def from_referable(referable: "Referable") -> "Key":

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -26,9 +26,8 @@ if TYPE_CHECKING:
 DataTypeDefXsd = Type[datatypes.AnyXSDType]
 ValueDataType = datatypes.AnyXSDType  # any xsd atomic type (from .datatypes)
 BlobType = bytes
-PathType = str
-QualifierType = str
 ValueList = Set["ValueReferencePair"]
+QualifierType = datatypes.NameType
 
 
 @unique
@@ -177,6 +176,9 @@ class Identifier(str):
         if len(value) > 2000:
             raise ValueError("Identifier has a maximum of 2000 characters")
         return super().__new__(cls, value)
+
+
+PathType = Identifier
 
 
 @unique

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -382,6 +382,13 @@ class LabelType(str):
         return super().__new__(cls, value)
 
 
+class NameType(str):
+    def __new__(cls, value: str):
+        if len(value) > 128:
+            raise ValueError("NameType has a maximum of 128 characters")
+        return super().__new__(cls, value)
+
+
 AnyXSDType = Union[
     Duration, DayTimeDuration, YearMonthDuration, DateTime, Date, Time, GYearMonth, GYear, GMonthDay, GMonth, GDay,
     Boolean, Base64Binary, HexBinary, Float, Double, Decimal, Integer, Long, Int, Short, Byte, NonPositiveInteger,

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -377,6 +377,8 @@ class NormalizedString(str):
 
 class LabelType(str):
     def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("LabelType has a minimum of 1 character")
         if len(value) > 64:
             raise ValueError("LabelType has a maximum of 64 characters")
         return super().__new__(cls, value)
@@ -384,6 +386,8 @@ class LabelType(str):
 
 class NameType(str):
     def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("NameType has a minimum of 1 character")
         if len(value) > 128:
             raise ValueError("NameType has a maximum of 128 characters")
         return super().__new__(cls, value)
@@ -391,10 +395,10 @@ class NameType(str):
 
 class RevisionType(str):
     def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("RevisionType has a minimum of 1 character")
         if len(value) > 4:
             raise ValueError("RevisionType has a maximum of 4 characters")
-        if len(value) == 0:
-            raise ValueError("RevisionType has a minimum of 1 character")
         pattern = r'^([0-9]|[1-9][0-9]*)$'
         if not re.match(pattern, value):
             raise ValueError("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'")
@@ -403,6 +407,8 @@ class RevisionType(str):
 
 class ShortNameType(str):
     def __new__(cls, value: str):
+        if len(value) < 1:
+            raise ValueError("ShortNameType has a minimum of 1 character")
         if len(value) > 64:
             raise ValueError("ShortNameType has a maximum of 64 characters")
         return super().__new__(cls, value)
@@ -412,7 +418,7 @@ class VersionType(str):
     def __new__(cls, value: str):
         if len(value) > 4:
             raise ValueError("VersionType has a maximum of 4 characters")
-        if len(value) == 0:
+        if len(value) < 1:
             raise ValueError("VersionType has a minimum of 1 character")
         pattern = r'^([0-9]|[1-9][0-9]*)$'
         if not re.match(pattern, value):

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -401,6 +401,25 @@ class RevisionType(str):
         return super().__new__(cls, value)
 
 
+class ShortNameType(str):
+    def __new__(cls, value: str):
+        if len(value) > 64:
+            raise ValueError("ShortNameType has a maximum of 64 characters")
+        return super().__new__(cls, value)
+
+
+class VersionType(str):
+    def __new__(cls, value: str):
+        if len(value) > 4:
+            raise ValueError("VersionType has a maximum of 4 characters")
+        if len(value) == 0:
+            raise ValueError("VersionType has a minimum of 1 character")
+        pattern = r'^([0-9]|[1-9][0-9]*)$'
+        if not re.match(pattern, value):
+            raise ValueError("VersionType does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'")
+        return super().__new__(cls, value)
+
+
 AnyXSDType = Union[
     Duration, DayTimeDuration, YearMonthDuration, DateTime, Date, Time, GYearMonth, GYear, GMonthDay, GMonth, GDay,
     Boolean, Base64Binary, HexBinary, Float, Double, Decimal, Integer, Long, Int, Short, Byte, NonPositiveInteger,

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -389,6 +389,18 @@ class NameType(str):
         return super().__new__(cls, value)
 
 
+class RevisionType(str):
+    def __new__(cls, value: str):
+        if len(value) > 4:
+            raise ValueError("RevisionType has a maximum of 4 characters")
+        if len(value) == 0:
+            raise ValueError("RevisionType has a minimum of 1 character")
+        pattern = r'^([0-9]|[1-9][0-9]*)$'
+        if not re.match(pattern, value):
+            raise ValueError("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'")
+        return super().__new__(cls, value)
+
+
 AnyXSDType = Union[
     Duration, DayTimeDuration, YearMonthDuration, DateTime, Date, Time, GYearMonth, GYear, GMonthDay, GMonth, GDay,
     Boolean, Base64Binary, HexBinary, Float, Double, Decimal, Integer, Long, Int, Short, Byte, NonPositiveInteger,

--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -375,6 +375,13 @@ class NormalizedString(str):
         return cls(value.translate({0xD: None, 0xA: None, 0x9: None}))
 
 
+class LabelType(str):
+    def __new__(cls, value: str):
+        if len(value) > 64:
+            raise ValueError("LabelType has a maximum of 64 characters")
+        return super().__new__(cls, value)
+
+
 AnyXSDType = Union[
     Duration, DayTimeDuration, YearMonthDuration, DateTime, Date, Time, GYearMonth, GYear, GMonthDay, GMonth, GDay,
     Boolean, Base64Binary, HexBinary, Float, Double, Decimal, Integer, Long, Int, Short, Byte, NonPositiveInteger,

--- a/basyx/aas/util/identification.py
+++ b/basyx/aas/util/identification.py
@@ -55,7 +55,7 @@ class UUIDGenerator(AbstractIdentifierGenerator):
     def generate_id(self, proposal: Optional[str] = None) -> model.Identifier:
         uuid_ = uuid.uuid1(clock_seq=self._sequence)
         self._sequence += 1
-        return "urn:uuid:{}".format(uuid_)
+        return model.Identifier("urn:uuid:{}".format(uuid_))
 
 
 class NamespaceIRIGenerator(AbstractIdentifierGenerator):
@@ -102,10 +102,10 @@ class NamespaceIRIGenerator(AbstractIdentifierGenerator):
                 iri = "{}{}".format(self._namespace, proposal)
             # Try to find iri in provider. If it does not exist (KeyError), we found a unique one to return
             try:
-                self.provider.get_identifiable(iri)
+                self.provider.get_identifiable(model.Identifier(iri))
             except KeyError:
                 self._counter_cache[proposal] = counter
-                return iri
+                return model.Identifier(iri)
             counter += 1
 
 

--- a/test/adapter/aasx/test_aasx.py
+++ b/test/adapter/aasx/test_aasx.py
@@ -21,9 +21,9 @@ from basyx.aas.examples.data import example_aas, example_aas_mandatory_attribute
 class TestAASXUtils(unittest.TestCase):
     def test_name_friendlyfier(self) -> None:
         friendlyfier = aasx.NameFriendlyfier()
-        name1 = friendlyfier.get_friendly_name("http://example.com/AAS-a")
+        name1 = friendlyfier.get_friendly_name(model.Identifier("http://example.com/AAS-a"))
         self.assertEqual("http___example_com_AAS_a", name1)
-        name2 = friendlyfier.get_friendly_name("http://example.com/AAS+a")
+        name2 = friendlyfier.get_friendly_name(model.Identifier("http://example.com/AAS+a"))
         self.assertEqual("http___example_com_AAS_a_1", name2)
 
     def test_supplementary_file_container(self) -> None:
@@ -81,7 +81,7 @@ class AASXWriterTest(unittest.TestCase):
                 with warnings.catch_warnings(record=True) as w:
                     with aasx.AASXWriter(filename) as writer:
                         # TODO test writing multiple AAS
-                        writer.write_aas('https://acplt.org/Test_AssetAdministrationShell',
+                        writer.write_aas(model.Identifier('https://acplt.org/Test_AssetAdministrationShell'),
                                          data, files, write_json=write_json)
                         writer.write_core_properties(cp)
 

--- a/test/adapter/json/test_json_deserialization.py
+++ b/test/adapter/json/test_json_deserialization.py
@@ -160,7 +160,7 @@ class JsonDeserializationTest(unittest.TestCase):
             read_aas_json_file(string_io, failsafe=False)
 
     def test_duplicate_identifier_object_store(self) -> None:
-        sm_id = "http://acplt.org/test_submodel"
+        sm_id = model.Identifier("http://acplt.org/test_submodel")
 
         def get_clean_store() -> model.DictObjectStore:
             store: model.DictObjectStore = model.DictObjectStore()

--- a/test/adapter/json/test_json_serialization.py
+++ b/test/adapter/json/test_json_serialization.py
@@ -34,7 +34,7 @@ class JsonSerializationTest(unittest.TestCase):
         submodel_reference = model.ModelReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier)
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id=asset_reference),
-                                                  aas_identifier, submodel={submodel_reference})
+                                                  model.Identifier(aas_identifier), submodel={submodel_reference})
 
         # serialize object to json
         json_data = json.dumps({
@@ -61,7 +61,7 @@ class JsonSerializationSchemaTest(unittest.TestCase):
                                   semantic_id=model.GlobalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE,
                                                                      "http://acplt.org/TestSemanticId"),)))
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id=asset_reference),
-                                                  aas_identifier, submodel={submodel_reference})
+                                                  model.Identifier(aas_identifier), submodel={submodel_reference})
 
         # serialize object to json
         json_data = json.dumps({
@@ -177,11 +177,11 @@ class JsonSerializationStrippedObjectsTest(unittest.TestCase):
                 assert_fn(attr, data)
 
     def test_stripped_qualifiable(self) -> None:
-        qualifier = model.Qualifier("test_qualifier", str)
-        qualifier2 = model.Qualifier("test_qualifier2", str)
+        qualifier = model.Qualifier(model.datatypes.NameType("test_qualifier"), str)
+        qualifier2 = model.Qualifier(model.datatypes.NameType("test_qualifier2"), str)
         operation = model.Operation("test_operation", qualifier={qualifier})
         submodel = model.Submodel(
-            "http://acplt.org/test_submodel",
+            model.Identifier("http://acplt.org/test_submodel"),
             submodel_element=[operation],
             qualifier={qualifier2}
         )
@@ -226,7 +226,7 @@ class JsonSerializationStrippedObjectsTest(unittest.TestCase):
         )
         aas = model.AssetAdministrationShell(
             model.AssetInformation(global_asset_id=asset_ref),
-            "http://acplt.org/test_aas",
+            model.Identifier("http://acplt.org/test_aas"),
             submodel={submodel_ref}
         )
 

--- a/test/adapter/json/test_json_serialization_deserialization.py
+++ b/test/adapter/json/test_json_serialization_deserialization.py
@@ -28,7 +28,7 @@ class JsonSerializationDeserializationTest(unittest.TestCase):
         submodel_reference = model.ModelReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier)
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id=asset_reference),
-                                                  aas_identifier, submodel={submodel_reference})
+                                                  model.Identifier(aas_identifier), submodel={submodel_reference})
 
         # serialize object to json
         json_data = json.dumps({

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -278,7 +278,7 @@ class XmlDeserializationTest(unittest.TestCase):
 
         def get_clean_store() -> model.DictObjectStore:
             store: model.DictObjectStore = model.DictObjectStore()
-            submodel_ = model.Submodel(sm_id, id_short="test123")
+            submodel_ = model.Submodel(model.Identifier(sm_id), id_short="test123")
             store.add(submodel_)
             return store
 

--- a/test/adapter/xml/test_xml_serialization.py
+++ b/test/adapter/xml/test_xml_serialization.py
@@ -35,7 +35,7 @@ class XMLSerializationTest(unittest.TestCase):
         submodel_reference = model.ModelReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier)
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id=asset_reference),
-                                                  aas_identifier, submodel={submodel_reference})
+                                                  model.Identifier(aas_identifier), submodel={submodel_reference})
 
         test_data: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
         test_data.add(test_aas)
@@ -58,7 +58,7 @@ class XMLSerializationSchemaTest(unittest.TestCase):
                                   semantic_id=model.GlobalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE,
                                                                                "http://acplt.org/TestSemanticId"),)))
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id=asset_reference),
-                                                  aas_identifier, submodel={submodel_reference})
+                                                  model.Identifier(aas_identifier), submodel={submodel_reference})
         # serialize object to xml
         test_data: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
         test_data.add(test_aas)

--- a/test/backend/test_couchdb.py
+++ b/test/backend/test_couchdb.py
@@ -91,7 +91,7 @@ class CouchDBBackendTest(unittest.TestCase):
         self.assertIn(example_submodel, self.object_store)
 
         # Restore example submodel and check data
-        submodel_restored = self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+        submodel_restored = self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         assert (isinstance(submodel_restored, model.Submodel))
         checker = AASDataChecker(raise_immediately=True)
         check_example_submodel(checker, submodel_restored)
@@ -126,10 +126,10 @@ class CouchDBBackendTest(unittest.TestCase):
                          "CouchDB database'", str(cm.exception))
 
         # Querying a deleted object should raise a KeyError
-        retrieved_submodel = self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+        retrieved_submodel = self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         self.object_store.discard(example_submodel)
         with self.assertRaises(KeyError) as cm:
-            self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+            self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         self.assertEqual("'No Identifiable with id https://acplt.org/Test_Submodel found in CouchDB database'",
                          str(cm.exception))
 

--- a/test/backend/test_local_file.py
+++ b/test/backend/test_local_file.py
@@ -63,7 +63,7 @@ class LocalFileBackendTest(unittest.TestCase):
         self.assertIn(example_submodel, self.object_store)
 
         # Restore example submodel and check data
-        submodel_restored = self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+        submodel_restored = self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         assert (isinstance(submodel_restored, model.Submodel))
         checker = AASDataChecker(raise_immediately=True)
         check_example_submodel(checker, submodel_restored)
@@ -98,10 +98,10 @@ class LocalFileBackendTest(unittest.TestCase):
                          "local file database'", str(cm.exception))
 
         # Querying a deleted object should raise a KeyError
-        retrieved_submodel = self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+        retrieved_submodel = self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         self.object_store.discard(example_submodel)
         with self.assertRaises(KeyError) as cm:
-            self.object_store.get_identifiable('https://acplt.org/Test_Submodel')
+            self.object_store.get_identifiable(model.Identifier('https://acplt.org/Test_Submodel'))
         self.assertEqual("'No Identifiable with id https://acplt.org/Test_Submodel "
                          "found in local file database'",
                          str(cm.exception))

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -119,24 +119,30 @@ class TestStringTypes(unittest.TestCase):
 
     def test_label_type(self):
         label_type: model.datatypes.LabelType = model.datatypes.LabelType('a' * 64)
-        label_type: model.datatypes.LabelType = model.datatypes.LabelType("")
         with self.assertRaises(ValueError) as cm:
+            label_type: model.datatypes.LabelType = model.datatypes.LabelType("")
+        self.assertEqual("LabelType has a minimum of 1 character", str(cm.exception))
+        with self.assertRaises(ValueError) as cm2:
             label_type: model.datatypes.LabelType = model.datatypes.LabelType('a'*65)
-        self.assertEqual("LabelType has a maximum of 64 characters", str(cm.exception))
+        self.assertEqual("LabelType has a maximum of 64 characters", str(cm2.exception))
 
     def test_name_type(self):
         name_type: model.datatypes.NameType = model.datatypes.NameType('a' * 128)
-        name_type: model.datatypes.NameType = model.datatypes.NameType("")
         with self.assertRaises(ValueError) as cm:
+            name_type: model.datatypes.NameType = model.datatypes.NameType("")
+        self.assertEqual("NameType has a minimum of 1 character", str(cm.exception))
+        with self.assertRaises(ValueError) as cm2:
             name_type: model.datatypes.NameType = model.datatypes.NameType('a'*129)
-        self.assertEqual("NameType has a maximum of 128 characters", str(cm.exception))
+        self.assertEqual("NameType has a maximum of 128 characters", str(cm2.exception))
 
     def test_short_name_type(self):
         short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType('a' * 64)
-        short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType("")
         with self.assertRaises(ValueError) as cm:
+            short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType("")
+        self.assertEqual("ShortNameType has a minimum of 1 character", str(cm.exception))
+        with self.assertRaises(ValueError) as cm2:
             short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType('a'*65)
-        self.assertEqual("ShortNameType has a maximum of 64 characters", str(cm.exception))
+        self.assertEqual("ShortNameType has a maximum of 64 characters", str(cm2.exception))
 
 
 class TestDateTimeTypes(unittest.TestCase):

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -87,6 +87,21 @@ class TestStringTypes(unittest.TestCase):
         self.assertEqual("abc", model.datatypes.xsd_repr(model.datatypes.String("abc")))
         self.assertEqual("abc", model.datatypes.xsd_repr(model.datatypes.NormalizedString("abc")))
 
+    def test_revision_type(self):
+        with self.assertRaises(ValueError) as cm:
+            revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("")
+        self.assertEqual("RevisionType has a minimum of 1 character", str(cm.exception))
+        revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("1")
+        with self.assertRaises(ValueError) as cm2:
+            revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("12345")
+        self.assertEqual("RevisionType has a maximum of 4 characters", str(cm2.exception))
+        with self.assertRaises(ValueError) as cm3:
+            revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("04")
+        self.assertEqual("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm3.exception))
+        with self.assertRaises(ValueError) as cm4:
+            revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("ABC")
+        self.assertEqual("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm4.exception))
+
 
 class TestDateTimeTypes(unittest.TestCase):
     def test_parse_duration(self) -> None:

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -102,6 +102,21 @@ class TestStringTypes(unittest.TestCase):
             revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("ABC")
         self.assertEqual("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm4.exception))
 
+    def test_version_type(self):
+        with self.assertRaises(ValueError) as cm:
+            version_type: model.datatypes.VersionType = model.datatypes.VersionType("")
+        self.assertEqual("VersionType has a minimum of 1 character", str(cm.exception))
+        version_type: model.datatypes.VersionType = model.datatypes.VersionType("1")
+        with self.assertRaises(ValueError) as cm2:
+            version_type: model.datatypes.VersionType = model.datatypes.VersionType("12345")
+        self.assertEqual("VersionType has a maximum of 4 characters", str(cm2.exception))
+        with self.assertRaises(ValueError) as cm3:
+            version_type: model.datatypes.VersionType = model.datatypes.VersionType("04")
+        self.assertEqual("VersionType does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm3.exception))
+        with self.assertRaises(ValueError) as cm4:
+            version_type: model.datatypes.VersionType = model.datatypes.VersionType("ABC")
+        self.assertEqual("VersionType does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm4.exception))
+
     def test_label_type(self):
         label_type: model.datatypes.LabelType = model.datatypes.LabelType('a' * 64)
         label_type: model.datatypes.LabelType = model.datatypes.LabelType("")

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -103,11 +103,18 @@ class TestStringTypes(unittest.TestCase):
         self.assertEqual("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm4.exception))
 
     def test_label_type(self):
-        revision_type: model.datatypes.LabelType = model.datatypes.LabelType('a' * 64)
-        revision_type: model.datatypes.LabelType = model.datatypes.LabelType("")
+        label_type: model.datatypes.LabelType = model.datatypes.LabelType('a' * 64)
+        label_type: model.datatypes.LabelType = model.datatypes.LabelType("")
         with self.assertRaises(ValueError) as cm:
-            revision_type: model.datatypes.LabelType = model.datatypes.LabelType('a'*65)
+            label_type: model.datatypes.LabelType = model.datatypes.LabelType('a'*65)
         self.assertEqual("LabelType has a maximum of 64 characters", str(cm.exception))
+
+    def test_name_type(self):
+        name_type: model.datatypes.NameType = model.datatypes.NameType('a' * 128)
+        name_type: model.datatypes.NameType = model.datatypes.NameType("")
+        with self.assertRaises(ValueError) as cm:
+            name_type: model.datatypes.NameType = model.datatypes.NameType('a'*129)
+        self.assertEqual("NameType has a maximum of 128 characters", str(cm.exception))
 
 
 class TestDateTimeTypes(unittest.TestCase):

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -116,6 +116,13 @@ class TestStringTypes(unittest.TestCase):
             name_type: model.datatypes.NameType = model.datatypes.NameType('a'*129)
         self.assertEqual("NameType has a maximum of 128 characters", str(cm.exception))
 
+    def test_short_name_type(self):
+        short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType('a' * 64)
+        short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType("")
+        with self.assertRaises(ValueError) as cm:
+            short_name_type: model.datatypes.ShortNameType = model.datatypes.ShortNameType('a'*65)
+        self.assertEqual("ShortNameType has a maximum of 64 characters", str(cm.exception))
+
 
 class TestDateTimeTypes(unittest.TestCase):
     def test_parse_duration(self) -> None:

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -102,6 +102,13 @@ class TestStringTypes(unittest.TestCase):
             revision_type: model.datatypes.RevisionType = model.datatypes.RevisionType("ABC")
         self.assertEqual("Revision Type does not match with pattern '/^([0-9]|[1-9][0-9]*)$/'", str(cm4.exception))
 
+    def test_label_type(self):
+        revision_type: model.datatypes.LabelType = model.datatypes.LabelType('a' * 64)
+        revision_type: model.datatypes.LabelType = model.datatypes.LabelType("")
+        with self.assertRaises(ValueError) as cm:
+            revision_type: model.datatypes.LabelType = model.datatypes.LabelType('a'*65)
+        self.assertEqual("LabelType has a maximum of 64 characters", str(cm.exception))
+
 
 class TestDateTimeTypes(unittest.TestCase):
     def test_parse_duration(self) -> None:

--- a/test/model/test_provider.py
+++ b/test/model/test_provider.py
@@ -12,10 +12,10 @@ from basyx.aas import model
 
 class ProvidersTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.aas1 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas1")
-        self.aas2 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas2")
-        self.submodel1 = model.Submodel("urn:x-test:submodel1")
-        self.submodel2 = model.Submodel("urn:x-test:submodel2")
+        self.aas1 = model.AssetAdministrationShell(model.AssetInformation(), model.Identifier("urn:x-test:aas1"))
+        self.aas2 = model.AssetAdministrationShell(model.AssetInformation(), model.Identifier("urn:x-test:aas2"))
+        self.submodel1 = model.Submodel(model.Identifier("urn:x-test:submodel1"))
+        self.submodel2 = model.Submodel(model.Identifier("urn:x-test:submodel2"))
 
     def test_store_retrieve(self) -> None:
         object_store: model.DictObjectStore[model.AssetAdministrationShell] = model.DictObjectStore()
@@ -24,21 +24,21 @@ class ProvidersTest(unittest.TestCase):
         self.assertIn(self.aas1, object_store)
         property = model.Property('test', model.datatypes.String)
         self.assertFalse(property in object_store)
-        aas3 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas1")
+        aas3 = model.AssetAdministrationShell(model.AssetInformation(), model.Identifier("urn:x-test:aas1"))
         with self.assertRaises(KeyError) as cm:
             object_store.add(aas3)
         self.assertEqual("'Identifiable object with same id urn:x-test:aas1 is already "
                          "stored in this store'", str(cm.exception))
         self.assertEqual(2, len(object_store))
         self.assertIs(self.aas1,
-                      object_store.get_identifiable("urn:x-test:aas1"))
+                      object_store.get_identifiable(model.Identifier("urn:x-test:aas1")))
         self.assertIs(self.aas1,
-                      object_store.get("urn:x-test:aas1"))
+                      object_store.get(model.Identifier("urn:x-test:aas1")))
         object_store.discard(self.aas1)
         object_store.discard(self.aas1)
         with self.assertRaises(KeyError) as cm:
-            object_store.get_identifiable("urn:x-test:aas1")
-        self.assertIsNone(object_store.get("urn:x-test:aas1"))
+            object_store.get_identifiable(model.Identifier("urn:x-test:aas1"))
+        self.assertIsNone(object_store.get(model.Identifier("urn:x-test:aas1")))
         self.assertEqual("'urn:x-test:aas1'", str(cm.exception))
         self.assertIs(self.aas2, object_store.pop())
         self.assertEqual(0, len(object_store))
@@ -61,8 +61,8 @@ class ProvidersTest(unittest.TestCase):
         submodel_object_store.add(self.submodel2)
 
         multiplexer = model.ObjectProviderMultiplexer([aas_object_store, submodel_object_store])
-        self.assertIs(self.aas1, multiplexer.get_identifiable("urn:x-test:aas1"))
-        self.assertIs(self.submodel1, multiplexer.get_identifiable("urn:x-test:submodel1"))
+        self.assertIs(self.aas1, multiplexer.get_identifiable(model.Identifier("urn:x-test:aas1")))
+        self.assertIs(self.submodel1, multiplexer.get_identifiable(model.Identifier("urn:x-test:submodel1")))
         with self.assertRaises(KeyError) as cm:
-            multiplexer.get_identifiable("urn:x-test:submodel3")
+            multiplexer.get_identifiable(model.Identifier("urn:x-test:submodel3"))
         self.assertEqual("'Identifier could not be found in any of the 2 consulted registries.'", str(cm.exception))


### PR DESCRIPTION
Version 3.0 of the specification introduces multiple new elements to enforce string constraints.

We introduce those elements and implement them in `model.datatypes.py`
Added Elements:
* LabelType
* NameType
* RevisionType
* ShortNameType
* VersionType

We add unittests for all new elements
We also change the types of  `AdministrativeInformation/version` and `AdministrativeInformation/revision` to `VersionType` and `RevisionType`

https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=166