### PR TITLE
model.base: Rename ModelingKind to ModellingKind

### DIFF
--- a/basyx/aas/adapter/_generic.py
+++ b/basyx/aas/adapter/_generic.py
@@ -16,9 +16,9 @@ from basyx.aas import model
 XML_NS_MAP = {"aas": "https://admin-shell.io/aas/3/0"}
 XML_NS_AAS = "{" + XML_NS_MAP["aas"] + "}"
 
-MODELING_KIND: Dict[model.ModelingKind, str] = {
-    model.ModelingKind.TEMPLATE: 'Template',
-    model.ModelingKind.INSTANCE: 'Instance'}
+MODELING_KIND: Dict[model.ModellingKind, str] = {
+    model.ModellingKind.TEMPLATE: 'Template',
+    model.ModellingKind.INSTANCE: 'Instance'}
 
 ASSET_KIND: Dict[model.AssetKind, str] = {
     model.AssetKind.TYPE: 'Type',
@@ -92,7 +92,7 @@ IEC61360_LEVEL_TYPES: Dict[model.base.IEC61360LevelType, str] = {
     model.base.IEC61360LevelType.MAX: 'max',
 }
 
-MODELING_KIND_INVERSE: Dict[str, model.ModelingKind] = {v: k for k, v in MODELING_KIND.items()}
+MODELING_KIND_INVERSE: Dict[str, model.ModellingKind] = {v: k for k, v in MODELING_KIND.items()}
 ASSET_KIND_INVERSE: Dict[str, model.AssetKind] = {v: k for k, v in ASSET_KIND.items()}
 QUALIFIER_KIND_INVERSE: Dict[str, model.QualifierKind] = {v: k for k, v in QUALIFIER_KIND.items()}
 DIRECTION_INVERSE: Dict[str, model.Direction] = {v: k for k, v in DIRECTION.items()}

--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -275,14 +275,14 @@ class AASFromJsonDecoder(json.JSONDecoder):
                     obj.extension.add(cls._construct_extension(extension))
 
     @classmethod
-    def _get_kind(cls, dct: Dict[str, object]) -> model.ModelingKind:
+    def _get_kind(cls, dct: Dict[str, object]) -> model.ModellingKind:
         """
         Utility method to get the kind of an HasKind object from its JSON representation.
 
         :param dct: The object's dict representation from JSON
         :return: The object's `kind` value
         """
-        return MODELING_KIND_INVERSE[_get_ts(dct, "kind", str)] if 'kind' in dct else model.ModelingKind.INSTANCE
+        return MODELING_KIND_INVERSE[_get_ts(dct, "kind", str)] if 'kind' in dct else model.ModellingKind.INSTANCE
 
     # #############################################################################
     # Helper Constructor Methods starting from here

--- a/basyx/aas/adapter/json/json_serialization.py
+++ b/basyx/aas/adapter/json/json_serialization.py
@@ -144,7 +144,7 @@ class AASToJsonEncoder(json.JSONEncoder):
             if obj.supplemental_semantic_id:
                 data['supplementalSemanticIds'] = list(obj.supplemental_semantic_id)
         if isinstance(obj, model.HasKind):
-            if obj.kind is model.ModelingKind.TEMPLATE:
+            if obj.kind is model.ModellingKind.TEMPLATE:
                 data['kind'] = _generic.MODELING_KIND[obj.kind]
         if isinstance(obj, model.Qualifiable) and not cls.stripped:
             if obj.qualifier:

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -388,15 +388,15 @@ def _child_text_mandatory_mapped(parent: etree.Element, child_tag: str, dct: Dic
     return _get_text_mandatory_mapped(_get_child_mandatory(parent, child_tag), dct)
 
 
-def _get_modeling_kind(element: etree.Element) -> model.ModelingKind:
+def _get_kind(element: etree.Element) -> model.ModellingKind:
     """
     Returns the modeling kind of an element with the default value INSTANCE, if none specified.
 
     :param element: The xml element.
     :return: The modeling kind of the element.
     """
-    modeling_kind = _get_text_mapped_or_none(element.find(NS_AAS + "kind"), MODELING_KIND_INVERSE)
-    return modeling_kind if modeling_kind is not None else model.ModelingKind.INSTANCE
+    modelling_kind = _get_text_mapped_or_none(element.find(NS_AAS + "kind"), MODELING_KIND_INVERSE)
+    return modelling_kind if modelling_kind is not None else model.ModellingKind.INSTANCE
 
 
 def _expect_reference_type(element: etree.Element, expected_type: Type[model.Reference]) -> None:
@@ -999,7 +999,7 @@ class AASFromXmlDecoder:
             -> model.Submodel:
         submodel = object_class(
             _child_text_mandatory(element, NS_AAS + "id"),
-            kind=_get_modeling_kind(element)
+            kind=_get_kind(element)
         )
         if not cls.stripped:
             submodel_elements = element.find(NS_AAS + "submodelElements")

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -102,7 +102,7 @@ def abstract_classes_to_xml(tag: str, obj: object) -> etree.Element:
             elm.append(administrative_information_to_xml(obj.administration))
         elm.append(_generate_element(name=NS_AAS + "id", text=obj.id))
     if isinstance(obj, model.HasKind):
-        if obj.kind is model.ModelingKind.TEMPLATE:
+        if obj.kind is model.ModellingKind.TEMPLATE:
             elm.append(_generate_element(name=NS_AAS + "kind", text="Template"))
         else:
             # then modeling-kind is Instance

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -198,7 +198,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
                                                     value='http://acplt.org/SubmodelTemplates/AssetIdentification'),),
                                          model.Submodel),
         qualifier=(),
-        kind=model.ModelingKind.INSTANCE,
+        kind=model.ModellingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=()
@@ -318,7 +318,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
                                                     value='http://acplt.org/SubmodelTemplates/BillOfMaterial'),),
                                          model.Submodel),
         qualifier=(),
-        kind=model.ModelingKind.INSTANCE,
+        kind=model.ModellingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=()
@@ -708,7 +708,7 @@ def create_example_submodel() -> model.Submodel:
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
         qualifier=(),
-        kind=model.ModelingKind.INSTANCE,
+        kind=model.ModellingKind.INSTANCE,
         extension=(),
         supplemental_semantic_id=(),
         embedded_data_specifications=(_embedded_data_specification_physical_unit,)

--- a/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -287,7 +287,7 @@ def create_example_submodel() -> model.Submodel:
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
         qualifier=(),
-        kind=model.ModelingKind.INSTANCE)
+        kind=model.ModellingKind.INSTANCE)
     return submodel
 
 

--- a/basyx/aas/examples/data/example_submodel_template.py
+++ b/basyx/aas/examples/data/example_submodel_template.py
@@ -296,7 +296,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                      value='http://acplt.org/SubmodelTemplates/'
                                                            'ExampleSubmodel'),)),
         qualifier=(),
-        kind=model.ModelingKind.TEMPLATE)
+        kind=model.ModellingKind.TEMPLATE)
     return submodel
 
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -189,19 +189,19 @@ class EntityType(Enum):
 
 
 @unique
-class ModelingKind(Enum):
+class ModellingKind(Enum):
     """
     Enumeration for denoting whether an element is a type or an instance.
     *Note:* An :attr:`~.ModelingKind.INSTANCE` becomes an individual entity of a template, for example a device model,
     by defining specific property values.
 
-    *Note:* In an object oriented view, an instance denotes an object of a template (class).
+    *Note:* In an object-oriented view, an instance denotes an object of a template (class).
 
     :cvar TEMPLATE: Software element which specifies the common attributes shared by all instances of the template
     :cvar INSTANCE: concrete, clearly identifiable component of a certain template.
         *Note:*  It becomes an individual entity of a template, for example a device model, by defining
         specific property values.
-        *Note:* In an object oriented view, an instance denotes an object of a template (class).
+        *Note:* In an object-oriented view, an instance denotes an object of a template (class).
     """
 
     TEMPLATE = 0
@@ -1410,7 +1410,7 @@ class HasKind(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self):
         super().__init__()
-        self._kind: ModelingKind = ModelingKind.INSTANCE
+        self._kind: ModellingKind = ModellingKind.INSTANCE
 
     @property
     def kind(self):

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -130,7 +130,7 @@ class Submodel(base.Identifiable, base.HasSemantics, base.HasKind, base.Qualifia
                  administration: Optional[base.AdministrativeInformation] = None,
                  semantic_id: Optional[base.Reference] = None,
                  qualifier: Iterable[base.Qualifier] = (),
-                 kind: base.ModelingKind = base.ModelingKind.INSTANCE,
+                 kind: base.ModellingKind = base.ModellingKind.INSTANCE,
                  extension: Iterable[base.Extension] = (),
                  supplemental_semantic_id: Iterable[base.Reference] = (),
                  embedded_data_specifications: Iterable[base.EmbeddedDataSpecification] = ()):
@@ -145,7 +145,7 @@ class Submodel(base.Identifiable, base.HasSemantics, base.HasKind, base.Qualifia
         self.administration: Optional[base.AdministrativeInformation] = administration
         self.semantic_id: Optional[base.Reference] = semantic_id
         self.qualifier = base.NamespaceSet(self, [("type", True)], qualifier)
-        self._kind: base.ModelingKind = kind
+        self._kind: base.ModellingKind = kind
         self.extension = base.NamespaceSet(self, [("name", True)], extension)
         self.supplemental_semantic_id: base.ConstrainedList[base.Reference] = \
             base.ConstrainedList(supplemental_semantic_id)

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -144,7 +144,7 @@ class XmlDeserializationTest(unittest.TestCase):
         submodel = object_store.pop()
         self.assertIsInstance(submodel, model.Submodel)
         assert isinstance(submodel, model.Submodel)  # to make mypy happy
-        self.assertEqual(submodel.kind, model.ModelingKind.INSTANCE)
+        self.assertEqual(submodel.kind, model.ModellingKind.INSTANCE)
 
     def test_reference_kind_mismatch(self) -> None:
         xml = _xml_wrap("""


### PR DESCRIPTION
In version 3.0 the Enum `ModelingKind` has been 
renamed to `ModellingKind`.
This commit renames the class definition and all 
its occurences in the code.

See also here [in the Spec](https://industrialdigitaltwin.org/wp-content/uploads/2023/06/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=154)