### PR TITLE
Make model.Entity.specific_asset_id a Set of model.SpecificAssetIds

### DIFF
--- a/basyx/aas/adapter/json/aasJSONSchema.json
+++ b/basyx/aas/adapter/json/aasJSONSchema.json
@@ -444,8 +444,12 @@
               "maxLength": 2000,
               "pattern": "^([\\t\\n\\r -\ud7ff\ue000-\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
-            "specificAssetId": {
-              "$ref": "#/definitions/SpecificAssetId"
+            "specificAssetIds": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SpecificAssetId"
+              },
+              "minItems": 1
             }
           },
           "required": [

--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -417,13 +417,19 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_asset_information(cls, dct: Dict[str, object], object_class=model.AssetInformation)\
             -> model.AssetInformation:
-        ret = object_class(asset_kind=ASSET_KIND_INVERSE[_get_ts(dct, 'assetKind', str)])
-        cls._amend_abstract_attributes(ret, dct)
+        global_asset_id = None
         if 'globalAssetId' in dct:
-            ret.global_asset_id = _get_ts(dct, 'globalAssetId', str)
+            global_asset_id = _get_ts(dct, 'globalAssetId', str)
+        specific_asset_id = set()
         if 'specificAssetIds' in dct:
             for desc_data in _get_ts(dct, "specificAssetIds", list):
-                ret.specific_asset_id.add(cls._construct_specific_asset_id(desc_data, model.SpecificAssetId))
+                specific_asset_id.add(cls._construct_specific_asset_id(desc_data, model.SpecificAssetId))
+
+        ret = object_class(asset_kind=ASSET_KIND_INVERSE[_get_ts(dct, 'assetKind', str)],
+                           global_asset_id=global_asset_id,
+                           specific_asset_id=specific_asset_id)
+        cls._amend_abstract_attributes(ret, dct)
+
         if 'assetType' in dct:
             ret.asset_type = _get_ts(dct, 'assetType', str)
         if 'defaultThumbnail' in dct:
@@ -497,9 +503,10 @@ class AASFromJsonDecoder(json.JSONDecoder):
         global_asset_id = None
         if 'globalAssetId' in dct:
             global_asset_id = _get_ts(dct, 'globalAssetId', str)
-        specific_asset_id = None
+        specific_asset_id = set()
         if 'specificAssetIds' in dct:
-            specific_asset_id = cls._construct_specific_asset_id(_get_ts(dct, 'specificAssetIds', dict))
+            for desc_data in _get_ts(dct, "specificAssetIds", list):
+                specific_asset_id.add(cls._construct_specific_asset_id(desc_data, model.SpecificAssetId))
 
         ret = object_class(id_short=None,
                            entity_type=ENTITY_TYPES_INVERSE[_get_ts(dct, "entityType", str)],

--- a/basyx/aas/adapter/json/json_serialization.py
+++ b/basyx/aas/adapter/json/json_serialization.py
@@ -631,7 +631,7 @@ class AASToJsonEncoder(json.JSONEncoder):
         if obj.global_asset_id:
             data['globalAssetId'] = obj.global_asset_id
         if obj.specific_asset_id:
-            data['specificAssetIds'] = obj.specific_asset_id
+            data['specificAssetIds'] = list(obj.specific_asset_id)
         return data
 
     @classmethod

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -284,7 +284,13 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="specificAssetIds" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
   </xs:group>
   <xs:group name="environment">

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -801,7 +801,10 @@ def entity_to_xml(obj: model.Entity,
     if obj.global_asset_id:
         et_entity.append(_generate_element(NS_AAS + "globalAssetId", text=obj.global_asset_id))
     if obj.specific_asset_id:
-        et_entity.append(specific_asset_id_to_xml(obj.specific_asset_id, NS_AAS + "specificAssetId"))
+        et_specific_asset_id = _generate_element(name=NS_AAS + "specificAssetIds")
+        for specific_asset_id in obj.specific_asset_id:
+            et_specific_asset_id.append(specific_asset_id_to_xml(specific_asset_id, NS_AAS + "specificAssetId"))
+        et_entity.append(et_specific_asset_id)
     return et_entity
 
 

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -277,7 +277,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         entity_type=model.EntityType.CO_MANAGED_ENTITY,
         statement=(),
         global_asset_id=None,
-        specific_asset_id=None,
+        specific_asset_id=(),
         category="PARAMETER",
         description=model.MultiLanguageTextType({
             'en-US': 'Legally valid designation of the natural or judicial person which '

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -244,11 +244,12 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         entity_type=model.EntityType.SELF_MANAGED_ENTITY,
         statement={submodel_element_property, submodel_element_property2},
         global_asset_id='http://acplt.org/TestAsset/',
-        specific_asset_id=model.SpecificAssetId(name="TestKey",
-                                                value="TestValue",
-                                                external_subject_id=model.ExternalReference(
-                                                           (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                      value='http://acplt.org/SpecificAssetId/'),))),
+        specific_asset_id={
+            model.SpecificAssetId(name="TestKey", value="TestValue",
+                                  external_subject_id=model.ExternalReference(
+                                      (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
+                                                 value='http://acplt.org/SpecificAssetId/'),))
+                                  )},
         category="PARAMETER",
         description=model.MultiLanguageTextType({
             'en-US': 'Legally valid designation of the natural or judicial person which '

--- a/basyx/aas/examples/data/example_aas_mandatory_attributes.py
+++ b/basyx/aas/examples/data/example_aas_mandatory_attributes.py
@@ -201,7 +201,8 @@ def create_example_empty_asset_administration_shell() -> model.AssetAdministrati
     :return: example asset administration shell
     """
     asset_administration_shell = model.AssetAdministrationShell(
-        asset_information=model.AssetInformation(),
+        asset_information=model.AssetInformation(
+            global_asset_id='http://acplt.org/TestAsset2_Mandatory/'),
         id_='https://acplt.org/Test_AssetAdministrationShell2_Mandatory')
     return asset_administration_shell
 

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -47,7 +47,7 @@ submodel = model.Submodel(
 )
 aashell = model.AssetAdministrationShell(
     id_='https://acplt.org/Simple_AAS',
-    asset_information=model.AssetInformation(),
+    asset_information=model.AssetInformation(global_asset_id="test"),
     submodel={model.ModelReference.from_referable(submodel)}
 )
 

--- a/basyx/aas/model/aas.py
+++ b/basyx/aas/model/aas.py
@@ -54,15 +54,14 @@ class AssetInformation:
     def __init__(self,
                  asset_kind: base.AssetKind = base.AssetKind.INSTANCE,
                  global_asset_id: Optional[base.Identifier] = None,
-                 specific_asset_id: Optional[Iterable[base.SpecificAssetId]] = None,
+                 specific_asset_id: Iterable[base.SpecificAssetId] = (),
                  asset_type: Optional[base.Identifier] = None,
                  default_thumbnail: Optional[base.Resource] = None):
 
         super().__init__()
         self.asset_kind: base.AssetKind = asset_kind
-        self.specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = base.ConstrainedList(
-            [] if specific_asset_id is None else specific_asset_id,
-            item_del_hook=self._check_constraint_del_spec_asset_id)
+        self.specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = \
+            base.ConstrainedList(specific_asset_id, item_del_hook=self._check_constraint_del_spec_asset_id)
         self.global_asset_id: Optional[base.Identifier] = global_asset_id
         self.asset_type: Optional[base.Identifier] = asset_type
         self.default_thumbnail: Optional[base.Resource] = default_thumbnail

--- a/basyx/aas/model/aas.py
+++ b/basyx/aas/model/aas.py
@@ -69,17 +69,8 @@ class AssetInformation:
             item_del_hook=self._check_constraint_del_spec_asset_id
         )
         self._global_asset_id: Optional[base.Identifier] = global_asset_id
-        self._validate_asset_ids(global_asset_id, bool(specific_asset_id))
-
-    def _check_constraint_set_spec_asset_id(self, items_to_replace: List[base.SpecificAssetId],
-                                            new_items: List[base.SpecificAssetId],
-                                            old_list: List[base.SpecificAssetId]) -> None:
-        self._validate_asset_ids(self.global_asset_id,
-                                 len(old_list) - len(items_to_replace) + len(new_items) > 0)
-
-    def _check_constraint_del_spec_asset_id(self, _item_to_del: base.SpecificAssetId,
-                                            old_list: List[base.SpecificAssetId]) -> None:
-        self._validate_asset_ids(self.global_asset_id, len(old_list) > 1)
+        self._validate_global_asset_id(global_asset_id)
+        self._validate_aasd_131(global_asset_id, bool(specific_asset_id))
 
     @property
     def global_asset_id(self) -> Optional[base.Identifier]:
@@ -87,7 +78,8 @@ class AssetInformation:
 
     @global_asset_id.setter
     def global_asset_id(self, global_asset_id: Optional[base.Identifier]) -> None:
-        self._validate_asset_ids(global_asset_id, bool(self.specific_asset_id))
+        self._validate_global_asset_id(global_asset_id)
+        self._validate_aasd_131(global_asset_id, bool(self.specific_asset_id))
         self._global_asset_id = global_asset_id
 
     @property
@@ -99,8 +91,23 @@ class AssetInformation:
         # constraints are checked via _check_constraint_set_spec_asset_id() in this case
         self._specific_asset_id[:] = specific_asset_id
 
+    def _check_constraint_set_spec_asset_id(self, items_to_replace: List[base.SpecificAssetId],
+                                            new_items: List[base.SpecificAssetId],
+                                            old_list: List[base.SpecificAssetId]) -> None:
+        self._validate_aasd_131(self.global_asset_id,
+                                len(old_list) - len(items_to_replace) + len(new_items) > 0)
+
+    def _check_constraint_del_spec_asset_id(self, _item_to_del: base.SpecificAssetId,
+                                            old_list: List[base.SpecificAssetId]) -> None:
+        self._validate_aasd_131(self.global_asset_id, len(old_list) > 1)
+
     @staticmethod
-    def _validate_asset_ids(global_asset_id: Optional[base.Identifier], specific_asset_id_nonempty: bool) -> None:
+    def _validate_global_asset_id(global_asset_id: Optional[base.Identifier]) -> None:
+        if global_asset_id is not None:
+            _string_constraints.check_identifier(global_asset_id)
+
+    @staticmethod
+    def _validate_aasd_131(global_asset_id: Optional[base.Identifier], specific_asset_id_nonempty: bool) -> None:
         if global_asset_id is None and not specific_asset_id_nonempty:
             raise base.AASConstraintViolation(131,
                                               "An AssetInformation has to have a globalAssetId or a specificAssetId")

--- a/basyx/aas/model/aas.py
+++ b/basyx/aas/model/aas.py
@@ -79,7 +79,7 @@ class AssetInformation:
     @global_asset_id.setter
     def global_asset_id(self, global_asset_id: Optional[base.Identifier]):
         if global_asset_id is None:
-            if self.specific_asset_id is None or not self.specific_asset_id:
+            if not self.specific_asset_id:
                 raise base.AASConstraintViolation(
                     131, "An AssetInformation has to have a globalAssetId or a specificAssetId")
         else:

--- a/basyx/aas/model/aas.py
+++ b/basyx/aas/model/aas.py
@@ -73,10 +73,12 @@ class AssetInformation:
             raise base.AASConstraintViolation(
                 131, "An AssetInformation has to have a globalAssetId or a specificAssetId")
 
-    def _get_global_asset_id(self):
+    @property
+    def global_asset_id(self):
         return self._global_asset_id
 
-    def _set_global_asset_id(self, global_asset_id: Optional[base.Identifier]):
+    @global_asset_id.setter
+    def global_asset_id(self, global_asset_id: Optional[base.Identifier]):
         if global_asset_id is None:
             if self.specific_asset_id is None or not self.specific_asset_id:
                 raise base.AASConstraintViolation(
@@ -84,8 +86,6 @@ class AssetInformation:
         else:
             _string_constraints.check_identifier(global_asset_id)
         self._global_asset_id = global_asset_id
-
-    global_asset_id = property(_get_global_asset_id, _set_global_asset_id)
 
     def __repr__(self) -> str:
         return "AssetInformation(assetKind={}, globalAssetId={}, specificAssetId={}, assetType={}, " \

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -599,7 +599,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
                   Default is an empty string, making it use the source of its ancestor, if possible.
     """
     @abc.abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._id_short: Optional[NameType] = None
         self.display_name: Optional[MultiLanguageNameType] = dict()
@@ -1258,7 +1258,7 @@ class Identifiable(Referable, metaclass=abc.ABCMeta):
     :ivar ~.id: The globally unique id of the element.
     """
     @abc.abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.administration: Optional[AdministrativeInformation] = None
         # The id attribute is set by all inheriting classes __init__ functions.
@@ -1516,7 +1516,7 @@ class HasKind(metaclass=abc.ABCMeta):
     :ivar _kind: Kind of the element: either type or instance. Default = :attr:`~ModellingKind.INSTANCE`.
     """
     @abc.abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._kind: ModellingKind = ModellingKind.INSTANCE
 
@@ -1537,7 +1537,7 @@ class Qualifiable(Namespace, metaclass=abc.ABCMeta):
         qualifiable element.
     """
     @abc.abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.namespace_element_sets: List[NamespaceSet] = []
         self.qualifier: NamespaceSet[Qualifier]

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1311,6 +1311,10 @@ class ConstrainedList(MutableSequence[_T], Generic[_T]):
                 self._item_add_hook(v, self._list + v_list[:idx])
         self._list = self._list + v_list
 
+    def clear(self) -> None:
+        # clear() repeatedly deletes the last item by default, making it not atomic
+        del self[:]
+
     @overload
     def __getitem__(self, index: int) -> _T: ...
 

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -599,7 +599,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
                   Default is an empty string, making it use the source of its ancestor, if possible.
     """
     @abc.abstractmethod
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         self._id_short: Optional[NameType] = None
         self.display_name: Optional[MultiLanguageNameType] = dict()

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -1111,8 +1111,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
             [] if specific_asset_id is None else specific_asset_id,
             item_del_hook=self._check_constraint_del_spec_asset_id)
         self.global_asset_id: Optional[base.Identifier] = global_asset_id
-        self._entity_type: base.EntityType = entity_type
-        self._validate_asset_ids_for_entity_type(self.entity_type, self.global_asset_id, self.specific_asset_id)
+        self.entity_type: base.EntityType = entity_type
 
     def _check_constraint_del_spec_asset_id(self, _item_to_del: base.SpecificAssetId,
                                             _list: List[base.SpecificAssetId]) -> None:
@@ -1120,17 +1119,21 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
             raise base.AASConstraintViolation(
                 131, "An AssetInformation has to have a globalAssetId or a specificAssetId")
 
-    def _get_entity_type(self) -> base.EntityType:
+    @property
+    def entity_type(self) -> base.EntityType:
         return self._entity_type
 
-    def _set_entity_type(self, entity_type: base.EntityType) -> None:
+    @entity_type.setter
+    def entity_type(self, entity_type: base.EntityType) -> None:
         self._validate_asset_ids_for_entity_type(entity_type, self.global_asset_id, self.specific_asset_id)
         self._entity_type = entity_type
 
-    def _get_global_asset_id(self):
+    @property
+    def global_asset_id(self):
         return self._global_asset_id
 
-    def _set_global_asset_id(self, global_asset_id: Optional[base.Identifier]):
+    @global_asset_id.setter
+    def global_asset_id(self, global_asset_id: Optional[base.Identifier]):
         self._validate_asset_ids_for_entity_type(self.entity_type, global_asset_id, self.specific_asset_id)
         self._global_asset_id = global_asset_id
 
@@ -1146,9 +1149,6 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
                 14, "A co-managed entity has to have neither a globalAssetId nor a specificAssetId")
         if global_asset_id:
             _string_constraints.check_identifier(global_asset_id)
-
-    global_asset_id = property(_get_global_asset_id, _set_global_asset_id)
-    entity_type = property(_get_entity_type, _set_entity_type)
 
 
 class EventElement(SubmodelElement, metaclass=abc.ABCMeta):

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -1091,7 +1091,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
                  entity_type: base.EntityType,
                  statement: Iterable[SubmodelElement] = (),
                  global_asset_id: Optional[base.Identifier] = None,
-                 specific_asset_id: Optional[Iterable[base.SpecificAssetId]] = None,
+                 specific_asset_id: Iterable[base.SpecificAssetId] = (),
                  display_name: Optional[base.MultiLanguageNameType] = None,
                  category: Optional[base.NameType] = None,
                  description: Optional[base.MultiLanguageTextType] = None,
@@ -1107,9 +1107,8 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
         self.statement = base.NamespaceSet(self, [("id_short", True)], statement)
-        self.specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = base.ConstrainedList(
-            [] if specific_asset_id is None else specific_asset_id,
-            item_del_hook=self._check_constraint_del_spec_asset_id)
+        self.specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = \
+            base.ConstrainedList(specific_asset_id, item_del_hook=self._check_constraint_del_spec_asset_id)
         self.global_asset_id: Optional[base.Identifier] = global_asset_id
         self.entity_type: base.EntityType = entity_type
 

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -1126,7 +1126,7 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     @entity_type.setter
     def entity_type(self, entity_type: base.EntityType) -> None:
         self._validate_asset_ids_for_entity_type(entity_type, self.global_asset_id, self.specific_asset_id)
-        self._entity_type = entity_type
+        self._entity_type: base.EntityType = entity_type
 
     @property
     def global_asset_id(self):

--- a/basyx/aas/model/submodel.py
+++ b/basyx/aas/model/submodel.py
@@ -1048,7 +1048,6 @@ class Capability(SubmodelElement):
                          supplemental_semantic_id, embedded_data_specifications)
 
 
-@_string_constraints.constrain_identifier("global_asset_id")
 class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     """
     An entity is a :class:`~.SubmodelElement` that is used to model entities
@@ -1107,16 +1106,33 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
         self.statement = base.NamespaceSet(self, [("id_short", True)], statement)
-        self.specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = \
-            base.ConstrainedList(specific_asset_id, item_del_hook=self._check_constraint_del_spec_asset_id)
-        self.global_asset_id: Optional[base.Identifier] = global_asset_id
-        self.entity_type: base.EntityType = entity_type
+        self._specific_asset_id: base.ConstrainedList[base.SpecificAssetId] = \
+            base.ConstrainedList(specific_asset_id, item_set_hook=self._check_constraint_set_spec_asset_id,
+                                 item_del_hook=self._check_constraint_del_spec_asset_id)
+        # assign private attributes, bypassing setters, as constraints will be checked below
+        self._entity_type: base.EntityType = entity_type
+        # add item_add_hook after items have been added, because checking the constraints requires the global_asset_id
+        # to be set
+        self._specific_asset_id._item_add_hook = self._check_constraint_add_spec_asset_id
+        # use setter for global_asset_id, as it also checks the string constraint,
+        # which hasn't been checked at this point
+        # furthermore, the setter also validates AASd-014
+        self._global_asset_id: Optional[base.Identifier]
+        self.global_asset_id = global_asset_id
+
+    def _check_constraint_add_spec_asset_id(self, _new: base.SpecificAssetId, _list: List[base.SpecificAssetId]) \
+            -> None:
+        self._validate_asset_ids_for_entity_type(self.entity_type, self.global_asset_id, True)
+
+    def _check_constraint_set_spec_asset_id(self, old: List[base.SpecificAssetId], new: List[base.SpecificAssetId],
+                                            list_: List[base.SpecificAssetId]) -> None:
+        self._validate_asset_ids_for_entity_type(self.entity_type, self.global_asset_id,
+                                                 # whether the list is nonempty after the set operation
+                                                 len(old) < len(list_) or len(new) > 0)
 
     def _check_constraint_del_spec_asset_id(self, _item_to_del: base.SpecificAssetId,
-                                            _list: List[base.SpecificAssetId]) -> None:
-        if self.global_asset_id is None and len(_list) == 1:
-            raise base.AASConstraintViolation(
-                131, "An AssetInformation has to have a globalAssetId or a specificAssetId")
+                                            list_: List[base.SpecificAssetId]) -> None:
+        self._validate_asset_ids_for_entity_type(self.entity_type, self.global_asset_id, len(list_) > 1)
 
     @property
     def entity_type(self) -> base.EntityType:
@@ -1124,30 +1140,41 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
 
     @entity_type.setter
     def entity_type(self, entity_type: base.EntityType) -> None:
-        self._validate_asset_ids_for_entity_type(entity_type, self.global_asset_id, self.specific_asset_id)
-        self._entity_type: base.EntityType = entity_type
+        self._validate_asset_ids_for_entity_type(entity_type, self.global_asset_id, bool(self.specific_asset_id))
+        self._entity_type = entity_type
 
     @property
-    def global_asset_id(self):
+    def global_asset_id(self) -> Optional[base.Identifier]:
         return self._global_asset_id
 
     @global_asset_id.setter
-    def global_asset_id(self, global_asset_id: Optional[base.Identifier]):
-        self._validate_asset_ids_for_entity_type(self.entity_type, global_asset_id, self.specific_asset_id)
+    def global_asset_id(self, global_asset_id: Optional[base.Identifier]) -> None:
+        self._validate_asset_ids_for_entity_type(self.entity_type, global_asset_id, bool(self.specific_asset_id))
+        if global_asset_id is not None:
+            _string_constraints.check_identifier(global_asset_id)
         self._global_asset_id = global_asset_id
+
+    @property
+    def specific_asset_id(self) -> base.ConstrainedList[base.SpecificAssetId]:
+        return self._specific_asset_id
+
+    @specific_asset_id.setter
+    def specific_asset_id(self, specific_asset_id: Iterable[base.SpecificAssetId]) -> None:
+        # constraints are checked via _check_constraint_set_spec_asset_id() in this case
+        self._specific_asset_id[:] = specific_asset_id
 
     @staticmethod
     def _validate_asset_ids_for_entity_type(entity_type: base.EntityType,
                                             global_asset_id: Optional[base.Identifier],
-                                            specific_asset_id: Optional[base.ConstrainedList[base.SpecificAssetId]]):
-        if entity_type == base.EntityType.SELF_MANAGED_ENTITY and global_asset_id is None and not specific_asset_id:
+                                            specific_asset_id_nonempty: bool) -> None:
+        if entity_type == base.EntityType.SELF_MANAGED_ENTITY and global_asset_id is None \
+                and not specific_asset_id_nonempty:
             raise base.AASConstraintViolation(
                 14, "A self-managed entity has to have a globalAssetId or a specificAssetId")
-        elif entity_type == base.EntityType.CO_MANAGED_ENTITY and (global_asset_id or specific_asset_id):
+        elif entity_type == base.EntityType.CO_MANAGED_ENTITY and (global_asset_id is not None
+                                                                   or specific_asset_id_nonempty):
             raise base.AASConstraintViolation(
                 14, "A co-managed entity has to have neither a globalAssetId nor a specificAssetId")
-        if global_asset_id:
-            _string_constraints.check_identifier(global_asset_id)
 
 
 class EventElement(SubmodelElement, metaclass=abc.ABCMeta):

--- a/test/adapter/json/test_json_deserialization.py
+++ b/test/adapter/json/test_json_deserialization.py
@@ -31,7 +31,8 @@ class JsonDeserializationTest(unittest.TestCase):
                         "modelType": "AssetAdministrationShell",
                         "id": "https://acplt.org/Test_Asset",
                         "assetInformation": {
-                            "assetKind": "Instance"
+                            "assetKind": "Instance",
+                            "globalAssetId": "https://acplt.org/Test_AssetId"
                         }
                     }
                 ]
@@ -142,7 +143,8 @@ class JsonDeserializationTest(unittest.TestCase):
                     "modelType": "AssetAdministrationShell",
                     "id": "http://acplt.org/test_aas",
                     "assetInformation": {
-                        "assetKind": "Instance"
+                        "assetKind": "Instance",
+                        "globalAssetId": "https://acplt.org/Test_AssetId"
                     }
                 }],
                 "submodels": [{

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -81,6 +81,7 @@ class XmlDeserializationTest(unittest.TestCase):
             <aas:assetAdministrationShell>
                 <aas:id>http://acplt.org/test_aas</aas:id>
                 <aas:assetInformation>
+                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -94,6 +95,7 @@ class XmlDeserializationTest(unittest.TestCase):
                 <aas:id>http://acplt.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind></aas:assetKind>
+                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -107,6 +109,7 @@ class XmlDeserializationTest(unittest.TestCase):
                 <aas:id>http://acplt.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>invalidKind</aas:assetKind>
+                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -153,6 +156,7 @@ class XmlDeserializationTest(unittest.TestCase):
                 <aas:id>http://acplt.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>Instance</aas:assetKind>
+                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
                 <aas:derivedFrom>
                     <aas:type>ModelReference</aas:type>
@@ -260,6 +264,7 @@ class XmlDeserializationTest(unittest.TestCase):
                 <aas:id>http://acplt.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>Instance</aas:assetKind>
+                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -375,6 +380,7 @@ class XmlDeserializationStrippedObjectsTest(unittest.TestCase):
             <aas:id>http://acplt.org/test_aas</aas:id>
             <aas:assetInformation>
                 <aas:assetKind>Instance</aas:assetKind>
+                <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
             </aas:assetInformation>
             <aas:submodels>
                 <aas:reference>

--- a/test/compliance_tool/files/test_demo_full_example.json
+++ b/test/compliance_tool/files/test_demo_full_example.json
@@ -254,7 +254,8 @@
             "modelType": "AssetAdministrationShell",
             "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
-                "assetKind": "Instance"
+                "assetKind": "Instance",
+                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -720,19 +721,21 @@
                     ],
                     "entityType": "SelfManagedEntity",
                     "globalAssetId": "http://acplt.org/TestAsset/",
-                    "specificAssetId": {
-                        "name": "TestKey",
-                        "value": "TestValue",
-                        "externalSubjectId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                                {
-                                    "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
-                                }
-                            ]
+                    "specificAssetIds": [
+                        {
+                            "name": "TestKey",
+                            "value": "TestValue",
+                            "externalSubjectId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "http://acplt.org/SpecificAssetId/"
+                                    }
+                                ]
+                            }
                         }
-                    }
+                    ]
                 },
                 {
                     "idShort": "ExampleEntity2",

--- a/test/compliance_tool/files/test_demo_full_example.xml
+++ b/test/compliance_tool/files/test_demo_full_example.xml
@@ -245,6 +245,7 @@
       <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
+        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -601,19 +602,21 @@
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
           <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
-          <aas:specificAssetId>
-            <aas:name>TestKey</aas:name>
-            <aas:value>TestValue</aas:value>
-            <aas:externalSubjectId>
-              <aas:type>ExternalReference</aas:type>
-              <aas:keys>
-                <aas:key>
-                  <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
-                </aas:key>
-              </aas:keys>
-            </aas:externalSubjectId>
-          </aas:specificAssetId>
+          <aas:specificAssetIds>
+            <aas:specificAssetId>
+              <aas:name>TestKey</aas:name>
+              <aas:value>TestValue</aas:value>
+              <aas:externalSubjectId>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:externalSubjectId>
+            </aas:specificAssetId>
+          </aas:specificAssetIds>
         </aas:entity>
         <aas:entity>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example_json_aasx/aasx/data.json
+++ b/test/compliance_tool/files/test_demo_full_example_json_aasx/aasx/data.json
@@ -262,7 +262,8 @@
             "modelType": "AssetAdministrationShell",
             "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
-                "assetKind": "Instance"
+                "assetKind": "Instance",
+                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -728,19 +729,21 @@
                     ],
                     "entityType": "SelfManagedEntity",
                     "globalAssetId": "http://acplt.org/TestAsset/",
-                    "specificAssetId": {
-                        "name": "TestKey",
-                        "value": "TestValue",
-                        "externalSubjectId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                                {
-                                    "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
-                                }
-                            ]
+                    "specificAssetIds": [
+                        {
+                            "name": "TestKey",
+                            "value": "TestValue",
+                            "externalSubjectId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "http://acplt.org/SpecificAssetId/"
+                                    }
+                                ]
+                            }
                         }
-                    }
+                    ]
                 },
                 {
                     "idShort": "ExampleEntity2",

--- a/test/compliance_tool/files/test_demo_full_example_wrong_attribute.json
+++ b/test/compliance_tool/files/test_demo_full_example_wrong_attribute.json
@@ -254,7 +254,8 @@
             "modelType": "AssetAdministrationShell",
             "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
-                "assetKind": "Instance"
+                "assetKind": "Instance",
+                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -718,19 +719,21 @@
                     ],
                     "entityType": "SelfManagedEntity",
                     "globalAssetId": "http://acplt.org/TestAsset/",
-                    "specificAssetId": {
-                        "name": "TestKey",
-                        "value": "TestValue",
-                        "externalSubjectId": {
-                            "type": "ExternalReference",
-                            "keys": [
-                                {
-                                    "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
-                                }
-                            ]
+                    "specificAssetIds": [
+                        {
+                            "name": "TestKey",
+                            "value": "TestValue",
+                            "externalSubjectId": {
+                                "type": "ExternalReference",
+                                "keys": [
+                                    {
+                                        "type": "GlobalReference",
+                                        "value": "http://acplt.org/SpecificAssetId/"
+                                    }
+                                ]
+                            }
                         }
-                    }
+                    ]
                 },
                 {
                     "idShort": "ExampleEntity2",

--- a/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
+++ b/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
@@ -245,6 +245,7 @@
       <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
+        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -601,19 +602,21 @@
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
           <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
-          <aas:specificAssetId>
-            <aas:name>TestKey</aas:name>
-            <aas:value>TestValue</aas:value>
-            <aas:externalSubjectId>
-              <aas:type>ExternalReference</aas:type>
-              <aas:keys>
-                <aas:key>
-                  <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
-                </aas:key>
-              </aas:keys>
-            </aas:externalSubjectId>
-          </aas:specificAssetId>
+          <aas:specificAssetIds>
+            <aas:specificAssetId>
+              <aas:name>TestKey</aas:name>
+              <aas:value>TestValue</aas:value>
+              <aas:externalSubjectId>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:externalSubjectId>
+            </aas:specificAssetId>
+          </aas:specificAssetIds>
         </aas:entity>
         <aas:entity>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -253,6 +253,7 @@
       <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
+        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -609,19 +610,21 @@
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
           <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
-          <aas:specificAssetId>
-            <aas:name>TestKey</aas:name>
-            <aas:value>TestValue</aas:value>
-            <aas:externalSubjectId>
-              <aas:type>ExternalReference</aas:type>
-              <aas:keys>
-                <aas:key>
-                  <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
-                </aas:key>
-              </aas:keys>
-            </aas:externalSubjectId>
-          </aas:specificAssetId>
+          <aas:specificAssetIds>
+            <aas:specificAssetId>
+              <aas:name>TestKey</aas:name>
+              <aas:value>TestValue</aas:value>
+              <aas:externalSubjectId>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:externalSubjectId>
+            </aas:specificAssetId>
+          </aas:specificAssetIds>
         </aas:entity>
         <aas:entity>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -253,6 +253,7 @@
       <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
+        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -609,19 +610,21 @@
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
           <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
-          <aas:specificAssetId>
-            <aas:name>TestKey</aas:name>
-            <aas:value>TestValue</aas:value>
-            <aas:externalSubjectId>
-              <aas:type>ExternalReference</aas:type>
-              <aas:keys>
-                <aas:key>
-                  <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
-                </aas:key>
-              </aas:keys>
-            </aas:externalSubjectId>
-          </aas:specificAssetId>
+          <aas:specificAssetIds>
+            <aas:specificAssetId>
+              <aas:name>TestKey</aas:name>
+              <aas:value>TestValue</aas:value>
+              <aas:externalSubjectId>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:externalSubjectId>
+            </aas:specificAssetId>
+          </aas:specificAssetIds>
         </aas:entity>
         <aas:entity>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_deserializable_aas_warning.json
+++ b/test/compliance_tool/files/test_deserializable_aas_warning.json
@@ -8,7 +8,8 @@
 			},
 			"modelType": "AssetAdministrationShell",
 			"assetInformation": {
-                "assetKind": "Instance"
+                "assetKind": "Instance",
+				"globalAssetId": "http://acplt.org/TestAsset/"
             }
 		}
 	]

--- a/test/compliance_tool/files/test_deserializable_aas_warning.xml
+++ b/test/compliance_tool/files/test_deserializable_aas_warning.xml
@@ -9,6 +9,7 @@
       <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
+        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
   </aas:assetAdministrationShells>

--- a/test/model/test_aas.py
+++ b/test/model/test_aas.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023 the Eclipse BaSyx Authors
+#
+# This program and the accompanying materials are made available under the terms of the MIT License, available in
+# the LICENSE file of this project.
+#
+# SPDX-License-Identifier: MIT
+
+import unittest
+
+from basyx.aas import model
+
+
+class AssetInformationTest(unittest.TestCase):
+    def test_aasd_131_init(self) -> None:
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            model.AssetInformation(model.AssetKind.INSTANCE)
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://acplt.org/TestAsset")
+        model.AssetInformation(model.AssetKind.INSTANCE, specific_asset_id=(model.SpecificAssetId("test", "test"),))
+        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://acplt.org/TestAsset",
+                               specific_asset_id=(model.SpecificAssetId("test", "test"),))
+
+    def test_aasd_131_set(self) -> None:
+        asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
+                                                   global_asset_id="https://acplt.org/TestAsset",
+                                                   specific_asset_id=(model.SpecificAssetId("test", "test"),))
+        asset_information.global_asset_id = None
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            asset_information.specific_asset_id = model.ConstrainedList(())
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+
+        asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
+                                                   global_asset_id="https://acplt.org/TestAsset",
+                                                   specific_asset_id=(model.SpecificAssetId("test", "test"),))
+        asset_information.specific_asset_id = model.ConstrainedList(())
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            asset_information.global_asset_id = None
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+
+    def test_aasd_131_specific_asset_id_add(self) -> None:
+        asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
+                                                   global_asset_id="https://acplt.org/TestAsset")
+        specific_asset_id1 = model.SpecificAssetId("test", "test")
+        specific_asset_id2 = model.SpecificAssetId("test", "test")
+        asset_information.specific_asset_id.append(specific_asset_id1)
+        asset_information.specific_asset_id.extend((specific_asset_id2,))
+        self.assertIs(asset_information.specific_asset_id[0], specific_asset_id1)
+        self.assertIs(asset_information.specific_asset_id[1], specific_asset_id2)
+
+    def test_aasd_131_specific_asset_id_set(self) -> None:
+        asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
+                                                   specific_asset_id=(model.SpecificAssetId("test", "test"),))
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            asset_information.specific_asset_id[:] = ()
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+        specific_asset_id = model.SpecificAssetId("test", "test")
+        self.assertIsNot(asset_information.specific_asset_id[0], specific_asset_id)
+        asset_information.specific_asset_id[:] = (specific_asset_id,)
+        self.assertIs(asset_information.specific_asset_id[0], specific_asset_id)
+        asset_information.specific_asset_id[0] = model.SpecificAssetId("test", "test")
+        self.assertIsNot(asset_information.specific_asset_id[0], specific_asset_id)
+
+    def test_aasd_131_specific_asset_id_del(self) -> None:
+        specific_asset_id = model.SpecificAssetId("test", "test")
+        asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
+                                                   specific_asset_id=(model.SpecificAssetId("test1", "test1"),
+                                                                      specific_asset_id))
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            del asset_information.specific_asset_id[:]
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            asset_information.specific_asset_id.clear()
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))
+        self.assertIsNot(asset_information.specific_asset_id[0], specific_asset_id)
+        del asset_information.specific_asset_id[0]
+        self.assertIs(asset_information.specific_asset_id[0], specific_asset_id)
+        with self.assertRaises(model.AASConstraintViolation) as cm:
+            del asset_information.specific_asset_id[0]
+        self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
+                         str(cm.exception))

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -1213,7 +1213,15 @@ class ConstrainedListTest(unittest.TestCase):
         self.assertEqual(c_list, [1, 2, 3])
         with self.assertRaises(ValueError):
             c_list.clear()
-        self.assertEqual(c_list, [1, 2, 3])
+        # the default clear() implementation seems to repeatedly delete the last item until the list is empty
+        # in this case, the last item is 3, which cannot be deleted because it is > 2, thus leaving it unclear whether
+        # clear() really is atomic. to work around this, the list is reversed, making 1 the last item, and attempting
+        # to clear again.
+        c_list.reverse()
+        with self.assertRaises(ValueError):
+            c_list.clear()
+        self.assertEqual(c_list, [3, 2, 1])
+        c_list.reverse()
         del c_list[0:2]
         self.assertEqual(c_list, [3])
 

--- a/test/model/test_provider.py
+++ b/test/model/test_provider.py
@@ -12,8 +12,10 @@ from basyx.aas import model
 
 class ProvidersTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.aas1 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas1")
-        self.aas2 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas2")
+        self.aas1 = model.AssetAdministrationShell(
+            model.AssetInformation(global_asset_id="http://acplt.org/TestAsset1/"), "urn:x-test:aas1")
+        self.aas2 = model.AssetAdministrationShell(
+            model.AssetInformation(global_asset_id="http://acplt.org/TestAsset2/"), "urn:x-test:aas2")
         self.submodel1 = model.Submodel("urn:x-test:submodel1")
         self.submodel2 = model.Submodel("urn:x-test:submodel2")
 
@@ -24,7 +26,8 @@ class ProvidersTest(unittest.TestCase):
         self.assertIn(self.aas1, object_store)
         property = model.Property('test', model.datatypes.String)
         self.assertFalse(property in object_store)
-        aas3 = model.AssetAdministrationShell(model.AssetInformation(), "urn:x-test:aas1")
+        aas3 = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="http://acplt.org/TestAsset/"),
+                                              "urn:x-test:aas1")
         with self.assertRaises(KeyError) as cm:
             object_store.add(aas3)
         self.assertEqual("'Identifiable object with same id urn:x-test:aas1 is already "

--- a/test/model/test_submodel.py
+++ b/test/model/test_submodel.py
@@ -29,11 +29,11 @@ class EntityTest(unittest.TestCase):
             str(cm.exception)
         )
 
-        specific_asset_id = model.SpecificAssetId(name="TestKey",
+        specific_asset_id = {model.SpecificAssetId(name="TestKey",
                                                   value="TestValue",
                                                   external_subject_id=model.ExternalReference((model.Key(
                                                                  type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                 value='http://acplt.org/SpecificAssetId/'),)))
+                                                                 value='http://acplt.org/SpecificAssetId/'),)))}
         with self.assertRaises(model.AASConstraintViolation) as cm:
             obj3 = model.Entity(id_short='Test', entity_type=model.EntityType.CO_MANAGED_ENTITY,
                                 specific_asset_id=specific_asset_id, statement=())

--- a/test/model/test_submodel.py
+++ b/test/model/test_submodel.py
@@ -30,10 +30,10 @@ class EntityTest(unittest.TestCase):
         )
 
         specific_asset_id = {model.SpecificAssetId(name="TestKey",
-                                                  value="TestValue",
-                                                  external_subject_id=model.ExternalReference((model.Key(
-                                                                 type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                 value='http://acplt.org/SpecificAssetId/'),)))}
+                                                   value="TestValue",
+                                                   external_subject_id=model.ExternalReference((model.Key(
+                                                       type_=model.KeyTypes.GLOBAL_REFERENCE,
+                                                       value='http://acplt.org/SpecificAssetId/'),)))}
         with self.assertRaises(model.AASConstraintViolation) as cm:
             obj3 = model.Entity(id_short='Test', entity_type=model.EntityType.CO_MANAGED_ENTITY,
                                 specific_asset_id=specific_asset_id, statement=())


### PR DESCRIPTION
- Fixed Entity.specificAssetIds in JSON and XSD schemas
- Set `Entity.specific_asset_id` as `Iterable[SpecificAssetId]`, because the spec has changed
- Added check of constraint AASd-014 for Entity, see https://rwth-iat.github.io/aas-specs/AASiD/AASiD_1_Metamodel/index.html#Entity
- Added check of constraint AASd-131 for AssetInformation, see https://rwth-iat.github.io/aas-specs/AASiD/AASiD_1_Metamodel/index.html#AssetInformation
- Refactored de-/serialization of Entity
- Refactored deserialization of AssetInformation because of check of constraint AASd-131
- Refactored `check_entity_equal()`&`check_asset_information_equal()
- Updated test files

Fixes #144 