### PR TITLE
model.base: replace `continue` with `break` in `NamespaceSet.remove()`

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1879,7 +1879,7 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
             item_in_dict = backend[self._get_attribute(item, attr_name, case_sensitive)]
             if item_in_dict is item:
                 item_found = True
-                continue
+                break
         if not item_found:
             raise KeyError("Object not found in NamespaceDict")
         item.parent = None


### PR DESCRIPTION
If an item has been found, it doesn't make any sense to continue iterating the remaining items. Thus, this `continue` is replaced by a `break`, to break out of the loop once an item has been found.