### PR TITLE
adapter: Fix serialization of `SubmodelElementList`

### DIFF
--- a/basyx/aas/adapter/_generic.py
+++ b/basyx/aas/adapter/_generic.py
@@ -62,6 +62,7 @@ KEY_TYPES: Dict[model.KeyTypes, str] = {
     model.KeyTypes.RELATIONSHIP_ELEMENT: 'RelationshipElement',
     model.KeyTypes.SUBMODEL_ELEMENT: 'SubmodelElement',
     model.KeyTypes.SUBMODEL_ELEMENT_COLLECTION: 'SubmodelElementCollection',
+    model.KeyTypes.SUBMODEL_ELEMENT_LIST: 'SubmodelElementList',
     model.KeyTypes.GLOBAL_REFERENCE: 'GlobalReference',
     model.KeyTypes.FRAGMENT_REFERENCE: 'FragmentReference'}
 


### PR DESCRIPTION
Add SubmodelElementList to `KEY_TYPES` dict in _generic.py

`model.KeyTypes.SUBMODEL_ELEMENT_LIST` was missed in the KEY_TYPES dict, which is required for serialization