### PR TITLE
model.datatypes: add `Decimal` parsing

### DIFF
--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -548,6 +548,16 @@ def from_xsd(value: str, type_: Type[AnyXSDType]) -> AnyXSDType:  # workaround. 
         return _parse_xsd_bool(value)
     elif issubclass(type_, (int, float, str)):
         return type_(value)
+    elif type_ is decimal.Decimal:
+        try:
+            return decimal.Decimal(value)
+        except decimal.InvalidOperation as e:
+            # We cannot use the original exception text here, because the text differs depending on
+            # whether the _decimal or _pydecimal module is used. Furthermore, the _decimal doesn't provide
+            # a real error message suited for end users, but provides a list of conditions that trigger the exception.
+            # See https://github.com/python/cpython/issues/76420
+            # Raising our own error message allows us to verify it in the tests.
+            raise ValueError(f"Cannot convert '{value}' to Decimal!") from e
     elif type_ is Duration:
         return _parse_xsd_duration(value)
     elif type_ is YearMonthDuration:

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -273,3 +273,14 @@ class TestFloatType(unittest.TestCase):
         self.assertEqual("NaN", model.datatypes.xsd_repr(float("nan")))
         self.assertEqual("INF", model.datatypes.xsd_repr(float("inf")))
         self.assertEqual("-INF", model.datatypes.xsd_repr(float("-inf")))
+
+
+class TestDecimalType(unittest.TestCase):
+    def test_parse_decimal(self) -> None:
+        self.assertEqual(model.datatypes.Decimal("0.1"), model.datatypes.from_xsd("0.1", model.datatypes.Decimal))
+        with self.assertRaises(ValueError) as cm:
+            model.datatypes.from_xsd("foo", model.datatypes.Decimal)
+        self.assertEqual("Cannot convert 'foo' to Decimal!", str(cm.exception))
+
+    def test_serialize_decimal(self) -> None:
+        self.assertEqual("0.1", model.datatypes.xsd_repr(model.datatypes.Decimal("0.1")))


### PR DESCRIPTION
This adds `Decimal` parsing to the `from_xsd()` function of `model.datatypes`.

During construction of a `Decimal`, an `InvalidOperation` exception may occur. Since the user only expects a `ValueError` from this function, because all other parsers only raise `ValueError`s, the `InvalidOperation` error-type is handled and re-raised as a `ValueError`.

Fix #99

Furthermore, some basic tests for decimal serialization and deserialization are added.

The static analysis of this PR currently fails because of #100.