### PR TITLE
model._string_constraints: don't overwrite existing attributes in case of a conflict

### DIFF
--- a/basyx/aas/model/_string_constraints.py
+++ b/basyx/aas/model/_string_constraints.py
@@ -130,6 +130,8 @@ def constrain_attr(pub_attr_name: str, constraint_check_fn: Callable[[str], None
                 constraint_check_fn(value)
             setattr(self, "_" + pub_attr_name, value)
 
+        if hasattr(decorated_class, pub_attr_name):
+            raise AttributeError(f"{decorated_class.__name__} already has an attribute named '{pub_attr_name}'")
         setattr(decorated_class, pub_attr_name, property(_getter, _setter))
         return decorated_class
 

--- a/test/model/test_string_constraints.py
+++ b/test/model/test_string_constraints.py
@@ -83,3 +83,19 @@ class StringConstraintsDecoratorTest(unittest.TestCase):
         dc = self.DummyClass(None)  # type: ignore
         self.assertIsNone(dc.some_attr)
         dc.some_attr = None  # type: ignore
+
+    def test_attribute_name_conflict(self) -> None:
+        # We don't want to overwrite existing attributes in case of a name conflict
+        with self.assertRaises(AttributeError) as cm:
+            @_string_constraints.constrain_revision_type("foo")
+            class DummyClass:
+                foo = property()
+        self.assertEqual("DummyClass already has an attribute named 'foo'", cm.exception.args[0])
+
+        with self.assertRaises(AttributeError) as cm:
+            @_string_constraints.constrain_label_type("bar")
+            class DummyClass2:
+                @property
+                def bar(self):
+                    return "baz"
+        self.assertEqual("DummyClass2 already has an attribute named 'bar'", cm.exception.args[0])


### PR DESCRIPTION
Currently a string constraints decorator silently overwrites existing attributes in case of a naming conflict. This behavior is changed such that the decorator checks for existing attributes beforehand and raises an exception in case of a conflict.
Futhermore, tests for this behavior are added.

I noticed this problem when reviewing #149. There, the decorator for `Entity.global_asset_id` currently overwrites the `global_asset_id` property, resulting in the constraints not being checked properly. A fix for this is currently in the making.