### PR TITLE
adapter.json: Remove deprecated XSD DataTypes from Schema

### DIFF
--- a/basyx/aas/adapter/json/aasJSONSchema.json
+++ b/basyx/aas/adapter/json/aasJSONSchema.json
@@ -445,8 +445,6 @@
         "xs:byte",
         "xs:date",
         "xs:dateTime",
-        "xs:dateTimeStamp",
-        "xs:dayTimeDuration",
         "xs:decimal",
         "xs:double",
         "xs:duration",


### PR DESCRIPTION
This removes the two XSD datatypes

- `xs:dateTimeStamp`
- `xs:dayTimeDuration`

from the `DataTypeDefXsd` in the JSON schema, as they were removed from the specification in v3.0