### PR TITLE
model.base: fix `ModelReference.resolve()` error messages for elements contained in `SubmodelElementLists`

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1012,13 +1012,14 @@ class ModelReference(Reference, Generic[_RT]):
                     # the `is_submodel_element_list` branch, but mypy doesn't infer types based on isinstance checks
                     # stored in boolean variables.
                     item = item.value[int(key.value)]  # type: ignore
+                    resolved_keys[-1] += f"[{key.value}]"
                 else:
                     item = item.get_referable(key.value)
+                    resolved_keys.append(item.id_short)
             except (KeyError, IndexError) as e:
                 raise KeyError("Could not resolve {} {} at {}".format(
                     "index" if is_submodel_element_list else "id_short", key.value, " / ".join(resolved_keys)))\
                     from e
-            resolved_keys.append(item.id_short)
 
         # Check type
         if not isinstance(item, self.type):

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -832,7 +832,7 @@ class ModelReferenceTest(unittest.TestCase):
                                     model.Property)
         with self.assertRaises(TypeError) as cm_3:
             ref4.resolve(DummyObjectProvider())
-        self.assertEqual("Object retrieved at urn:x-test:submodel / list / collection / prop is not a Namespace",
+        self.assertEqual("Object retrieved at urn:x-test:submodel / list[0] / prop is not a Namespace",
                          str(cm_3.exception))
 
         with self.assertRaises(AttributeError) as cm_4:
@@ -863,7 +863,7 @@ class ModelReferenceTest(unittest.TestCase):
 
         with self.assertRaises(KeyError) as cm_8:
             ref8.resolve(DummyObjectProvider())
-        self.assertEqual("'Could not resolve id_short prop_false at urn:x-test:submodel / list / collection'",
+        self.assertEqual("'Could not resolve id_short prop_false at urn:x-test:submodel / list[0]'",
                          str(cm_8.exception))
 
         with self.assertRaises(ValueError) as cm_9:


### PR DESCRIPTION
Some error messages raised in `ModelReference.resolve()` make use of the `resolved_keys` local list variable, which keeps track of all Identifiers, id_shorts and `SubmodelElementList` indices that have been resolved successfully.
Instead of `SubmodelElementList` indices, the children's id_shorts were added to this list previously, which is inconsistent, and soon would cease to work anyway, since AASd-120 prohibits specifying id_shorts for children of `SubmodelElementList`.
This commit fixes this such that indices are added and adjusts the tests accordingly.