### PR TITLE
improve `xml_deserilization` tests

### DIFF
--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -232,7 +232,7 @@ class XmlDeserializationTest(unittest.TestCase):
             </aas:submodel>
         </aas:submodels>
         """)
-        self._assertInExceptionAndLog(xml, "aas:value", KeyError, logging.ERROR)
+        self._assertInExceptionAndLog(xml, ["aas:value", "has no submodel element"], KeyError, logging.ERROR)
 
     def test_operation_variable_too_many_submodel_elements(self) -> None:
         # TODO: simplify this should our suggestion regarding the XML schema get accepted
@@ -266,6 +266,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
         self.assertIn("aas:value", context.output[0])
+        self.assertIn("more than one submodel element", context.output[0])
 
     def test_duplicate_identifier(self) -> None:
         xml = _xml_wrap("""

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -54,7 +54,7 @@ class XmlDeserializationTest(unittest.TestCase):
             read_aas_xml_file(bytes_io, failsafe=False)
         cause = _root_cause(err_ctx.exception)
         for s in strings:
-            self.assertIn(s, log_ctx.output[0])  # type: ignore
+            self.assertIn(s, log_ctx.output[0])
             self.assertIn(s, str(cause))
 
     def test_malformed_xml(self) -> None:
@@ -177,7 +177,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
         for s in ("GLOBAL_REFERENCE", "IRI=http://acplt.org/test_ref", "Asset"):
-            self.assertIn(s, context.output[0])  # type: ignore
+            self.assertIn(s, context.output[0])
 
     def test_invalid_submodel_element(self) -> None:
         # TODO: simplify this should our suggestion regarding the XML schema get accepted
@@ -265,7 +265,7 @@ class XmlDeserializationTest(unittest.TestCase):
         """)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
-        self.assertIn("aas:value", context.output[0])  # type: ignore
+        self.assertIn("aas:value", context.output[0])
 
     def test_duplicate_identifier(self) -> None:
         xml = _xml_wrap("""
@@ -319,7 +319,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.INFO) as log_ctx:
             identifiers = read_aas_xml_file_into(object_store, bytes_io, replace_existing=False, ignore_existing=True)
         self.assertEqual(len(identifiers), 0)
-        self.assertIn("already exists in the object store", log_ctx.output[0])  # type: ignore
+        self.assertIn("already exists in the object store", log_ctx.output[0])
         submodel = object_store.pop()
         self.assertIsInstance(submodel, model.Submodel)
         self.assertEqual(submodel.id_short, "test123")


### PR DESCRIPTION
This PR removes unneeded `# type: ignore` comments and improves the `OperationVariable` tests.