### PR TITLE
model.KeyTypes: Ignore mypy errors for abstract classes to be compliant to spec

### DIFF
--- a/basyx/aas/model/__init__.py
+++ b/basyx/aas/model/__init__.py
@@ -44,7 +44,7 @@ KEY_TYPES_CLASSES: Dict[Type[Referable], KeyTypes] = {
     Submodel: KeyTypes.SUBMODEL,
     Entity: KeyTypes.ENTITY,
     BasicEventElement: KeyTypes.BASIC_EVENT_ELEMENT,
-    EventElement: KeyTypes.EVENT_ELEMENT,
+    EventElement: KeyTypes.EVENT_ELEMENT,  # type: ignore
     Blob: KeyTypes.BLOB,
     File: KeyTypes.FILE,
     Operation: KeyTypes.OPERATION,
@@ -53,10 +53,10 @@ KEY_TYPES_CLASSES: Dict[Type[Referable], KeyTypes] = {
     MultiLanguageProperty: KeyTypes.MULTI_LANGUAGE_PROPERTY,
     Range: KeyTypes.RANGE,
     ReferenceElement: KeyTypes.REFERENCE_ELEMENT,
-    DataElement: KeyTypes.DATA_ELEMENT,
+    DataElement: KeyTypes.DATA_ELEMENT,  # type: ignore
     SubmodelElementCollection: KeyTypes.SUBMODEL_ELEMENT_COLLECTION,
     SubmodelElementList: KeyTypes.SUBMODEL_ELEMENT_LIST,
     AnnotatedRelationshipElement: KeyTypes.ANNOTATED_RELATIONSHIP_ELEMENT,
     RelationshipElement: KeyTypes.RELATIONSHIP_ELEMENT,
-    SubmodelElement: KeyTypes.SUBMODEL_ELEMENT,
+    SubmodelElement: KeyTypes.SUBMODEL_ELEMENT,  # type: ignore
 }


### PR DESCRIPTION
Mypy appears to not like abstract classes in a context where only concrete classes should be given:

```
Only concrete class can be given where
"tuple[type[Referable], KeyTypes]" is expected
```

However, the [spec](https://industrialdigitaltwin.org/wp-content/uploads/2023/06/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=84) demands the three abstract classes
- `EventElement`
- `DataElement`
- `SubmodelElement`

to appear inside the `model.KeyTypes` Enum.
Therefore, we ignore these errors via `# type: ignore`.

This fixes the mypy error in #104 