### PR TITLE
Add not failsafe mode to AASX Reader

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -111,7 +111,7 @@ class AASXReader:
 
     def read_into(self, object_store: model.AbstractObjectStore,
                   file_store: "AbstractSupplementaryFileContainer",
-                  override_existing: bool = False) -> Set[model.Identifier]:
+                  override_existing: bool = False, **kwargs) -> Set[model.Identifier]:
         """
         Read the contents of the AASX package and add them into a given
         :class:`ObjectStore <aas.model.provider.AbstractObjectStore>`
@@ -147,12 +147,12 @@ class AASXReader:
         # Iterate AAS files
         for aas_part in self.reader.get_related_parts_by_type(aasx_origin_part)[
                 RELATIONSHIP_TYPE_AAS_SPEC]:
-            self._read_aas_part_into(aas_part, object_store, file_store, read_identifiables, override_existing)
+            self._read_aas_part_into(aas_part, object_store, file_store, read_identifiables, override_existing, **kwargs)
 
             # Iterate split parts of AAS file
             for split_part in self.reader.get_related_parts_by_type(aas_part)[
                     RELATIONSHIP_TYPE_AAS_SPEC_SPLIT]:
-                self._read_aas_part_into(split_part, object_store, file_store, read_identifiables, override_existing)
+                self._read_aas_part_into(split_part, object_store, file_store, read_identifiables, override_existing, **kwargs)
 
         return read_identifiables
 
@@ -172,7 +172,7 @@ class AASXReader:
                             object_store: model.AbstractObjectStore,
                             file_store: "AbstractSupplementaryFileContainer",
                             read_identifiables: Set[model.Identifier],
-                            override_existing: bool) -> None:
+                            override_existing: bool, **kwargs) -> None:
         """
         Helper function for :meth:`read_into()` to read and process the contents of an AAS-spec part of the AASX file.
 
@@ -188,7 +188,7 @@ class AASXReader:
         :param override_existing: If True, existing objects in the object store are overridden with objects from the
             AASX that have the same Identifer. Default behavior is to skip those objects from the AASX.
         """
-        for obj in self._parse_aas_part(part_name):
+        for obj in self._parse_aas_part(part_name, **kwargs):
             if obj.identification in read_identifiables:
                 continue
             if obj.identification in object_store:
@@ -204,7 +204,7 @@ class AASXReader:
             if isinstance(obj, model.Submodel):
                 self._collect_supplementary_files(part_name, obj, file_store)
 
-    def _parse_aas_part(self, part_name: str) -> model.DictObjectStore:
+    def _parse_aas_part(self, part_name: str, **kwargs) -> model.DictObjectStore:
         """
         Helper function to parse the AAS objects from a single JSON or XML part of the AASX package.
 
@@ -218,12 +218,12 @@ class AASXReader:
         if content_type.split(";")[0] in ("text/xml", "application/xml") or content_type == "" and extension == "xml":
             logger.debug("Parsing AAS objects from XML stream in OPC part {} ...".format(part_name))
             with self.reader.open_part(part_name) as p:
-                return read_aas_xml_file(p)
+                return read_aas_xml_file(p, **kwargs)
         elif content_type.split(";")[0] in ("text/json", "application/json") \
                 or content_type == "" and extension == "json":
             logger.debug("Parsing AAS objects from JSON stream in OPC part {} ...".format(part_name))
             with self.reader.open_part(part_name) as p:
-                return read_aas_json_file(io.TextIOWrapper(p, encoding='utf-8-sig'))
+                return read_aas_json_file(io.TextIOWrapper(p, encoding='utf-8-sig'), **kwargs)
         else:
             logger.error("Could not determine part format of AASX part {} (Content Type: {}, extension: {}"
                          .format(part_name, content_type, extension))


### PR DESCRIPTION
Currently, we can pass a `failsafe` parameter in deserializing methods of JSON- and XML-adapters. The parameter determines whether a document should be parsed in a failsafe way. However, I cannot pass the parameter in the deserializing method of the AASX Reader because it does not have `**kwargs`. This commit adds `**kwargs` to deserializing methods of `AASXReader`, such that it is possible to pass the parameter and documents will be deserializend in a not failsafe mode.