### PR TITLE
Reformulate Constraints for V3.0

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1476,6 +1476,8 @@ class Qualifier(HasSemantics):
 
     *Constraint AASd-006:*  If both, the value and the valueId of a Qualifier are present, the value needs
      to be identical to the value of the referenced coded value in Qualifier/valueId.
+    *Constraint AASd-020:*  The value of Qualifier/value shall be consistent with the
+    data type as defined in Qualifier/valueType.
 
     :ivar type: The type (:class:`~.QualifierType`) of the qualifier that is applied to the element.
     :ivar value_type: Data type (:class:`~.DataTypeDefXsd`) of the qualifier value

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -856,8 +856,8 @@ class ModelReference(Reference, Generic[_RT]):
 
     This is a special construct of the implementation to allow typed references and de-referencing.
 
-    *Constraint AASd-123:* For model references the type of the first key of Reference/keys shall be one of
-                           AasIdentifiables.
+    *Constraint AASd-123:*  For model references, i.e. References with Reference/type = ModelReference,
+    the value of Key/type of the first key of Reference/keys shall be one of AasIdentifiables.
     *Constraint AASd-125:* For model references with more than one key in Reference/keys the type of the keys following
                            the first key of Reference/keys shall be one of FragmentKeyElements.
     *Constraint AASd-126:* For model references with more than one key in Reference/keys the type of the last Key in

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1279,8 +1279,8 @@ class HasSemantics(metaclass=abc.ABCMeta):
 
     <<abstract>>
 
-    *Constraint AASd-118:* If there is a supplemental semantic ID (HasSemantics/supplementalSemanticId) defined,
-                           then there shall be also a main semantic ID (HasSemantics/semanticId).
+    *Constraint AASd-118:*  If a supplemental semantic ID (HasSemantics/supplementalSemanticId) is defined,
+    there shall also be a main semantic ID (HasSemantics/semanticId).
 
     :ivar semantic_id: Identifier of the semantic definition of the element. It is called semantic id of the element.
                        The semantic id may either reference an external global id or it may reference a referable model

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -507,13 +507,10 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     <<abstract>>
 
     *Constraint AASd-001:* In case of a referable element not being an identifiable element the
-    idShort is mandatory and used for referring to the element in its name space.
-
+        idShort is mandatory and used for referring to the element in its name space.
     *Constraint AASd-002:* idShort shall only feature letters, digits, underscore ("_"); starting
-    mandatory with a letter.
-
+        mandatory with a letter.
     *Constraint AASd-003:* idShort shall be matched case insensitive.
-
     *Constraint AASd-004:* Add parent in case of non identifiable elements.
 
     :ivar _id_short: Identifying string of the element within its name space
@@ -781,7 +778,7 @@ class Reference(metaclass=abc.ABCMeta):
     <<abstract>>
 
     *Constraint AASd-121:* For References the value of Key/type of the first key of Reference/keys shall be one of
-    GloballyIdentifiables.
+        GloballyIdentifiables.
 
     :ivar key: Ordered list of unique reference in its name space, each key referencing an element. The complete
                list of keys may for example be concatenated to a path that then gives unique access to an element
@@ -824,10 +821,11 @@ class GlobalReference(Reference):
     A reference is an ordered list of keys, each key referencing an element. The complete list of keys may for
     example be concatenated to a path that then gives unique access to an element or entity.
 
-    *Constraint AASd-122:*  For external references, i.e. References with Reference/type = ExternalReference,
-    the value of Key/type of the first key of Reference/keys shall be one of GenericGloballyIdentifiables.
-    *Constraint AASd-124:*  For external references, i.e. References with Reference/type = ExternalReference,
-    the last key of Reference/keys shall be either one of GenericGloballyIdentifiables or one of GenericFragmentKeys.
+    *Constraint AASd-122:* For external references, i.e. References with Reference/type = ExternalReference,
+        the value of Key/type of the first key of Reference/keys shall be one of GenericGloballyIdentifiables.
+    *Constraint AASd-124:* For external references, i.e. References with Reference/type = ExternalReference,
+        the last key of Reference/keys shall be either one of GenericGloballyIdentifiables
+        or one of GenericFragmentKeys.
 
     :ivar key: Ordered list of unique reference in its name space, each key referencing an element. The complete
                list of keys may for example be concatenated to a path that then gives unique access to an element
@@ -856,17 +854,18 @@ class ModelReference(Reference, Generic[_RT]):
 
     This is a special construct of the implementation to allow typed references and de-referencing.
 
-    *Constraint AASd-123:*  For model references, i.e. References with Reference/type = ModelReference,
-    the value of Key/type of the first key of Reference/keys shall be one of AasIdentifiables.
-    *Constraint AASd-125:*  For model references, i.e. References with Reference/type = ModelReference with more
-    than one key in Reference/keys, the value of Key/type of each of the keys following the first key of Reference/keys
-    shall be one of FragmentKeys.
-    *Constraint AASd-126:*  For model references, i.e. References with Reference/type = ModelReference with more than
-    one key in Reference/keys, the value of Key/type of the last Key in the reference key chain may be one of
-    GenericFragmentKeys, or no key at all shall have a value out of GenericFragmentKeys.
-    *Constraint AASd-127:*  For model references, i.e. References with Reference/type = ModelReference with more than
-    one key in Reference/keys, a key with Key/type FragmentReference shall be preceded by a key with Key/type
-    File or Blob. All other AAS fragments, i.e. Key/type values out of AasSubmodelElements, do not support fragments.
+    *Constraint AASd-123:* For model references, i.e. References with Reference/type = ModelReference,
+        the value of Key/type of the first key of Reference/keys shall be one of AasIdentifiables.
+    *Constraint AASd-125:* For model references, i.e. References with Reference/type = ModelReference with more than
+        one key in Reference/keys, the value of Key/type of each of the keys following the first key of Reference/keys
+        shall be one of FragmentKeys.
+    *Constraint AASd-126:* For model references, i.e. References with Reference/type = ModelReference with more than
+        one key in Reference/keys, the value of Key/type of the last Key in the reference key chain may be one of
+        GenericFragmentKeys, or no key at all shall have a value out of GenericFragmentKeys.
+    *Constraint AASd-127:* For model references, i.e. References with Reference/type = ModelReference with more than
+        one key in Reference/keys, a key with Key/type FragmentReference shall be preceded by a key with Key/type
+        File or Blob. All other AAS fragments, i.e. Key/type values out of AasSubmodelElements,
+        do not support fragments.
     *Constraint AASd-128:* For model references the Key/value of a Key preceded by a Key with
                            Key/type=SubmodelElementList is an integer number denoting the position in the array of the
                            submodel element list.
@@ -1038,10 +1037,10 @@ class DataSpecificationContent:
     the data specification template and meta information about the template itself.
 
     *Constraint AASc-3a-050:* If the `Data_specification_IEC_61360` is used
-    for an element, the value of `Has_data_specification.embedded_data_specifications`
-    shall contain the global reference to the IRI of the corresponding data specification
-    template
-    https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0
+        for an element, the value of `Has_data_specification.embedded_data_specifications`
+        shall contain the global reference to the IRI of the corresponding data specification
+        template
+        https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0
 
     """
     @abc.abstractmethod
@@ -1091,7 +1090,7 @@ class AdministrativeInformation(HasDataSpecification):
     Administrative meta-information for an element like version information.
 
     *Constraint AASd-005:* A revision requires a version. This means,
-    if there is no version there is no revision either.
+        if there is no version there is no revision either.
 
     :ivar version: Version of the element.
     :ivar revision: Revision of the element.
@@ -1280,8 +1279,8 @@ class HasSemantics(metaclass=abc.ABCMeta):
 
     <<abstract>>
 
-    *Constraint AASd-118:*  If a supplemental semantic ID (HasSemantics/supplementalSemanticId) is defined,
-    there shall also be a main semantic ID (HasSemantics/semanticId).
+    *Constraint AASd-118:* If a supplemental semantic ID (HasSemantics/supplementalSemanticId) is defined,
+        there shall also be a main semantic ID (HasSemantics/semanticId).
 
     :ivar semantic_id: Identifier of the semantic definition of the element. It is called semantic id of the element.
                        The semantic id may either reference an external global id or it may reference a referable model
@@ -1475,10 +1474,10 @@ class Qualifier(HasSemantics):
     """
     A qualifier is a type-value pair that makes additional statements w.r.t. the value of the element.
 
-    *Constraint AASd-006:*  If both, the value and the valueId of a Qualifier are present, the value needs
-     to be identical to the value of the referenced coded value in Qualifier/valueId.
-    *Constraint AASd-020:*  The value of Qualifier/value shall be consistent with the
-    data type as defined in Qualifier/valueType.
+    *Constraint AASd-006:* If both, the value and the valueId of a Qualifier are present, the value needs
+        to be identical to the value of the referenced coded value in Qualifier/valueId.
+    *Constraint AASd-020:* The value of Qualifier/value shall be consistent with the
+        data type as defined in Qualifier/valueType.
 
     :ivar type: The type (:class:`~.QualifierType`) of the qualifier that is applied to the element.
     :ivar value_type: Data type (:class:`~.DataTypeDefXsd`) of the qualifier value

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -858,8 +858,9 @@ class ModelReference(Reference, Generic[_RT]):
 
     *Constraint AASd-123:*  For model references, i.e. References with Reference/type = ModelReference,
     the value of Key/type of the first key of Reference/keys shall be one of AasIdentifiables.
-    *Constraint AASd-125:* For model references with more than one key in Reference/keys the type of the keys following
-                           the first key of Reference/keys shall be one of FragmentKeyElements.
+    *Constraint AASd-125:*  For model references, i.e. References with Reference/type = ModelReference with more
+    than one key in Reference/keys, the value of Key/type of each of the keys following the first key of Reference/keys
+    shall be one of FragmentKeys.
     *Constraint AASd-126:* For model references with more than one key in Reference/keys the type of the last Key in
                            the reference key chain may be one of GenericFragments or no key at all shall have a value
                            out of GenericFragmentKeys.

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -864,9 +864,9 @@ class ModelReference(Reference, Generic[_RT]):
     *Constraint AASd-126:*  For model references, i.e. References with Reference/type = ModelReference with more than
     one key in Reference/keys, the value of Key/type of the last Key in the reference key chain may be one of
     GenericFragmentKeys, or no key at all shall have a value out of GenericFragmentKeys.
-    *Constraint AASd-127:* For model references with more than one key in Reference/keys a key with type
-                           FragmentReference shall be preceded by a key with type File or Blob. All other AAS fragments,
-                           i.e. type values out of AasSubmodelElements, do not support fragments.
+    *Constraint AASd-127:*  For model references, i.e. References with Reference/type = ModelReference with more than
+    one key in Reference/keys, a key with Key/type FragmentReference shall be preceded by a key with Key/type
+    File or Blob. All other AAS fragments, i.e. Key/type values out of AasSubmodelElements, do not support fragments.
     *Constraint AASd-128:* For model references the Key/value of a Key preceded by a Key with
                            Key/type=SubmodelElementList is an integer number denoting the position in the array of the
                            submodel element list.

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -780,8 +780,8 @@ class Reference(metaclass=abc.ABCMeta):
 
     <<abstract>>
 
-    *Constraint AASd-121:* For References the type of the first key of Reference/keys shall be one of
-                           GloballyIdentifiables.
+    *Constraint AASd-121:* For References the value of Key/type of the first key of Reference/keys shall be one of
+    GloballyIdentifiables.
 
     :ivar key: Ordered list of unique reference in its name space, each key referencing an element. The complete
                list of keys may for example be concatenated to a path that then gives unique access to an element

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -861,9 +861,9 @@ class ModelReference(Reference, Generic[_RT]):
     *Constraint AASd-125:*  For model references, i.e. References with Reference/type = ModelReference with more
     than one key in Reference/keys, the value of Key/type of each of the keys following the first key of Reference/keys
     shall be one of FragmentKeys.
-    *Constraint AASd-126:* For model references with more than one key in Reference/keys the type of the last Key in
-                           the reference key chain may be one of GenericFragments or no key at all shall have a value
-                           out of GenericFragmentKeys.
+    *Constraint AASd-126:*  For model references, i.e. References with Reference/type = ModelReference with more than
+    one key in Reference/keys, the value of Key/type of the last Key in the reference key chain may be one of
+    GenericFragmentKeys, or no key at all shall have a value out of GenericFragmentKeys.
     *Constraint AASd-127:* For model references with more than one key in Reference/keys a key with type
                            FragmentReference shall be preceded by a key with type File or Blob. All other AAS fragments,
                            i.e. type values out of AasSubmodelElements, do not support fragments.

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1474,8 +1474,8 @@ class Qualifier(HasSemantics):
     """
     A qualifier is a type-value pair that makes additional statements w.r.t. the value of the element.
 
-    *Constraint AASd-006:* if both, the value and the valueId are present, then the value needs to be
-    identical to the value of the referenced coded value in Qualifier/valueId.
+    *Constraint AASd-006:*  If both, the value and the valueId of a Qualifier are present, the value needs
+     to be identical to the value of the referenced coded value in Qualifier/valueId.
 
     :ivar type: The type (:class:`~.QualifierType`) of the qualifier that is applied to the element.
     :ivar value_type: Data type (:class:`~.DataTypeDefXsd`) of the qualifier value

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -824,8 +824,8 @@ class GlobalReference(Reference):
     A reference is an ordered list of keys, each key referencing an element. The complete list of keys may for
     example be concatenated to a path that then gives unique access to an element or entity.
 
-    *Constraint AASd-122:* For global references the type of the first key of Reference/keys shall be one of
-                           GenericGloballyIdentifiables.
+    *Constraint AASd-122:*  For external references, i.e. References with Reference/type = ExternalReference,
+    the value of Key/type of the first key of Reference/keys shall be one of GenericGloballyIdentifiables.
     *Constraint AASd-124:* For global references the last key of Reference/keys shall be either one of
                            GenericGloballyIdentifiables or one of GenericFragmentKeys.
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -826,8 +826,8 @@ class GlobalReference(Reference):
 
     *Constraint AASd-122:*  For external references, i.e. References with Reference/type = ExternalReference,
     the value of Key/type of the first key of Reference/keys shall be one of GenericGloballyIdentifiables.
-    *Constraint AASd-124:* For global references the last key of Reference/keys shall be either one of
-                           GenericGloballyIdentifiables or one of GenericFragmentKeys.
+    *Constraint AASd-124:*  For external references, i.e. References with Reference/type = ExternalReference,
+    the last key of Reference/keys shall be either one of GenericGloballyIdentifiables or one of GenericFragmentKeys.
 
     :ivar key: Ordered list of unique reference in its name space, each key referencing an element. The complete
                list of keys may for example be concatenated to a path that then gives unique access to an element

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -672,8 +672,8 @@ class SubmodelElementList(SubmodelElement, base.UniqueIdShortNamespace, Generic[
     identical to SubmodelElementList/semanticIdListElement.
     *Constraint AASd-114:* If two first level child elements in a :class:`SubmodelElementList` have a semanticId then
     they shall be identical.
-    *Constraint AASd-115:* If a first level child element in a :class:`SubmodelElementList` does not specify
-    a semanticId then the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
+    *Constraint AASd-115:* If a first level child element in a :class:`SubmodelElementList` does not specify a
+    semanticId, the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
     *Constraint AASd-108:* All first level child elements in a :class:`SubmodelElementList` shall have the same
     submodel element type as specified in SubmodelElementList/typeValueListElement.
     *Constraint AASd-109:* If SubmodelElementList/typeValueListElement is equal to Property or Range,

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -305,8 +305,8 @@ class MultiLanguageProperty(DataElement):
     """
     A multi language property is a :class:`~.DataElement` that has a multi language value.
 
-    *Constraint AASd-012*: if both, the value and the valueId are present then for each string in a
-    specific language the meaning must be the same as specified in valueId.
+    *Constraint AASd-012*:  if both the MultiLanguageProperty/value and the MultiLanguageProperty/valueId are present,
+    the meaning must be the same for each string in a specific language, as specified inMultiLanguageProperty/valueId.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -232,8 +232,8 @@ class Property(DataElement):
     """
     A property is a :class:`DataElement` that has a single value.
 
-    *Constraint AASd-007:* if both, the value and the valueId are present then the value needs to be
-    identical to the value of the referenced coded value in valueId
+    *Constraint AASd-007:* If both, the value and the valueId of a Qualifier are present,
+    the value needs to be identical to the value of the referenced coded value in Qualifier/valueId.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -676,7 +676,7 @@ class SubmodelElementList(SubmodelElement, base.UniqueIdShortNamespace, Generic[
     a semanticId then the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
     *Constraint AASd-108:* All first level child elements in a :class:`SubmodelElementList` shall have the same
     submodel element type as specified in SubmodelElementList/typeValueListElement.
-    *Constraint AASd-109:* If SubmodelElementList/typeValueListElement equal to Property or Range
+    *Constraint AASd-109:* If SubmodelElementList/typeValueListElement is equal to Property or Range,
     SubmodelElementList/valueTypeListElement shall be set and all first level child elements in the
     :class:`SubmodelElementList` shall have the value type as specified in SubmodelElementList/valueTypeListElement.
 

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -233,7 +233,7 @@ class Property(DataElement):
     A property is a :class:`DataElement` that has a single value.
 
     *Constraint AASd-007:* If both, the value and the valueId of a Qualifier are present,
-    the value needs to be identical to the value of the referenced coded value in Qualifier/valueId.
+        the value needs to be identical to the value of the referenced coded value in Qualifier/valueId.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)
@@ -305,8 +305,9 @@ class MultiLanguageProperty(DataElement):
     """
     A multi language property is a :class:`~.DataElement` that has a multi language value.
 
-    *Constraint AASd-012*:  if both the MultiLanguageProperty/value and the MultiLanguageProperty/valueId are present,
-    the meaning must be the same for each string in a specific language, as specified inMultiLanguageProperty/valueId.
+    *Constraint AASd-012*: if both the MultiLanguageProperty/value and the MultiLanguageProperty/valueId are present,
+        the meaning must be the same for each string in a specific language,
+        as specified inMultiLanguageProperty/valueId.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)
@@ -364,7 +365,7 @@ class Range(DataElement):
     A range is a :class:`~.DataElement` that has a range value.
 
     *Constraint AASd-013:* In case of a range with `kind=Instance` either the min or the max value or both
-    need to be defined
+        need to be defined
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)
@@ -669,16 +670,16 @@ class SubmodelElementList(SubmodelElement, base.UniqueIdShortNamespace, Generic[
     The numbering starts with Zero (0).
 
     *Constraint AASd-107:* If a first level child element in a :class:`SubmodelElementList` has a semanticId it shall be
-    identical to SubmodelElementList/semanticIdListElement.
+        identical to SubmodelElementList/semanticIdListElement.
     *Constraint AASd-114:* If two first level child elements in a :class:`SubmodelElementList` have a semanticId then
-    they shall be identical.
+        they shall be identical.
     *Constraint AASd-115:* If a first level child element in a :class:`SubmodelElementList` does not specify a
-    semanticId, the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
+        semanticId, the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
     *Constraint AASd-108:* All first level child elements in a :class:`SubmodelElementList` shall have the same
-    submodel element type as specified in SubmodelElementList/typeValueListElement.
+        submodel element type as specified in SubmodelElementList/typeValueListElement.
     *Constraint AASd-109:* If SubmodelElementList/typeValueListElement is equal to Property or Range,
-    SubmodelElementList/valueTypeListElement shall be set and all first level child elements in the
-    :class:`SubmodelElementList` shall have the value type as specified in SubmodelElementList/valueTypeListElement.
+        SubmodelElementList/valueTypeListElement shall be set and all first level child elements in the
+        :class:`SubmodelElementList` shall have the value type as specified in SubmodelElementList/valueTypeListElement.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)
@@ -1055,7 +1056,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     An entity is a :class:`~.SubmodelElement` that is used to model entities
 
     *Constraint AASd-014:* global_asset_id or specific_asset_id must be set if :attr:`~.entity_type` is set to
-    :attr:`~.EntityType.SELF_MANAGED_ENTITY`. They must be empty otherwise.
+        :attr:`~.EntityType.SELF_MANAGED_ENTITY`. They must be empty otherwise.
 
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~aas.model.base.Referable`)

--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -45,18 +45,12 @@ AASd-008    The submodel element value of an    ✅
             operation variable shall be
 
             of kind=Template.
-AASd-012    If both, the                        ❌     Uncheckable
+AASd-012    if both the                         ❌     Uncheckable
             MultiLanguageProperty/value and
-
             the MultiLanguageProperty/valueId
-            are present then for
-
-            each string in a specific
-            language the meaning must be
-
-
-            the same as specified in
-
+            are present, the meaning must be
+            the same for each string in a
+            specific language, as specified in
             MultiLanguageProperty/valueId.
 AASd-014    Either the attribute globalAssetId  ✅
             or specificAssetId of an

--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -61,11 +61,9 @@ AASd-014    Either the attribute globalAssetId  ✅
 
             “SelfManagedEntity”.
             They are not existing otherwise.
-AASd-020    The value of Qualifier/value        tbd
-            shall be consistent to the
-
-            data type as defined in
-            Qualifier/valueType.
+AASd-020    The value of Qualifier/value shall  ✅
+            be consistent with the data type
+            as defined in Qualifier/valueType.
 AASd-021    Every Qualifiable can only have     WIP    postponed
             one qualifier with the same
 

--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -31,13 +31,10 @@ AASd-005    A revision requires a version.      ✅
             This means, if there is no
             version there is no
             revision either.
-AASd-006    if both, the value and the valueId  ❌     Uncheckable, cannot check the value
-            of a Qualifier are                         of what value_id points to
-
-            present then the value needs to
-            be identical to the value of
-
-            the referenced coded
+AASd-006    If both, the value and the valueId
+            of a Qualifier are present,
+            the value needs to be identical to
+            the value of the referenced coded
             value in Qualifier/valueId.
 AASd-007    If both, the value and the valueId  ❌     Uncheckable, cannot check the value
             of a Property are                          of what value_id points to

--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -37,13 +37,10 @@ AASd-006    If both, the value and the valueId
             the value of the referenced coded
             value in Qualifier/valueId.
 AASd-007    If both, the value and the valueId  ❌     Uncheckable, cannot check the value
-            of a Property are                          of what value_id points to
-
-            present then the value needs to
-            be identical to the value of
-
-            the referenced coded value in
-            Property/valueId.
+            of a Qualifier are present, the            of what value_id points to
+            value needs to be identical to the
+            value of the referenced coded value
+            in Qualifier/valueId.
 AASd-008    The submodel element value of an    ✅
             operation variable shall be
 

--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -31,8 +31,8 @@ AASd-005    A revision requires a version.      ✅
             This means, if there is no
             version there is no
             revision either.
-AASd-006    If both, the value and the valueId
-            of a Qualifier are present,
+AASd-006    If both, the value and the valueId  ❌     Uncheckable, cannot check the value
+            of a Qualifier are present,                of what value_id points to
             the value needs to be identical to
             the value of the referenced coded
             value in Qualifier/valueId.


### PR DESCRIPTION
Version 3.0 reformulates multiple Constraints.
Reformulations that are connected to updates on Version 3.0 are listed and NOT changed yet.
I recommend to reformulate the constraints as part of the update.

Reformulations:
* 6
* 7
* 12
* 20
* 109
* 115
* 118
* 121
* 122
* 123
* 124
* 125
* 126
* 127

t.b.d. with other updates:
* 2 (Referable/idShort)
* 5 (AdministrativeInformation/version)
* 77 (Extension/name)

Constrains that have not been implemented yet and therefore have not been reformulated:
* 119
* 120