### PR TITLE
test: fix accidentally disabled tests

### DIFF
--- a/test/backend/test_couchdb.py
+++ b/test/backend/test_couchdb.py
@@ -38,10 +38,10 @@ class CouchDBBackendOfflineMethodsTest(unittest.TestCase):
 
         with self.assertRaises(couchdb.CouchDBSourceError) as cm:
             couchdb.CouchDBBackend._parse_source("wrong_scheme:plt.rwth-aachen.couchdb:5984/path_to_db/path_to_doc")
-            self.assertEqual("Source has wrong format. "
-                             "Expected to start with {couchdb, couchdbs}, got "
-                             "{wrong_scheme:plt.rwth-aachen.couchdb:5984/path_to_db/path_to_doc}",
-                             cm.exception)
+        self.assertEqual("Source has wrong format. "
+                         "Expected to start with {couchdb://, couchdbs://}, got "
+                         "{wrong_scheme:plt.rwth-aachen.couchdb:5984/path_to_db/path_to_doc}",
+                         str(cm.exception))
 
 
 @unittest.skipUnless(COUCHDB_OKAY, "No CouchDB is reachable at {}/{}: {}".format(TEST_CONFIG['couchdb']['url'],

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -372,11 +372,11 @@ class ModelNamespaceTest(unittest.TestCase):
         namespace.remove_referable("Prop2")
         with self.assertRaises(KeyError) as cm2:
             namespace.get_referable("Prop2")
-            self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm2.exception))
+        self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm2.exception))
 
         with self.assertRaises(KeyError) as cm3:
             namespace.remove_referable("Prop2")
-            self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm3.exception))
+        self.assertEqual("'Referable with id_short Prop2 not found in this namespace'", str(cm3.exception))
 
     def test_renaming(self) -> None:
         self.namespace.set1.add(self.prop1)
@@ -570,8 +570,8 @@ class AASReferenceTest(unittest.TestCase):
 
         with self.assertRaises(KeyError) as cm_6:
             ref6.resolve(DummyObjectProvider())
-            self.assertEqual("'Could not resolve id_short prop_false at Identifier(IRI=urn:x-test:submodel)'",
-                             str(cm_6.exception))
+        self.assertEqual("'Could not resolve id_short prop_false at Identifier(IRI=urn:x-test:submodel) / collection'",
+                         str(cm_6.exception))
 
     def test_get_identifier(self) -> None:
         ref = model.AASReference((model.Key(model.KeyElements.SUBMODEL, False, "urn:x-test:x", model.KeyType.IRI),),


### PR DESCRIPTION
If an assertion is contained within the same context as a statement, that raises an error, the assertion is never executed, because the raised error leaves the context.