### PR TITLE
model.base: fix `Referable.__repr__()` for `SubmodelElementList`-children

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -610,12 +610,17 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     def __repr__(self) -> str:
         reversed_path = []
         item = self  # type: Any
+        from .submodel import SubmodelElementList
         while item is not None:
             if isinstance(item, Identifiable):
-                reversed_path.append(str(item.id))
+                reversed_path.append(item.id)
                 break
             elif isinstance(item, Referable):
-                reversed_path.append(item.id_short)
+                if isinstance(item.parent, SubmodelElementList):
+                    reversed_path.append(f"{item.parent.id_short}[{item.parent.value.index(item)}]")
+                    item = item.parent
+                else:
+                    reversed_path.append(item.id_short)
                 item = item.parent
             else:
                 raise AttributeError('Referable must have an identifiable as root object and only parents that are '

--- a/test/examples/test_helpers.py
+++ b/test/examples/test_helpers.py
@@ -94,13 +94,13 @@ class AASDataCheckerTest(unittest.TestCase):
         checker.check_submodel_element_list_equal(list_, list_expected)
         self.assertEqual(4, sum(1 for _ in checker.failed_checks))
         checker_iterator = checker.failed_checks
-        self.assertEqual("FAIL: Attribute id_short of Range[test_list / range1] must be == range2 (value='range1')",
+        self.assertEqual("FAIL: Attribute id_short of Range[test_list[0]] must be == range2 (value='range1')",
                          repr(next(checker_iterator)))
-        self.assertEqual("FAIL: Attribute max of Range[test_list / range1] must be == 1337 (value=142857)",
+        self.assertEqual("FAIL: Attribute max of Range[test_list[0]] must be == 1337 (value=142857)",
                          repr(next(checker_iterator)))
-        self.assertEqual("FAIL: Attribute id_short of Range[test_list / range2] must be == range1 (value='range2')",
+        self.assertEqual("FAIL: Attribute id_short of Range[test_list[1]] must be == range1 (value='range2')",
                          repr(next(checker_iterator)))
-        self.assertEqual("FAIL: Attribute max of Range[test_list / range2] must be == 142857 (value=1337)",
+        self.assertEqual("FAIL: Attribute max of Range[test_list[1]] must be == 142857 (value=1337)",
                          repr(next(checker_iterator)))
 
         # order_relevant

--- a/test/model/test_submodel.py
+++ b/test/model/test_submodel.py
@@ -127,7 +127,7 @@ class SubmodelElementListTest(unittest.TestCase):
             model.SubmodelElementList("test_list", model.MultiLanguageProperty, [mlp1, mlp2])
         self.assertEqual("Element to be added MultiLanguageProperty[mlp2] has semantic_id "
                          "ExternalReference(key=(Key(type=GLOBAL_REFERENCE, value=urn:x-test:different),)), "
-                         "while already contained element MultiLanguageProperty[test_list / mlp1] has semantic_id "
+                         "while already contained element MultiLanguageProperty[test_list[0]] has semantic_id "
                          "ExternalReference(key=(Key(type=GLOBAL_REFERENCE, value=urn:x-test:test),)), "
                          "which aren't equal. (Constraint AASd-114)", str(cm.exception))
         mlp2.semantic_id = semantic_id1


### PR DESCRIPTION
Since AASd-120 prohibits specifying id_shorts of direct children of
`SubmodelElementLists`, this commit adjusts `Referable.__repr__()` such
that the index of the element in the corresponding list is returned
instead.
Furthermore, the tests are adjusted accordingly.