### PR TITLE
model.KeyTypes: Ignore mypy errors for abstract classes to be compliant

### DIFF
--- a/basyx/aas/model/__init__.py
+++ b/basyx/aas/model/__init__.py
@@ -53,7 +53,7 @@ KEY_ELEMENTS_CLASSES: Dict[Type[Referable], KeyElements] = {
     ConceptDictionary: KeyElements.CONCEPT_DICTIONARY,
     Entity: KeyElements.ENTITY,
     BasicEvent: KeyElements.BASIC_EVENT,
-    Event: KeyElements.EVENT,
+    Event: KeyElements.EVENT,  # type: ignore
     Blob: KeyElements.BLOB,
     File: KeyElements.FILE,
     Operation: KeyElements.OPERATION,
@@ -62,9 +62,9 @@ KEY_ELEMENTS_CLASSES: Dict[Type[Referable], KeyElements] = {
     MultiLanguageProperty: KeyElements.MULTI_LANGUAGE_PROPERTY,
     Range: KeyElements.RANGE,
     ReferenceElement: KeyElements.REFERENCE_ELEMENT,
-    DataElement: KeyElements.DATA_ELEMENT,
-    SubmodelElementCollection: KeyElements.SUBMODEL_ELEMENT_COLLECTION,
+    DataElement: KeyElements.DATA_ELEMENT,  # type: ignore
+    SubmodelElementCollection: KeyElements.SUBMODEL_ELEMENT_COLLECTION,  # type: ignore
     AnnotatedRelationshipElement: KeyElements.ANNOTATED_RELATIONSHIP_ELEMENT,
     RelationshipElement: KeyElements.RELATIONSHIP_ELEMENT,
-    SubmodelElement: KeyElements.SUBMODEL_ELEMENT,
+    SubmodelElement: KeyElements.SUBMODEL_ELEMENT,  # type: ignore
 }


### PR DESCRIPTION
Mypy appears to not like abstract classes in a context where only concrete classes should be given:

```
Only concrete class can be given where
"tuple[type[Referable], KeyTypes]" is expected
```

However, the spec demands the four abstract classes
- `Event`
- `DataElement`
- `SubmodelElement`
- `SubmodelElementCollection`

to appear inside the `model.KeyTypes` Enum.
Therefore, we ignore these errors via `# type: ignore`.

This is the same fix as #105, just for the `main`-branch this time. 