### PR TITLE
Partially revert "Remove attribute `kind` from `SubmodelElement`"

### DIFF
--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -563,7 +563,8 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_submodel(cls, dct: Dict[str, object], object_class=model.Submodel) -> model.Submodel:
-        ret = object_class(id_=_get_ts(dct, 'id', str))
+        ret = object_class(id_=_get_ts(dct, 'id', str),
+                           kind=cls._get_kind(dct))
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'submodelElements' in dct:
             for element in _get_ts(dct, "submodelElements", list):

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -997,7 +997,8 @@ class AASFromXmlDecoder:
     def construct_submodel(cls, element: etree.Element, object_class=model.Submodel, **_kwargs: Any) \
             -> model.Submodel:
         submodel = object_class(
-            _child_text_mandatory(element, NS_AAS + "id")
+            _child_text_mandatory(element, NS_AAS + "id"),
+            kind=_get_modeling_kind(element)
         )
         if not cls.stripped:
             submodel_elements = element.find(NS_AAS + "submodelElements")

--- a/basyx/aas/examples/data/_helper.py
+++ b/basyx/aas/examples/data/_helper.py
@@ -671,6 +671,7 @@ class AASDataChecker(DataChecker):
         """
         self._check_identifiable_equal(object_, expected_value)
         self._check_has_semantics_equal(object_, expected_value)
+        self._check_has_kind_equal(object_, expected_value)
         self._check_qualifiable_equal(object_, expected_value)
         self._check_has_data_specification_equal(object_, expected_value)
         self.check_contained_element_length(object_, 'submodel_element', model.SubmodelElement,
@@ -699,6 +700,7 @@ class AASDataChecker(DataChecker):
         self.check_attribute_equal(object_, 'value_type', expected_value.value_type)
         self.check_attribute_equal(object_, 'value', expected_value.value)
         self.check_attribute_equal(object_, 'value_id', expected_value.value_id)
+        self.check_attribute_equal(object_, 'kind', expected_value.kind)
 
     def check_specific_asset_id(self, object_: model.SpecificAssetId,
                                 expected_value: model.SpecificAssetId):

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -107,7 +107,8 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value=100,
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                   value=model.Identifier('http://acplt.org/ValueId/ExampleValueId')
-                                                  ),)),)
+                                                  ),)),
+        kind=model.QualifierKind.CONCEPT_QUALIFIER)
 
     qualifier2 = model.Qualifier(
         type_='http://acplt.org/Qualifier/ExampleQualifier2',
@@ -115,7 +116,8 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value=50,
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                   value=model.Identifier('http://acplt.org/ValueId/ExampleValueId')
-                                                  ),)),)
+                                                  ),)),
+        kind=model.QualifierKind.TEMPLATE_QUALIFIER)
 
     qualifier3 = model.Qualifier(
         type_='http://acplt.org/Qualifier/ExampleQualifier3',
@@ -123,7 +125,8 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value=model.datatypes.DateTime(2023, 4, 7, 16, 59, 54, 870123),
         value_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                   value=model.Identifier('http://acplt.org/ValueId/ExampleValueId')
-                                                  ),)),)
+                                                  ),)),
+        kind=model.QualifierKind.VALUE_QUALIFIER)
 
     extension = model.Extension(
         name='ExampleExtension',
@@ -203,6 +206,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
                                                     value='http://acplt.org/SubmodelTemplates/AssetIdentification'),),
                                          model.Submodel),
         qualifier=(),
+        kind=model.ModelingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=()
@@ -323,6 +327,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
                                                     value='http://acplt.org/SubmodelTemplates/BillOfMaterial'),),
                                          model.Submodel),
         qualifier=(),
+        kind=model.ModelingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=()
@@ -715,6 +720,7 @@ def create_example_submodel() -> model.Submodel:
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
         qualifier=(),
+        kind=model.ModelingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=(_embedded_data_specification_physical_unit,)

--- a/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -286,7 +286,8 @@ def create_example_submodel() -> model.Submodel:
         semantic_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
-        qualifier=())
+        qualifier=(),
+        kind=model.ModelingKind.INSTANCE)
     return submodel
 
 

--- a/basyx/aas/examples/data/example_submodel_template.py
+++ b/basyx/aas/examples/data/example_submodel_template.py
@@ -300,7 +300,8 @@ def create_example_submodel_template() -> model.Submodel:
         semantic_id=model.GlobalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
-        qualifier=())
+        qualifier=(),
+        kind=model.ModelingKind.TEMPLATE)
     return submodel
 
 


### PR DESCRIPTION
This partially reverts 77c33e773b3e22365627c1f59ed2d5e09fd12ea0. The attribute is only removed from `SubmodelElement`s in the spec, but the commit also removes deserialization of the `kind`-Attribute for `Submodels` and some `kind` attributes of `Qualifier`s and `Submodel`s in the examples.