### PR TITLE
model.AdministrativeInformation: Update formulation of AASd-005 to v3.0

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1163,7 +1163,7 @@ class AdministrativeInformation(HasDataSpecification):
     """
     Administrative meta-information for an element like version information.
 
-    *Constraint AASd-005:* If AdministrativeInformation/version is not specified than also
+    *Constraint AASd-005:* If AdministrativeInformation/version is not specified then also
         AdministrativeInformation/revision shall be unspecified. This means, a revision
         requires a version. if there is no version there is no revision neither. Revision is
         optional.

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1163,8 +1163,10 @@ class AdministrativeInformation(HasDataSpecification):
     """
     Administrative meta-information for an element like version information.
 
-    *Constraint AASd-005:* A revision requires a version. This means,
-        if there is no version there is no revision either.
+    *Constraint AASd-005:* If AdministrativeInformation/version is not specified than also
+        AdministrativeInformation/revision shall be unspecified. This means, a revision
+        requires a version. if there is no version there is no revision neither. Revision is
+        optional.
 
     :ivar version: Version of the element.
     :ivar revision: Revision of the element.


### PR DESCRIPTION
Version 3.0 of the specification reformulates AASd-005:

> If AdministrativeInformation/version is not specified,
  AdministrativeInformation/revision shall also be unspecified. 
  This means that a revision requires a version. If there is no version,
  there is no revision. Revision is optional.