### PR TITLE
adapter: Refactor XML and JSON de-/serialization methods

### DIFF
--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -70,7 +70,7 @@ def _get_ts(dct: Dict[str, object], key: str, type_: Type[T]) -> T:
     return val
 
 
-def _expect_type(object_: object, type_: Type, context: str, failsafe: bool) -> bool:
+def _is_of_type(object_: object, type_: Type, context: str, failsafe: bool) -> bool:
     """
     Helper function to check type of an embedded object.
 
@@ -232,48 +232,72 @@ class AASFromJsonDecoder(json.JSONDecoder):
         :param dct: The object's dict representation from JSON
         """
         if isinstance(obj, model.Referable):
-            if 'idShort' in dct:
-                obj.id_short = _get_ts(dct, 'idShort', str)
-            if 'category' in dct:
-                obj.category = _get_ts(dct, 'category', str)
-            if 'displayName' in dct:
-                obj.display_name = cls._construct_lang_string_set(_get_ts(dct, 'displayName', list),
-                                                                  model.MultiLanguageNameType)
-            if 'description' in dct:
-                obj.description = cls._construct_lang_string_set(_get_ts(dct, 'description', list),
-                                                                 model.MultiLanguageTextType)
+            cls._amend_referable_attrs(obj, dct)
         if isinstance(obj, model.Identifiable):
-            if 'administration' in dct:
-                obj.administration = cls._construct_administrative_information(_get_ts(dct, 'administration', dict))
+            cls._amend_identifiable_attrs(obj, dct)
         if isinstance(obj, model.HasSemantics):
-            if 'semanticId' in dct:
-                obj.semantic_id = cls._construct_reference(_get_ts(dct, 'semanticId', dict))
-            if 'supplementalSemanticIds' in dct:
-                for ref in _get_ts(dct, 'supplementalSemanticIds', list):
-                    obj.supplemental_semantic_id.append(cls._construct_reference(ref))
+            cls._amend_has_semantics_attrs(obj, dct)
         # `HasKind` provides only mandatory, immutable attributes; so we cannot do anything here, after object creation.
         # However, the `cls._get_kind()` function may assist by retrieving them from the JSON object
         if isinstance(obj, model.Qualifiable) and not cls.stripped:
-            if 'qualifiers' in dct:
-                for constraint_dct in _get_ts(dct, 'qualifiers', list):
-                    constraint = cls._construct_qualifier(constraint_dct)
-                    obj.qualifier.add(constraint)
+            cls._amend_qualifiable_attrs(obj, dct)
         if isinstance(obj, model.HasDataSpecification) and not cls.stripped:
-            if 'embeddedDataSpecifications' in dct:
-                for dspec in _get_ts(dct, 'embeddedDataSpecifications', list):
-                    obj.embedded_data_specifications.append(
-                        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
-                        # see https://github.com/python/mypy/issues/5374
-                        model.EmbeddedDataSpecification(
-                            data_specification=cls._construct_reference(_get_ts(dspec, 'dataSpecification', dict)),
-                            data_specification_content=_get_ts(dspec, 'dataSpecificationContent',
-                                                               model.DataSpecificationContent)  # type: ignore
-                        )
-                    )
+            cls._amend_has_data_specification_attrs(obj, dct)
         if isinstance(obj, model.HasExtension) and not cls.stripped:
-            if 'extensions' in dct:
-                for extension in _get_ts(dct, 'extensions', list):
-                    obj.extension.add(cls._construct_extension(extension))
+            cls._amend_has_extension_attrs(obj, dct)
+
+    @classmethod
+    def _amend_referable_attrs(cls, obj: model.Referable, dct: Dict[str, object]):
+        if 'idShort' in dct:
+            obj.id_short = _get_ts(dct, 'idShort', str)
+        if 'category' in dct:
+            obj.category = _get_ts(dct, 'category', str)
+        if 'displayName' in dct:
+            obj.display_name = cls._construct_lang_string_set(_get_ts(dct, 'displayName', list),
+                                                              model.MultiLanguageNameType)
+        if 'description' in dct:
+            obj.description = cls._construct_lang_string_set(_get_ts(dct, 'description', list),
+                                                             model.MultiLanguageTextType)
+
+    @classmethod
+    def _amend_identifiable_attrs(cls, obj: model.Identifiable, dct: Dict[str, object]):
+        if 'administration' in dct:
+            obj.administration = cls._construct_administrative_information(_get_ts(dct, 'administration', dict))
+
+    @classmethod
+    def _amend_has_semantics_attrs(cls, obj: model.HasSemantics, dct: Dict[str, object]):
+        if 'semanticId' in dct:
+            obj.semantic_id = cls._construct_reference(_get_ts(dct, 'semanticId', dict))
+        if 'supplementalSemanticIds' in dct:
+            for ref in _get_ts(dct, 'supplementalSemanticIds', list):
+                obj.supplemental_semantic_id.append(cls._construct_reference(ref))
+
+    @classmethod
+    def _amend_qualifiable_attrs(cls, obj: model.Qualifiable, dct: Dict[str, object]):
+        if 'qualifiers' in dct:
+            for constraint_dct in _get_ts(dct, 'qualifiers', list):
+                constraint = cls._construct_qualifier(constraint_dct)
+                obj.qualifier.add(constraint)
+
+    @classmethod
+    def _amend_has_data_specification_attrs(cls, obj: model.HasDataSpecification, dct: Dict[str, object]):
+        if 'embeddedDataSpecifications' in dct:
+            for dspec in _get_ts(dct, 'embeddedDataSpecifications', list):
+                obj.embedded_data_specifications.append(
+                    # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
+                    # see https://github.com/python/mypy/issues/5374
+                    model.EmbeddedDataSpecification(
+                        data_specification=cls._construct_reference(_get_ts(dspec, 'dataSpecification', dict)),
+                        data_specification_content=_get_ts(dspec, 'dataSpecificationContent',
+                                                           model.DataSpecificationContent)  # type: ignore
+                    )
+                )
+
+    @classmethod
+    def _amend_has_extension_attrs(cls, obj: model.HasExtension, dct: Dict[str, object]):
+        if 'extensions' in dct:
+            for extension in _get_ts(dct, 'extensions', list):
+                obj.extension.add(cls._construct_extension(extension))
 
     @classmethod
     def _get_kind(cls, dct: Dict[str, object]) -> model.ModellingKind:
@@ -517,7 +541,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'statements' in dct:
             for element in _get_ts(dct, "statements", list):
-                if _expect_type(element, model.SubmodelElement, str(ret), cls.failsafe):
+                if _is_of_type(element, model.SubmodelElement, str(ret), cls.failsafe):
                     ret.statement.add(element)
         return ret
 
@@ -554,7 +578,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'submodelElements' in dct:
             for element in _get_ts(dct, "submodelElements", list):
-                if _expect_type(element, model.SubmodelElement, str(ret), cls.failsafe):
+                if _is_of_type(element, model.SubmodelElement, str(ret), cls.failsafe):
                     ret.submodel_element.add(element)
         return ret
 
@@ -633,7 +657,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'annotations' in dct:
             for element in _get_ts(dct, 'annotations', list):
-                if _expect_type(element, model.DataElement, str(ret), cls.failsafe):
+                if _is_of_type(element, model.DataElement, str(ret), cls.failsafe):
                     ret.annotation.add(element)
         return ret
 
@@ -645,7 +669,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'value' in dct:
             for element in _get_ts(dct, "value", list):
-                if _expect_type(element, model.SubmodelElement, str(ret), cls.failsafe):
+                if _is_of_type(element, model.SubmodelElement, str(ret), cls.failsafe):
                     ret.value.add(element)
         return ret
 
@@ -670,7 +694,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         cls._amend_abstract_attributes(ret, dct)
         if not cls.stripped and 'value' in dct:
             for element in _get_ts(dct, 'value', list):
-                if _expect_type(element, type_value_list_element, str(ret), cls.failsafe):
+                if _is_of_type(element, type_value_list_element, str(ret), cls.failsafe):
                     ret.value.add(element)
         return ret
 

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -18,20 +18,33 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
+  <xs:group name="abstractLangString_choice">
+    <xs:choice>
+      <xs:element name="langStringDefinitionTypeIec61360" type="langStringDefinitionTypeIec61360_t"/>
+      <xs:element name="langStringNameType" type="langStringNameType_t"/>
+      <xs:element name="langStringPreferredNameTypeIec61360" type="langStringPreferredNameTypeIec61360_t"/>
+      <xs:element name="langStringShortNameTypeIec61360" type="langStringShortNameTypeIec61360_t"/>
+      <xs:element name="langStringTextType" type="langStringTextType_t"/>
+    </xs:choice>
+  </xs:group>
   <xs:group name="administrativeInformation">
     <xs:sequence>
       <xs:group ref="hasDataSpecification"/>
       <xs:element name="version" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
+            <xs:pattern value="(0|[1-9][0-9]*)"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="4"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="revision" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
+            <xs:pattern value="(0|[1-9][0-9]*)"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="4"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -112,6 +125,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -119,21 +133,21 @@
       <xs:element name="lastUpdate" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)(Z|[+-]00:00)"/>
+            <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)(Z|\+00:00|-00:00)"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="minInterval" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="P(([0-9]+Y|[0-9]+Y[0-9]+M|[0-9]+Y[0-9]+M[0-9]+D|[0-9]+Y[0-9]+D|[0-9]+M|[0-9]+M[0-9]+D|[0-9]+D)(T([0-9]+H[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+H[0-9]+(\.[0-9]+)?S|[0-9]+H|[0-9]+H[0-9]+M|[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+M|[0-9]+(\.[0-9]+)?S))?|T([0-9]+H[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+H[0-9]+(\.[0-9]+)?S|[0-9]+H|[0-9]+H[0-9]+M|[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+M|[0-9]+(\.[0-9]+)?S))"/>
+            <xs:pattern value="-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S))))"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="maxInterval" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="P(([0-9]+Y|[0-9]+Y[0-9]+M|[0-9]+Y[0-9]+M[0-9]+D|[0-9]+Y[0-9]+D|[0-9]+M|[0-9]+M[0-9]+D|[0-9]+D)(T([0-9]+H[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+H[0-9]+(\.[0-9]+)?S|[0-9]+H|[0-9]+H[0-9]+M|[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+M|[0-9]+(\.[0-9]+)?S))?|T([0-9]+H[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+H[0-9]+(\.[0-9]+)?S|[0-9]+H|[0-9]+H[0-9]+M|[0-9]+M[0-9]+(\.[0-9]+)?S|[0-9]+M|[0-9]+(\.[0-9]+)?S))"/>
+            <xs:pattern value="-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S))))"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -148,6 +162,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([\t !#-\[\]-~]|[-ÿ])|\\([\t !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="100"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -249,7 +264,14 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueList" type="valueList_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
       <xs:element name="levelType" type="levelType_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -338,6 +360,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="255"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -345,17 +368,11 @@
       <xs:element name="timeStamp">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z"/>
+            <xs:pattern value="-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)(Z|\+00:00|-00:00)"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="payload" minOccurs="0" maxOccurs="1">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="payload" type="xs:base64Binary" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="extension">
@@ -365,6 +382,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="128"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -382,6 +400,7 @@
             <!-- disable this pattern for now, until we have decided which values are allowed for a File objects value -->
             <!--<xs:pattern value="file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)"/>-->
             <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -390,6 +409,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([\t !#-\[\]-~]|[-ÿ])|\\([\t !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="100"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -467,21 +487,7 @@
   </xs:group>
   <xs:group name="hasKind_choice">
     <xs:choice>
-      <xs:element name="relationshipElement" type="relationshipElement_t"/>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
       <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementCollection" type="submodelElementCollection_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
     </xs:choice>
   </xs:group>
   <xs:group name="hasSemantics">
@@ -526,6 +532,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -545,6 +552,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -671,6 +679,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="128"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -694,13 +703,15 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="128"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="idShort" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z][a-zA-Z0-9_]+"/>
+            <xs:pattern value="[a-zA-Z][a-zA-Z0-9_]*"/>
+            <xs:minLength value="1"/>
             <xs:maxLength value="128"/>
           </xs:restriction>
         </xs:simpleType>
@@ -718,13 +729,6 @@
             <xs:element name="langStringTextType" type="langStringTextType_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
-      </xs:element>
-      <xs:element name="checksum" minOccurs="0" maxOccurs="1">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
       </xs:element>
     </xs:sequence>
   </xs:group>
@@ -788,6 +792,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -796,6 +801,7 @@
           <xs:restriction base="xs:string">
             <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([\t !#-\[\]-~]|[-ÿ])|\\([\t !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
+            <xs:maxLength value="100"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -808,6 +814,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="64"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
@@ -815,10 +822,11 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="externalSubjectId" type="reference_t"/>
+      <xs:element name="externalSubjectId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="submodel">
@@ -905,7 +913,14 @@
   </xs:group>
   <xs:group name="valueReferencePair">
     <xs:sequence>
-      <xs:element name="value" type="xs:string"/>
+      <xs:element name="value">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="2000"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
       <xs:element name="valueId" type="reference_t"/>
     </xs:sequence>
   </xs:group>
@@ -942,9 +957,9 @@
       <xs:enumeration value="xs:anyURI"/>
       <xs:enumeration value="xs:base64Binary"/>
       <xs:enumeration value="xs:boolean"/>
+      <xs:enumeration value="xs:byte"/>
       <xs:enumeration value="xs:date"/>
       <xs:enumeration value="xs:dateTime"/>
-      <xs:enumeration value="xs:dateTimeStamp"/>
       <xs:enumeration value="xs:decimal"/>
       <xs:enumeration value="xs:double"/>
       <xs:enumeration value="xs:duration"/>
@@ -955,23 +970,20 @@
       <xs:enumeration value="xs:gYear"/>
       <xs:enumeration value="xs:gYearMonth"/>
       <xs:enumeration value="xs:hexBinary"/>
-      <xs:enumeration value="xs:string"/>
-      <xs:enumeration value="xs:time"/>
-      <xs:enumeration value="xs:dayTimeDuration"/>
-      <xs:enumeration value="xs:yearMonthDuration"/>
+      <xs:enumeration value="xs:int"/>
       <xs:enumeration value="xs:integer"/>
       <xs:enumeration value="xs:long"/>
-      <xs:enumeration value="xs:int"/>
-      <xs:enumeration value="xs:short"/>
-      <xs:enumeration value="xs:byte"/>
-      <xs:enumeration value="xs:nonNegativeInteger"/>
-      <xs:enumeration value="xs:positiveInteger"/>
-      <xs:enumeration value="xs:unsignedLong"/>
-      <xs:enumeration value="xs:unsignedInt"/>
-      <xs:enumeration value="xs:unsignedShort"/>
-      <xs:enumeration value="xs:unsignedByte"/>
-      <xs:enumeration value="xs:nonPositiveInteger"/>
       <xs:enumeration value="xs:negativeInteger"/>
+      <xs:enumeration value="xs:nonNegativeInteger"/>
+      <xs:enumeration value="xs:nonPositiveInteger"/>
+      <xs:enumeration value="xs:positiveInteger"/>
+      <xs:enumeration value="xs:short"/>
+      <xs:enumeration value="xs:string"/>
+      <xs:enumeration value="xs:time"/>
+      <xs:enumeration value="xs:unsignedByte"/>
+      <xs:enumeration value="xs:unsignedInt"/>
+      <xs:enumeration value="xs:unsignedLong"/>
+      <xs:enumeration value="xs:unsignedShort"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="dataTypeIec61360_t">
@@ -1011,30 +1023,30 @@
   </xs:simpleType>
   <xs:simpleType name="keyTypes_t">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="FragmentReference"/>
-      <xs:enumeration value="GlobalReference"/>
       <xs:enumeration value="AnnotatedRelationshipElement"/>
       <xs:enumeration value="AssetAdministrationShell"/>
       <xs:enumeration value="BasicEventElement"/>
       <xs:enumeration value="Blob"/>
       <xs:enumeration value="Capability"/>
       <xs:enumeration value="ConceptDescription"/>
-      <xs:enumeration value="Identifiable"/>
       <xs:enumeration value="DataElement"/>
       <xs:enumeration value="Entity"/>
       <xs:enumeration value="EventElement"/>
       <xs:enumeration value="File"/>
+      <xs:enumeration value="FragmentReference"/>
+      <xs:enumeration value="GlobalReference"/>
+      <xs:enumeration value="Identifiable"/>
       <xs:enumeration value="MultiLanguageProperty"/>
       <xs:enumeration value="Operation"/>
       <xs:enumeration value="Property"/>
       <xs:enumeration value="Range"/>
-      <xs:enumeration value="ReferenceElement"/>
       <xs:enumeration value="Referable"/>
+      <xs:enumeration value="ReferenceElement"/>
       <xs:enumeration value="RelationshipElement"/>
       <xs:enumeration value="Submodel"/>
       <xs:enumeration value="SubmodelElement"/>
-      <xs:enumeration value="SubmodelElementList"/>
       <xs:enumeration value="SubmodelElementCollection"/>
+      <xs:enumeration value="SubmodelElementList"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:group name="levelType">

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -862,7 +862,6 @@
   <xs:group name="submodelElement">
     <xs:sequence>
       <xs:group ref="referable"/>
-      <xs:group ref="hasKind"/>
       <xs:group ref="hasSemantics"/>
       <xs:group ref="qualifiable"/>
       <xs:group ref="hasDataSpecification"/>

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -589,6 +589,14 @@
       <xs:group ref="abstractLangString"/>
     </xs:sequence>
   </xs:group>
+  <xs:group name="levelType">
+    <xs:sequence>
+      <xs:element name="min" type="xs:boolean"/>
+      <xs:element name="nom" type="xs:boolean"/>
+      <xs:element name="typ" type="xs:boolean"/>
+      <xs:element name="max" type="xs:boolean"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="multiLanguageProperty">
     <xs:sequence>
       <xs:group ref="dataElement"/>
@@ -1055,19 +1063,6 @@
       <xs:enumeration value="SubmodelElementList"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:group name="levelType">
-    <xs:sequence>
-      <xs:element name="min" type="xs:boolean"/>
-      <xs:element name="nom" type="xs:boolean"/>
-      <xs:element name="typ" type="xs:boolean"/>
-      <xs:element name="max" type="xs:boolean"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="levelType_t">
-    <xs:sequence>
-      <xs:group ref="levelType"/>
-    </xs:sequence>
-  </xs:complexType>
   <xs:simpleType name="modellingKind_t">
     <xs:restriction base="xs:string">
       <xs:enumeration value="Template"/>
@@ -1244,6 +1239,11 @@
   <xs:complexType name="langStringTextType_t">
     <xs:sequence>
       <xs:group ref="langStringTextType"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="levelType_t">
+    <xs:sequence>
+      <xs:group ref="levelType"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="multiLanguageProperty_t">

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -884,6 +884,9 @@
     <xs:sequence>
       <xs:group ref="submodelElement"/>
       <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="typeValueListElement" type="aasSubmodelElements_t"/>
+      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
@@ -891,9 +894,6 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="typeValueListElement" type="aasSubmodelElements_t"/>
-      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="submodelElement_choice">

--- a/basyx/aas/adapter/xml/AAS.xsd
+++ b/basyx/aas/adapter/xml/AAS.xsd
@@ -387,8 +387,14 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="value" type="valueDataType_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="refersTo" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="refersTo" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
   </xs:group>
   <xs:group name="file">
@@ -637,7 +643,7 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="valueDataType_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -684,7 +690,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="valueDataType_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -692,8 +698,8 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" type="valueDataType_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="max" type="valueDataType_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="min" type="valueDataType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="max" type="valueDataType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">
@@ -1087,11 +1093,14 @@
       <xs:enumeration value="off"/>
     </xs:restriction>
   </xs:simpleType>
-	<xs:complexType name="valueDataType_t">
-		<xs:simpleContent>
-			<xs:extension base="xs:anySimpleType"/>
-		</xs:simpleContent>
-	</xs:complexType>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="abstractLangString_t">
+    <xs:sequence>
+      <xs:group ref="abstractLangString"/>
+    </xs:sequence>
+  </xs:complexType>
   <xs:complexType name="administrativeInformation_t">
     <xs:sequence>
       <xs:group ref="administrativeInformation"/>

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -692,8 +692,10 @@ class AASFromXmlDecoder:
         value = _get_text_or_none(element.find(NS_AAS + "value"))
         if value is not None:
             extension.value = model.datatypes.from_xsd(value, extension.value_type)
-        extension.refers_to = _failsafe_construct_multiple(element.findall(NS_AAS + "refersTo"),
-                                                           cls._construct_referable_reference, cls.failsafe)
+        extension.refers_to = _failsafe_construct_multiple(
+            element.find(NS_AAS + "refersTo").findall(NS_AAS + "reference"),
+            cls._construct_referable_reference, cls.failsafe
+        )
         cls._amend_abstract_attributes(extension, element)
         return extension
 

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1319,86 +1319,52 @@ def read_aas_xml_element(file: IO, construct: XMLConstructables, failsafe: bool 
     decoder_ = _select_decoder(failsafe, stripped, decoder)
     constructor: Callable[..., object]
 
-    if construct == XMLConstructables.KEY:
-        constructor = decoder_.construct_key
-    elif construct == XMLConstructables.REFERENCE:
-        constructor = decoder_.construct_reference
-    elif construct == XMLConstructables.MODEL_REFERENCE:
-        constructor = decoder_.construct_model_reference
-    elif construct == XMLConstructables.GLOBAL_REFERENCE:
-        constructor = decoder_.construct_external_reference
-    elif construct == XMLConstructables.ADMINISTRATIVE_INFORMATION:
-        constructor = decoder_.construct_administrative_information
-    elif construct == XMLConstructables.QUALIFIER:
-        constructor = decoder_.construct_qualifier
-    elif construct == XMLConstructables.ANNOTATED_RELATIONSHIP_ELEMENT:
-        constructor = decoder_.construct_annotated_relationship_element
-    elif construct == XMLConstructables.BASIC_EVENT_ELEMENT:
-        constructor = decoder_.construct_basic_event_element
-    elif construct == XMLConstructables.BLOB:
-        constructor = decoder_.construct_blob
-    elif construct == XMLConstructables.CAPABILITY:
-        constructor = decoder_.construct_capability
-    elif construct == XMLConstructables.ENTITY:
-        constructor = decoder_.construct_entity
-    elif construct == XMLConstructables.EXTENSION:
-        constructor = decoder_.construct_extension
-    elif construct == XMLConstructables.FILE:
-        constructor = decoder_.construct_file
-    elif construct == XMLConstructables.RESOURCE:
-        constructor = decoder_.construct_resource
-    elif construct == XMLConstructables.MULTI_LANGUAGE_PROPERTY:
-        constructor = decoder_.construct_multi_language_property
-    elif construct == XMLConstructables.OPERATION:
-        constructor = decoder_.construct_operation
-    elif construct == XMLConstructables.PROPERTY:
-        constructor = decoder_.construct_property
-    elif construct == XMLConstructables.RANGE:
-        constructor = decoder_.construct_range
-    elif construct == XMLConstructables.REFERENCE_ELEMENT:
-        constructor = decoder_.construct_reference_element
-    elif construct == XMLConstructables.RELATIONSHIP_ELEMENT:
-        constructor = decoder_.construct_relationship_element
-    elif construct == XMLConstructables.SUBMODEL_ELEMENT_COLLECTION:
-        constructor = decoder_.construct_submodel_element_collection
-    elif construct == XMLConstructables.SUBMODEL_ELEMENT_LIST:
-        constructor = decoder_.construct_submodel_element_list
-    elif construct == XMLConstructables.ASSET_ADMINISTRATION_SHELL:
-        constructor = decoder_.construct_asset_administration_shell
-    elif construct == XMLConstructables.ASSET_INFORMATION:
-        constructor = decoder_.construct_asset_information
-    elif construct == XMLConstructables.SPECIFIC_ASSET_ID:
-        constructor = decoder_.construct_specific_asset_id
-    elif construct == XMLConstructables.SUBMODEL:
-        constructor = decoder_.construct_submodel
-    elif construct == XMLConstructables.VALUE_REFERENCE_PAIR:
-        constructor = decoder_.construct_value_reference_pair
-    elif construct == XMLConstructables.CONCEPT_DESCRIPTION:
-        constructor = decoder_.construct_concept_description
-    elif construct == XMLConstructables.MULTI_LANGUAGE_NAME_TYPE:
-        constructor = decoder_.construct_multi_language_name_type
-    elif construct == XMLConstructables.MULTI_LANGUAGE_TEXT_TYPE:
-        constructor = decoder_.construct_multi_language_text_type
-    elif construct == XMLConstructables.DEFINITION_TYPE_IEC61360:
-        constructor = decoder_.construct_definition_type_iec61360
-    elif construct == XMLConstructables.PREFERRED_NAME_TYPE_IEC61360:
-        constructor = decoder_.construct_preferred_name_type_iec61360
-    elif construct == XMLConstructables.SHORT_NAME_TYPE_IEC61360:
-        constructor = decoder_.construct_short_name_type_iec61360
-    elif construct == XMLConstructables.EMBEDDED_DATA_SPECIFICATION:
-        constructor = decoder_.construct_embedded_data_specification
-    elif construct == XMLConstructables.DATA_SPECIFICATION_IEC61360:
-        constructor = decoder_.construct_data_specification_iec61360
-    # the following constructors decide which constructor to call based on the elements tag
-    elif construct == XMLConstructables.DATA_ELEMENT:
-        constructor = decoder_.construct_data_element
-    elif construct == XMLConstructables.SUBMODEL_ELEMENT:
-        constructor = decoder_.construct_submodel_element
-    elif construct == XMLConstructables.DATA_SPECIFICATION_CONTENT:
-        constructor = decoder_.construct_data_specification_content
-    # type aliases
-    elif construct == XMLConstructables.VALUE_LIST:
-        constructor = decoder_.construct_value_list
+    type_constructors = {
+        XMLConstructables.KEY: decoder_.construct_key,
+        XMLConstructables.REFERENCE: decoder_.construct_reference,
+        XMLConstructables.MODEL_REFERENCE: decoder_.construct_model_reference,
+        XMLConstructables.GLOBAL_REFERENCE: decoder_.construct_external_reference,
+        XMLConstructables.ADMINISTRATIVE_INFORMATION: decoder_.construct_administrative_information,
+        XMLConstructables.QUALIFIER: decoder_.construct_qualifier,
+        XMLConstructables.ANNOTATED_RELATIONSHIP_ELEMENT: decoder_.construct_annotated_relationship_element,
+        XMLConstructables.BASIC_EVENT_ELEMENT: decoder_.construct_basic_event_element,
+        XMLConstructables.BLOB: decoder_.construct_blob,
+        XMLConstructables.CAPABILITY: decoder_.construct_capability,
+        XMLConstructables.ENTITY: decoder_.construct_entity,
+        XMLConstructables.EXTENSION: decoder_.construct_extension,
+        XMLConstructables.FILE: decoder_.construct_file,
+        XMLConstructables.RESOURCE: decoder_.construct_resource,
+        XMLConstructables.MULTI_LANGUAGE_PROPERTY: decoder_.construct_multi_language_property,
+        XMLConstructables.OPERATION: decoder_.construct_operation,
+        XMLConstructables.PROPERTY: decoder_.construct_property,
+        XMLConstructables.RANGE: decoder_.construct_range,
+        XMLConstructables.REFERENCE_ELEMENT: decoder_.construct_reference_element,
+        XMLConstructables.RELATIONSHIP_ELEMENT: decoder_.construct_relationship_element,
+        XMLConstructables.SUBMODEL_ELEMENT_COLLECTION: decoder_.construct_submodel_element_collection,
+        XMLConstructables.SUBMODEL_ELEMENT_LIST: decoder_.construct_submodel_element_list,
+        XMLConstructables.ASSET_ADMINISTRATION_SHELL: decoder_.construct_asset_administration_shell,
+        XMLConstructables.ASSET_INFORMATION: decoder_.construct_asset_information,
+        XMLConstructables.SPECIFIC_ASSET_ID: decoder_.construct_specific_asset_id,
+        XMLConstructables.SUBMODEL: decoder_.construct_submodel,
+        XMLConstructables.VALUE_REFERENCE_PAIR: decoder_.construct_value_reference_pair,
+        XMLConstructables.CONCEPT_DESCRIPTION: decoder_.construct_concept_description,
+        XMLConstructables.MULTI_LANGUAGE_NAME_TYPE: decoder_.construct_multi_language_name_type,
+        XMLConstructables.MULTI_LANGUAGE_TEXT_TYPE: decoder_.construct_multi_language_text_type,
+        XMLConstructables.DEFINITION_TYPE_IEC61360: decoder_.construct_definition_type_iec61360,
+        XMLConstructables.PREFERRED_NAME_TYPE_IEC61360: decoder_.construct_preferred_name_type_iec61360,
+        XMLConstructables.SHORT_NAME_TYPE_IEC61360: decoder_.construct_short_name_type_iec61360,
+        XMLConstructables.EMBEDDED_DATA_SPECIFICATION: decoder_.construct_embedded_data_specification,
+        XMLConstructables.DATA_SPECIFICATION_IEC61360: decoder_.construct_data_specification_iec61360,
+        # the following constructors decide which constructor to call based on the elements tag
+        XMLConstructables.DATA_ELEMENT: decoder_.construct_data_element,
+        XMLConstructables.SUBMODEL_ELEMENT: decoder_.construct_submodel_element,
+        XMLConstructables.DATA_SPECIFICATION_CONTENT: decoder_.construct_data_specification_content,
+        # type aliases
+        XMLConstructables.VALUE_LIST: decoder_.construct_value_list,
+    }
+
+    if construct in type_constructors:
+        constructor = type_constructors[construct]
     else:
         raise ValueError(f"{construct.name} cannot be constructed!")
 

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -436,52 +436,76 @@ class AASFromXmlDecoder:
         :return: None
         """
         if isinstance(obj, model.Referable):
-            id_short = _get_text_or_none(element.find(NS_AAS + "idShort"))
-            if id_short is not None:
-                obj.id_short = id_short
-            category = _get_text_or_none(element.find(NS_AAS + "category"))
-            display_name = _failsafe_construct(element.find(NS_AAS + "displayName"),
-                                               cls.construct_multi_language_name_type, cls.failsafe)
-            if display_name is not None:
-                obj.display_name = display_name
-            if category is not None:
-                obj.category = category
-            description = _failsafe_construct(element.find(NS_AAS + "description"),
-                                              cls.construct_multi_language_text_type, cls.failsafe)
-            if description is not None:
-                obj.description = description
+            cls._amend_referable_attrs(element, obj)
         if isinstance(obj, model.Identifiable):
-            administration = _failsafe_construct(element.find(NS_AAS + "administration"),
-                                                 cls.construct_administrative_information, cls.failsafe)
-            if administration:
-                obj.administration = administration
+            cls._amend_identifiable_attrs(element, obj)
         if isinstance(obj, model.HasSemantics):
-            semantic_id = _failsafe_construct(element.find(NS_AAS + "semanticId"), cls.construct_reference,
-                                              cls.failsafe)
-            if semantic_id is not None:
-                obj.semantic_id = semantic_id
-            supplemental_semantic_ids = element.find(NS_AAS + "supplementalSemanticIds")
-            if supplemental_semantic_ids is not None:
-                for supplemental_semantic_id in _child_construct_multiple(supplemental_semantic_ids,
-                                                                          NS_AAS + "reference", cls.construct_reference,
-                                                                          cls.failsafe):
-                    obj.supplemental_semantic_id.append(supplemental_semantic_id)
+            cls._amend_has_semantics_attrs(element, obj)
         if isinstance(obj, model.Qualifiable) and not cls.stripped:
-            qualifiers_elem = element.find(NS_AAS + "qualifiers")
-            if qualifiers_elem is not None and len(qualifiers_elem) > 0:
-                for qualifier in _failsafe_construct_multiple(qualifiers_elem, cls.construct_qualifier, cls.failsafe):
-                    obj.qualifier.add(qualifier)
+            cls._amend_qualifiable_attrs(element, obj)
         if isinstance(obj, model.HasDataSpecification) and not cls.stripped:
-            embedded_data_specifications_elem = element.find(NS_AAS + "embeddedDataSpecifications")
-            if embedded_data_specifications_elem is not None:
-                for eds in _failsafe_construct_multiple(embedded_data_specifications_elem,
-                                                        cls.construct_embedded_data_specification, cls.failsafe):
-                    obj.embedded_data_specifications.append(eds)
+            cls.amend_has_data_specification_attrs(element, obj)
         if isinstance(obj, model.HasExtension) and not cls.stripped:
-            extension_elem = element.find(NS_AAS + "extension")
-            if extension_elem is not None:
-                for extension in _failsafe_construct_multiple(extension_elem, cls.construct_extension, cls.failsafe):
-                    obj.extension.add(extension)
+            cls._amend_extension_attrs(element, obj)
+
+    @classmethod
+    def _amend_referable_attrs(cls, element: etree.Element, obj: model.Referable):
+        id_short = _get_text_or_none(element.find(NS_AAS + "idShort"))
+        if id_short is not None:
+            obj.id_short = id_short
+        display_name = _failsafe_construct(element.find(NS_AAS + "displayName"),
+                                           cls.construct_multi_language_name_type, cls.failsafe)
+        if display_name is not None:
+            obj.display_name = display_name
+        category = _get_text_or_none(element.find(NS_AAS + "category"))
+        if category is not None:
+            obj.category = category
+        description = _failsafe_construct(element.find(NS_AAS + "description"),
+                                          cls.construct_multi_language_text_type, cls.failsafe)
+        if description is not None:
+            obj.description = description
+
+    @classmethod
+    def _amend_identifiable_attrs(cls, element: etree.Element, obj: model.Identifiable):
+        administration = _failsafe_construct(element.find(NS_AAS + "administration"),
+                                             cls.construct_administrative_information, cls.failsafe)
+        if administration:
+            obj.administration = administration
+
+    @classmethod
+    def _amend_has_semantics_attrs(cls, element: etree.Element, obj: model.HasSemantics):
+        semantic_id = _failsafe_construct(element.find(NS_AAS + "semanticId"), cls.construct_reference,
+                                          cls.failsafe)
+        if semantic_id is not None:
+            obj.semantic_id = semantic_id
+        supplemental_semantic_ids = element.find(NS_AAS + "supplementalSemanticIds")
+        if supplemental_semantic_ids is not None:
+            for supplemental_semantic_id in _child_construct_multiple(supplemental_semantic_ids,
+                                                                      NS_AAS + "reference", cls.construct_reference,
+                                                                      cls.failsafe):
+                obj.supplemental_semantic_id.append(supplemental_semantic_id)
+
+    @classmethod
+    def _amend_qualifiable_attrs(cls, element: etree.Element, obj: model.Qualifiable):
+        qualifiers_elem = element.find(NS_AAS + "qualifiers")
+        if qualifiers_elem is not None and len(qualifiers_elem) > 0:
+            for qualifier in _failsafe_construct_multiple(qualifiers_elem, cls.construct_qualifier, cls.failsafe):
+                obj.qualifier.add(qualifier)
+
+    @classmethod
+    def amend_has_data_specification_attrs(cls, element: etree.Element, obj: model.HasDataSpecification):
+        embedded_data_specifications_elem = element.find(NS_AAS + "embeddedDataSpecifications")
+        if embedded_data_specifications_elem is not None:
+            for eds in _failsafe_construct_multiple(embedded_data_specifications_elem,
+                                                    cls.construct_embedded_data_specification, cls.failsafe):
+                obj.embedded_data_specifications.append(eds)
+
+    @classmethod
+    def _amend_extension_attrs(cls, element: etree.Element, obj: model.HasExtension):
+        extension_elem = element.find(NS_AAS + "extension")
+        if extension_elem is not None:
+            for extension in _failsafe_construct_multiple(extension_elem, cls.construct_extension, cls.failsafe):
+                obj.extension.add(extension)
 
     @classmethod
     def _construct_relationship_element_internal(cls, element: etree.Element, object_class: Type[RE], **_kwargs: Any) \

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -729,16 +729,16 @@ class AASFromXmlDecoder:
         This function doesn't support the object_class parameter.
         Overwrite each individual SubmodelElement/DataElement constructor function instead.
         """
-        submodel_elements: Dict[str, Callable[..., model.SubmodelElement]] = {NS_AAS + k: v for k, v in {
-            "annotatedRelationshipElement": cls.construct_annotated_relationship_element,
-            "basicEventElement": cls.construct_basic_event_element,
-            "capability": cls.construct_capability,
-            "entity": cls.construct_entity,
-            "operation": cls.construct_operation,
-            "relationshipElement": cls.construct_relationship_element,
-            "submodelElementCollection": cls.construct_submodel_element_collection,
-            "submodelElementList": cls.construct_submodel_element_list
-        }.items()}
+        submodel_elements: Dict[str, Callable[..., model.SubmodelElement]] = {
+            f"{NS_AAS}annotatedRelationshipElement": cls.construct_annotated_relationship_element,
+            f"{NS_AAS}basicEventElement": cls.construct_basic_event_element,
+            f"{NS_AAS}capability": cls.construct_capability,
+            f"{NS_AAS}entity": cls.construct_entity,
+            f"{NS_AAS}operation": cls.construct_operation,
+            f"{NS_AAS}relationshipElement": cls.construct_relationship_element,
+            f"{NS_AAS}submodelElementCollection": cls.construct_submodel_element_collection,
+            f"{NS_AAS}submodelElementList": cls.construct_submodel_element_list
+        }
         if element.tag not in submodel_elements:
             return cls.construct_data_element(element, abstract_class_name="SubmodelElement", **kwargs)
         return submodel_elements[element.tag](element, **kwargs)
@@ -750,14 +750,14 @@ class AASFromXmlDecoder:
         This function does not support the object_class parameter.
         Overwrite each individual DataElement constructor function instead.
         """
-        data_elements: Dict[str, Callable[..., model.DataElement]] = {NS_AAS + k: v for k, v in {
-            "blob": cls.construct_blob,
-            "file": cls.construct_file,
-            "multiLanguageProperty": cls.construct_multi_language_property,
-            "property": cls.construct_property,
-            "range": cls.construct_range,
-            "referenceElement": cls.construct_reference_element,
-        }.items()}
+        data_elements: Dict[str, Callable[..., model.DataElement]] = {
+            f"{NS_AAS}blob": cls.construct_blob,
+            f"{NS_AAS}file": cls.construct_file,
+            f"{NS_AAS}multiLanguageProperty": cls.construct_multi_language_property,
+            f"{NS_AAS}property": cls.construct_property,
+            f"{NS_AAS}range": cls.construct_range,
+            f"{NS_AAS}referenceElement": cls.construct_reference_element,
+        }
         if element.tag not in data_elements:
             raise KeyError(_element_pretty_identifier(element) + f" is not a valid {abstract_class_name}!")
         return data_elements[element.tag](element, **kwargs)
@@ -1112,9 +1112,9 @@ class AASFromXmlDecoder:
         Overwrite each individual DataSpecificationContent constructor function instead.
         """
         data_specification_contents: Dict[str, Callable[..., model.DataSpecificationContent]] = \
-            {NS_AAS + k: v for k, v in {
-                "dataSpecificationIec61360": cls.construct_data_specification_iec61360,
-            }.items()}
+            {
+                f"{NS_AAS}dataSpecificationIec61360": cls.construct_data_specification_iec61360,
+            }
         if element.tag not in data_specification_contents:
             raise KeyError(f"{_element_pretty_identifier(element)} is not a valid DataSpecificationContent!")
         return data_specification_contents[element.tag](element, **kwargs)
@@ -1435,12 +1435,10 @@ def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identif
     decoder_ = _select_decoder(failsafe, stripped, decoder)
 
     element_constructors: Dict[str, Callable[..., model.Identifiable]] = {
-        "assetAdministrationShell": decoder_.construct_asset_administration_shell,
-        "conceptDescription": decoder_.construct_concept_description,
-        "submodel": decoder_.construct_submodel
+        f"{NS_AAS}assetAdministrationShell": decoder_.construct_asset_administration_shell,
+        f"{NS_AAS}conceptDescription": decoder_.construct_concept_description,
+        f"{NS_AAS}submodel": decoder_.construct_submodel
     }
-
-    element_constructors = {NS_AAS + k: v for k, v in element_constructors.items()}
 
     root = _parse_xml_document(file, failsafe=decoder_.failsafe, **parser_kwargs)
 

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -679,11 +679,6 @@ def submodel_element_list_to_xml(obj: model.SubmodelElementList,
                                  tag: str = NS_AAS+"submodelElementList") -> etree.Element:
     et_submodel_element_list = abstract_classes_to_xml(tag, obj)
     et_submodel_element_list.append(_generate_element(NS_AAS + "orderRelevant", boolean_to_xml(obj.order_relevant)))
-    if len(obj.value) > 0:
-        et_value = _generate_element(NS_AAS + "value")
-        for se in obj.value:
-            et_value.append(submodel_element_to_xml(se))
-        et_submodel_element_list.append(et_value)
     if obj.semantic_id_list_element is not None:
         et_submodel_element_list.append(reference_to_xml(obj.semantic_id_list_element,
                                                          NS_AAS + "semanticIdListElement"))
@@ -692,6 +687,11 @@ def submodel_element_list_to_xml(obj: model.SubmodelElementList,
     if obj.value_type_list_element is not None:
         et_submodel_element_list.append(_generate_element(NS_AAS + "valueTypeListElement",
                                                           model.datatypes.XSD_TYPE_NAMES[obj.value_type_list_element]))
+    if len(obj.value) > 0:
+        et_value = _generate_element(NS_AAS + "value")
+        for se in obj.value:
+            et_value.append(submodel_element_to_xml(se))
+        et_submodel_element_list.append(et_value)
     return et_submodel_element_list
 
 

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -83,52 +83,80 @@ def abstract_classes_to_xml(tag: str, obj: object) -> etree.Element:
     """
     elm = _generate_element(tag)
     if isinstance(obj, model.HasExtension):
-        if obj.extension:
-            et_extension = _generate_element(NS_AAS + "extensions")
-            for extension in obj.extension:
-                if isinstance(extension, model.Extension):
-                    et_extension.append(extension_to_xml(extension, tag=NS_AAS + "extension"))
-            elm.append(et_extension)
+        _extend_with_has_extension_attrs(elm, obj)
     if isinstance(obj, model.Referable):
-        if obj.category:
-            elm.append(_generate_element(name=NS_AAS + "category", text=obj.category))
-        if obj.id_short and not isinstance(obj.parent, model.SubmodelElementList):
-            elm.append(_generate_element(name=NS_AAS + "idShort", text=obj.id_short))
-        if obj.display_name:
-            elm.append(lang_string_set_to_xml(obj.display_name, tag=NS_AAS + "displayName"))
-        if obj.description:
-            elm.append(lang_string_set_to_xml(obj.description, tag=NS_AAS + "description"))
+        _extend_with_referable_attrs(elm, obj)
     if isinstance(obj, model.Identifiable):
-        if obj.administration:
-            elm.append(administrative_information_to_xml(obj.administration))
-        elm.append(_generate_element(name=NS_AAS + "id", text=obj.id))
+        _extend_with_identifiable_attrs(elm, obj)
     if isinstance(obj, model.HasKind):
-        if obj.kind is model.ModellingKind.TEMPLATE:
-            elm.append(_generate_element(name=NS_AAS + "kind", text="Template"))
-        else:
-            # then modelling-kind is Instance
-            elm.append(_generate_element(name=NS_AAS + "kind", text="Instance"))
+        _extend_with_has_kind_attrs(elm, obj)
     if isinstance(obj, model.HasSemantics):
-        if obj.semantic_id:
-            elm.append(reference_to_xml(obj.semantic_id, tag=NS_AAS+"semanticId"))
-        if obj.supplemental_semantic_id:
-            et_supplemental_semantic_ids = _generate_element(NS_AAS + "supplementalSemanticIds")
-            for supplemental_semantic_id in obj.supplemental_semantic_id:
-                et_supplemental_semantic_ids.append(reference_to_xml(supplemental_semantic_id, NS_AAS+"reference"))
-            elm.append(et_supplemental_semantic_ids)
+        _extend_with_has_semantics_attrs(elm, obj)
     if isinstance(obj, model.Qualifiable):
-        if obj.qualifier:
-            et_qualifier = _generate_element(NS_AAS + "qualifiers")
-            for qualifier in obj.qualifier:
-                et_qualifier.append(qualifier_to_xml(qualifier, tag=NS_AAS+"qualifier"))
-            elm.append(et_qualifier)
+        _extend_with_qualifiable_attrs(elm, obj)
     if isinstance(obj, model.HasDataSpecification):
-        if obj.embedded_data_specifications:
-            et_embedded_data_specifications = _generate_element(NS_AAS + "embeddedDataSpecifications")
-            for eds in obj.embedded_data_specifications:
-                et_embedded_data_specifications.append(embedded_data_specification_to_xml(eds))
-            elm.append(et_embedded_data_specifications)
+        _extend_with_has_data_specification_attrs(elm, obj)
     return elm
+
+
+def _extend_with_has_extension_attrs(elm: etree.Element, obj: model.HasExtension):
+    if obj.extension:
+        et_extension = _generate_element(NS_AAS + "extensions")
+        for extension in obj.extension:
+            if isinstance(extension, model.Extension):
+                et_extension.append(extension_to_xml(extension, tag=NS_AAS + "extension"))
+        elm.append(et_extension)
+
+
+def _extend_with_referable_attrs(elm: etree.Element, obj: model.Referable):
+    if obj.category:
+        elm.append(_generate_element(name=NS_AAS + "category", text=obj.category))
+    if obj.id_short and not isinstance(obj.parent, model.SubmodelElementList):
+        elm.append(_generate_element(name=NS_AAS + "idShort", text=obj.id_short))
+    if obj.display_name:
+        elm.append(lang_string_set_to_xml(obj.display_name, tag=NS_AAS + "displayName"))
+    if obj.description:
+        elm.append(lang_string_set_to_xml(obj.description, tag=NS_AAS + "description"))
+
+
+def _extend_with_identifiable_attrs(elm: etree.Element, obj: model.Identifiable):
+    if obj.administration:
+        elm.append(administrative_information_to_xml(obj.administration))
+    elm.append(_generate_element(name=NS_AAS + "id", text=obj.id))
+
+
+def _extend_with_has_kind_attrs(elm: etree.Element, obj: model.HasKind):
+    if obj.kind is model.ModellingKind.TEMPLATE:
+        elm.append(_generate_element(name=NS_AAS + "kind", text="Template"))
+    else:
+        # then modelling-kind is Instance
+        elm.append(_generate_element(name=NS_AAS + "kind", text="Instance"))
+
+
+def _extend_with_has_semantics_attrs(elm: etree.Element, obj: model.HasSemantics):
+    if obj.semantic_id:
+        elm.append(reference_to_xml(obj.semantic_id, tag=NS_AAS + "semanticId"))
+    if obj.supplemental_semantic_id:
+        et_supplemental_semantic_ids = _generate_element(NS_AAS + "supplementalSemanticIds")
+        for supplemental_semantic_id in obj.supplemental_semantic_id:
+            et_supplemental_semantic_ids.append(reference_to_xml(supplemental_semantic_id, NS_AAS + "reference"))
+        elm.append(et_supplemental_semantic_ids)
+
+
+def _extend_with_qualifiable_attrs(elm: etree.Element, obj: model.Qualifiable):
+    if obj.qualifier:
+        et_qualifier = _generate_element(NS_AAS + "qualifiers")
+        for qualifier in obj.qualifier:
+            et_qualifier.append(qualifier_to_xml(qualifier, tag=NS_AAS + "qualifier"))
+        elm.append(et_qualifier)
+
+
+def _extend_with_has_data_specification_attrs(elm: etree.Element, obj: model.HasDataSpecification):
+    if obj.embedded_data_specifications:
+        et_embedded_data_specifications = _generate_element(NS_AAS + "embeddedDataSpecifications")
+        for eds in obj.embedded_data_specifications:
+            et_embedded_data_specifications.append(embedded_data_specification_to_xml(eds))
+        elm.append(et_embedded_data_specifications)
 
 
 # ##############################################################

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -277,7 +277,7 @@ def extension_to_xml(obj: model.Extension, tag: str = NS_AAS+"extension") -> etr
                                               text=model.datatypes.XSD_TYPE_NAMES[obj.value_type]))
     if obj.value:
         et_extension.append(_value_to_xml(obj.value, obj.value_type))  # type: ignore # (value_type could be None)
-    if obj.refers_to:
+    if len(obj.refers_to) > 0:
         refers_to = _generate_element(NS_AAS+"refersTo")
         for reference in obj.refers_to:
             refers_to.append(reference_to_xml(reference, NS_AAS+"reference"))

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -277,9 +277,11 @@ def extension_to_xml(obj: model.Extension, tag: str = NS_AAS+"extension") -> etr
                                               text=model.datatypes.XSD_TYPE_NAMES[obj.value_type]))
     if obj.value:
         et_extension.append(_value_to_xml(obj.value, obj.value_type))  # type: ignore # (value_type could be None)
-    for refers_to in obj.refers_to:
-        et_extension.append(reference_to_xml(refers_to, NS_AAS+"refersTo"))
-
+    if obj.refers_to:
+        refers_to = _generate_element(NS_AAS+"refersTo")
+        for reference in obj.refers_to:
+            refers_to.append(reference_to_xml(reference, NS_AAS+"reference"))
+        et_extension.append(refers_to)
     return et_extension
 
 

--- a/basyx/aas/examples/data/example_aas.py
+++ b/basyx/aas/examples/data/example_aas.py
@@ -101,9 +101,9 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         name='ExampleExtension',
         value_type=model.datatypes.String,
         value="ExampleExtensionValue",
-        refers_to=(model.ModelReference((model.Key(type_=model.KeyTypes.ASSET_ADMINISTRATION_SHELL,
+        refers_to=[model.ModelReference((model.Key(type_=model.KeyTypes.ASSET_ADMINISTRATION_SHELL,
                                                    value='http://acplt.org/RefersTo/ExampleRefersTo'),),
-                                        model.AssetAdministrationShell),))
+                                        model.AssetAdministrationShell)],)
 
     # Property-Element conform to 'Verwaltungssschale in der Praxis' page 41 ManufacturerName:
     # https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/2019-verwaltungsschale-in-der-praxis.html

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1458,7 +1458,7 @@ class Extension(HasSemantics):
                  name: NameType,
                  value_type: Optional[DataTypeDefXsd] = None,
                  value: Optional[ValueDataType] = None,
-                 refers_to: Iterable[ModelReference] = (),
+                 refers_to: Optional[List[ModelReference]] = None,
                  semantic_id: Optional[Reference] = None,
                  supplemental_semantic_id: Iterable[Reference] = ()):
         super().__init__()
@@ -1468,7 +1468,10 @@ class Extension(HasSemantics):
         self.value_type: Optional[DataTypeDefXsd] = value_type
         self._value: Optional[ValueDataType]
         self.value = value
-        self.refers_to: Iterable[ModelReference] = refers_to
+        if refers_to is None:
+            self.refers_to: List[ModelReference] = []
+        else:
+            self.refers_to = refers_to
         self.semantic_id: Optional[Reference] = semantic_id
         self.supplemental_semantic_id: ConstrainedList[Reference] = ConstrainedList(supplemental_semantic_id)
 

--- a/test/compliance_tool/files/test_demo_full_example.xml
+++ b/test/compliance_tool/files/test_demo_full_example.xml
@@ -1180,6 +1180,17 @@
                 </aas:keys>
               </aas:semanticId>
               <aas:orderRelevant>true</aas:orderRelevant>
+              <aas:semanticIdListElement>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:semanticIdListElement>
+              <aas:typeValueListElement>Property</aas:typeValueListElement>
+              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
               <aas:value>
                 <aas:property>
                   <aas:category>CONSTANT</aas:category>
@@ -1397,17 +1408,6 @@
                   </aas:valueId>
                 </aas:property>
               </aas:value>
-              <aas:semanticIdListElement>
-                <aas:type>ExternalReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
-                  </aas:key>
-                </aas:keys>
-              </aas:semanticIdListElement>
-              <aas:typeValueListElement>Property</aas:typeValueListElement>
-              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
             </aas:submodelElementList>
             <aas:multiLanguageProperty>
               <aas:category>CONSTANT</aas:category>
@@ -1622,6 +1622,7 @@
         </aas:basicEventElement>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList</aas:idShort>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:kind>Instance</aas:kind>
@@ -1665,7 +1666,6 @@
               <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList2</aas:idShort>
@@ -2630,6 +2630,16 @@
             </aas:keys>
           </aas:semanticId>
           <aas:orderRelevant>true</aas:orderRelevant>
+          <aas:semanticIdListElement>
+            <aas:type>ExternalReference</aas:type>
+            <aas:keys>
+              <aas:key>
+                <aas:type>GlobalReference</aas:type>
+                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+              </aas:key>
+            </aas:keys>
+          </aas:semanticIdListElement>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:category>PARAMETER</aas:category>
@@ -2856,16 +2866,6 @@
               </aas:semanticId>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:semanticIdListElement>
-            <aas:type>ExternalReference</aas:type>
-            <aas:keys>
-              <aas:key>
-                <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
-              </aas:key>
-            </aas:keys>
-          </aas:semanticIdListElement>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example.xml
+++ b/test/compliance_tool/files/test_demo_full_example.xml
@@ -371,7 +371,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -438,7 +437,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -520,7 +518,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -544,7 +541,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -579,7 +575,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -633,7 +628,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -697,7 +691,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -747,7 +740,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -787,14 +779,12 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -814,7 +804,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -850,7 +839,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -901,7 +889,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -952,7 +939,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -991,7 +977,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1015,7 +1000,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1067,7 +1051,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1091,7 +1074,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1117,7 +1099,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1143,7 +1124,6 @@
                   <aas:text>Details of the Asset Administration Shell – Ein Beispiel für eine extern referenzierte Datei</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1169,7 +1149,6 @@
                   <aas:text>Beispiel SubmodelElementList Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1214,7 +1193,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1374,7 +1352,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1422,7 +1399,6 @@
                   <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:referredSemanticId>
@@ -1474,7 +1450,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1501,7 +1476,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1535,7 +1509,6 @@
       <aas:submodelElements>
         <aas:relationshipElement>
           <aas:idShort>ExampleRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1565,7 +1538,6 @@
         </aas:relationshipElement>
         <aas:annotatedRelationshipElement>
           <aas:idShort>ExampleAnnotatedRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1595,15 +1567,12 @@
         </aas:annotatedRelationshipElement>
         <aas:operation>
           <aas:idShort>ExampleOperation</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:operation>
         <aas:capability>
           <aas:idShort>ExampleCapability</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:capability>
         <aas:basicEventElement>
           <aas:idShort>ExampleBasicEventElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:observed>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1625,45 +1594,37 @@
           <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
               <aas:value>
                 <aas:blob>
                   <aas:idShort>ExampleBlob</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:value/>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:blob>
                 <aas:file>
                   <aas:idShort>ExampleFile</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:file>
                 <aas:multiLanguageProperty>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleMultiLanguageProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:multiLanguageProperty>
                 <aas:property>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:property>
                 <aas:range>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleRange</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:int</aas:valueType>
                 </aas:range>
                 <aas:referenceElement>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleReferenceElement</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:referenceElement>
               </aas:value>
             </aas:submodelElementCollection>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
         </aas:submodelElementList>
@@ -1718,7 +1679,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1768,7 +1728,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1808,7 +1767,6 @@
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -1816,7 +1774,6 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
@@ -1835,7 +1792,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1871,7 +1827,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1922,7 +1877,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1973,7 +1927,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2012,7 +1965,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2036,7 +1988,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2088,7 +2039,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2112,7 +2062,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2138,7 +2087,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2164,7 +2112,6 @@
                   <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2198,7 +2145,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2230,7 +2176,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2257,7 +2202,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2326,7 +2270,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2376,7 +2319,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2426,7 +2368,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2452,7 +2393,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2483,7 +2423,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2514,7 +2453,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2543,7 +2481,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2567,7 +2504,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2619,7 +2555,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2653,7 +2588,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2677,7 +2611,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2702,7 +2635,6 @@
                       <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2726,7 +2658,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2752,7 +2683,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2778,7 +2708,6 @@
                       <aas:text>Beispiel Blob Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2804,7 +2733,6 @@
                       <aas:text>Beispiel File Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2829,7 +2757,6 @@
                       <aas:text>Beispiel Reference Element Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2854,7 +2781,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2880,7 +2806,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>

--- a/test/compliance_tool/files/test_demo_full_example.xml
+++ b/test/compliance_tool/files/test_demo_full_example.xml
@@ -347,13 +347,15 @@
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>ExampleExtensionValue</aas:value>
               <aas:refersTo>
-                <aas:type>ModelReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>AssetAdministrationShell</aas:type>
-                    <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
-                  </aas:key>
-                </aas:keys>
+                <aas:reference>
+                  <aas:type>ModelReference</aas:type>
+                  <aas:keys>
+                    <aas:key>
+                      <aas:type>AssetAdministrationShell</aas:type>
+                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                    </aas:key>
+                  </aas:keys>
+                </aas:reference>
               </aas:refersTo>
             </aas:extension>
           </aas:extensions>

--- a/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
+++ b/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
@@ -1178,6 +1178,17 @@
                 </aas:keys>
               </aas:semanticId>
               <aas:orderRelevant>true</aas:orderRelevant>
+              <aas:semanticIdListElement>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:semanticIdListElement>
+              <aas:typeValueListElement>Property</aas:typeValueListElement>
+              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
               <aas:value>
                 <aas:property>
                   <aas:category>CONSTANT</aas:category>
@@ -1395,17 +1406,6 @@
                   </aas:valueId>
                 </aas:property>
               </aas:value>
-              <aas:semanticIdListElement>
-                <aas:type>ExternalReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
-                  </aas:key>
-                </aas:keys>
-              </aas:semanticIdListElement>
-              <aas:typeValueListElement>Property</aas:typeValueListElement>
-              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
             </aas:submodelElementList>
             <aas:multiLanguageProperty>
               <aas:category>CONSTANT</aas:category>
@@ -1620,6 +1620,7 @@
         </aas:basicEventElement>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList</aas:idShort>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:kind>Instance</aas:kind>
@@ -1663,7 +1664,6 @@
               <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList2</aas:idShort>
@@ -2628,6 +2628,16 @@
             </aas:keys>
           </aas:semanticId>
           <aas:orderRelevant>true</aas:orderRelevant>
+          <aas:semanticIdListElement>
+            <aas:type>ExternalReference</aas:type>
+            <aas:keys>
+              <aas:key>
+                <aas:type>GlobalReference</aas:type>
+                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+              </aas:key>
+            </aas:keys>
+          </aas:semanticIdListElement>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:category>PARAMETER</aas:category>
@@ -2854,16 +2864,6 @@
               </aas:semanticId>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:semanticIdListElement>
-            <aas:type>ExternalReference</aas:type>
-            <aas:keys>
-              <aas:key>
-                <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
-              </aas:key>
-            </aas:keys>
-          </aas:semanticIdListElement>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
+++ b/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
@@ -369,7 +369,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -436,7 +435,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -518,7 +516,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -542,7 +539,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -577,7 +573,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -631,7 +626,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -695,7 +689,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -745,7 +738,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -785,14 +777,12 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -812,7 +802,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -848,7 +837,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -899,7 +887,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -950,7 +937,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -989,7 +975,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1013,7 +998,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1065,7 +1049,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1089,7 +1072,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1115,7 +1097,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1141,7 +1122,6 @@
                   <aas:text>Details of the Asset Administration Shell – Ein Beispiel für eine extern referenzierte Datei</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1167,7 +1147,6 @@
                   <aas:text>Beispiel SubmodelElementList Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1212,7 +1191,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1372,7 +1350,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1420,7 +1397,6 @@
                   <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:referredSemanticId>
@@ -1472,7 +1448,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1499,7 +1474,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1533,7 +1507,6 @@
       <aas:submodelElements>
         <aas:relationshipElement>
           <aas:idShort>ExampleRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1563,7 +1536,6 @@
         </aas:relationshipElement>
         <aas:annotatedRelationshipElement>
           <aas:idShort>ExampleAnnotatedRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1593,15 +1565,12 @@
         </aas:annotatedRelationshipElement>
         <aas:operation>
           <aas:idShort>ExampleOperation</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:operation>
         <aas:capability>
           <aas:idShort>ExampleCapability</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:capability>
         <aas:basicEventElement>
           <aas:idShort>ExampleBasicEventElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:observed>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1623,45 +1592,37 @@
           <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
               <aas:value>
                 <aas:blob>
                   <aas:idShort>ExampleBlob</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:value/>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:blob>
                 <aas:file>
                   <aas:idShort>ExampleFile</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:file>
                 <aas:multiLanguageProperty>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleMultiLanguageProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:multiLanguageProperty>
                 <aas:property>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:property>
                 <aas:range>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleRange</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:int</aas:valueType>
                 </aas:range>
                 <aas:referenceElement>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleReferenceElement</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:referenceElement>
               </aas:value>
             </aas:submodelElementCollection>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
         </aas:submodelElementList>
@@ -1716,7 +1677,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1766,7 +1726,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1806,7 +1765,6 @@
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -1814,7 +1772,6 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
@@ -1833,7 +1790,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1869,7 +1825,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1920,7 +1875,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1971,7 +1925,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2010,7 +1963,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2034,7 +1986,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2086,7 +2037,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2110,7 +2060,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2136,7 +2085,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2162,7 +2110,6 @@
                   <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2196,7 +2143,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2228,7 +2174,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2255,7 +2200,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2324,7 +2268,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2374,7 +2317,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2424,7 +2366,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2450,7 +2391,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2481,7 +2421,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2512,7 +2451,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2541,7 +2479,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2565,7 +2502,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2617,7 +2553,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2651,7 +2586,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2675,7 +2609,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2700,7 +2633,6 @@
                       <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2724,7 +2656,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2750,7 +2681,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2776,7 +2706,6 @@
                       <aas:text>Beispiel Blob Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2802,7 +2731,6 @@
                       <aas:text>Beispiel File Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2827,7 +2755,6 @@
                       <aas:text>Beispiel Reference Element Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2852,7 +2779,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2878,7 +2804,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>

--- a/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
+++ b/test/compliance_tool/files/test_demo_full_example_wrong_attribute.xml
@@ -347,13 +347,15 @@
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>ExampleExtensionValue</aas:value>
               <aas:refersTo>
+                <aas:reference>
                 <aas:type>ModelReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>AssetAdministrationShell</aas:type>
-                    <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
-                  </aas:key>
-                </aas:keys>
+                  <aas:keys>
+                    <aas:key>
+                      <aas:type>AssetAdministrationShell</aas:type>
+                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                    </aas:key>
+                  </aas:keys>
+                </aas:reference>
               </aas:refersTo>
             </aas:extension>
           </aas:extensions>

--- a/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -355,13 +355,15 @@
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>ExampleExtensionValue</aas:value>
               <aas:refersTo>
-                <aas:type>ModelReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>AssetAdministrationShell</aas:type>
-                    <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
-                  </aas:key>
-                </aas:keys>
+                <aas:reference>
+                  <aas:type>ModelReference</aas:type>
+                  <aas:keys>
+                    <aas:key>
+                      <aas:type>AssetAdministrationShell</aas:type>
+                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                    </aas:key>
+                  </aas:keys>
+                </aas:reference>
               </aas:refersTo>
             </aas:extension>
           </aas:extensions>

--- a/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -379,7 +379,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -446,7 +445,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -528,7 +526,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -552,7 +549,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -587,7 +583,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -641,7 +636,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -705,7 +699,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -755,7 +748,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -795,14 +787,12 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -822,7 +812,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -858,7 +847,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -909,7 +897,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -960,7 +947,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -999,7 +985,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1023,7 +1008,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1075,7 +1059,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1099,7 +1082,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1125,7 +1107,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1151,7 +1132,6 @@
                   <aas:text>Details of the Asset Administration Shell – Ein Beispiel für eine extern referenzierte Datei</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1177,7 +1157,6 @@
                   <aas:text>Beispiel SubmodelElementList Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1222,7 +1201,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1382,7 +1360,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1430,7 +1407,6 @@
                   <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:referredSemanticId>
@@ -1482,7 +1458,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1509,7 +1484,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1543,7 +1517,6 @@
       <aas:submodelElements>
         <aas:relationshipElement>
           <aas:idShort>ExampleRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1573,7 +1546,6 @@
         </aas:relationshipElement>
         <aas:annotatedRelationshipElement>
           <aas:idShort>ExampleAnnotatedRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1603,15 +1575,12 @@
         </aas:annotatedRelationshipElement>
         <aas:operation>
           <aas:idShort>ExampleOperation</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:operation>
         <aas:capability>
           <aas:idShort>ExampleCapability</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:capability>
         <aas:basicEventElement>
           <aas:idShort>ExampleBasicEventElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:observed>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1633,45 +1602,37 @@
           <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
               <aas:value>
                 <aas:blob>
                   <aas:idShort>ExampleBlob</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:value/>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:blob>
                 <aas:file>
                   <aas:idShort>ExampleFile</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:file>
                 <aas:multiLanguageProperty>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleMultiLanguageProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:multiLanguageProperty>
                 <aas:property>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:property>
                 <aas:range>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleRange</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:int</aas:valueType>
                 </aas:range>
                 <aas:referenceElement>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleReferenceElement</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:referenceElement>
               </aas:value>
             </aas:submodelElementCollection>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
         </aas:submodelElementList>
@@ -1726,7 +1687,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1776,7 +1736,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1816,7 +1775,6 @@
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -1824,7 +1782,6 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
@@ -1843,7 +1800,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1879,7 +1835,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1930,7 +1885,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1981,7 +1935,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2020,7 +1973,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2044,7 +1996,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2096,7 +2047,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2120,7 +2070,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2146,7 +2095,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2172,7 +2120,6 @@
                   <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2206,7 +2153,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2238,7 +2184,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2265,7 +2210,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2334,7 +2278,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2384,7 +2327,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2434,7 +2376,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2460,7 +2401,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2491,7 +2431,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2522,7 +2461,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2551,7 +2489,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2575,7 +2512,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2627,7 +2563,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2661,7 +2596,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2685,7 +2619,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2710,7 +2643,6 @@
                       <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2734,7 +2666,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2760,7 +2691,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2786,7 +2716,6 @@
                       <aas:text>Beispiel Blob Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2812,7 +2741,6 @@
                       <aas:text>Beispiel File Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2837,7 +2765,6 @@
                       <aas:text>Beispiel Reference Element Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2862,7 +2789,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2888,7 +2814,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>

--- a/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -1188,6 +1188,17 @@
                 </aas:keys>
               </aas:semanticId>
               <aas:orderRelevant>true</aas:orderRelevant>
+              <aas:semanticIdListElement>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:semanticIdListElement>
+              <aas:typeValueListElement>Property</aas:typeValueListElement>
+              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
               <aas:value>
                 <aas:property>
                   <aas:category>CONSTANT</aas:category>
@@ -1405,17 +1416,6 @@
                   </aas:valueId>
                 </aas:property>
               </aas:value>
-              <aas:semanticIdListElement>
-                <aas:type>ExternalReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
-                  </aas:key>
-                </aas:keys>
-              </aas:semanticIdListElement>
-              <aas:typeValueListElement>Property</aas:typeValueListElement>
-              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
             </aas:submodelElementList>
             <aas:multiLanguageProperty>
               <aas:category>CONSTANT</aas:category>
@@ -1630,6 +1630,7 @@
         </aas:basicEventElement>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList</aas:idShort>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:kind>Instance</aas:kind>
@@ -1673,7 +1674,6 @@
               <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList2</aas:idShort>
@@ -2638,6 +2638,16 @@
             </aas:keys>
           </aas:semanticId>
           <aas:orderRelevant>true</aas:orderRelevant>
+          <aas:semanticIdListElement>
+            <aas:type>ExternalReference</aas:type>
+            <aas:keys>
+              <aas:key>
+                <aas:type>GlobalReference</aas:type>
+                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+              </aas:key>
+            </aas:keys>
+          </aas:semanticIdListElement>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:category>PARAMETER</aas:category>
@@ -2864,16 +2874,6 @@
               </aas:semanticId>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:semanticIdListElement>
-            <aas:type>ExternalReference</aas:type>
-            <aas:keys>
-              <aas:key>
-                <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
-              </aas:key>
-            </aas:keys>
-          </aas:semanticIdListElement>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:category>PARAMETER</aas:category>

--- a/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -379,7 +379,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -446,7 +445,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -528,7 +526,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -552,7 +549,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -587,7 +583,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -641,7 +636,6 @@
               <aas:text>Bezeichnung für eine natürliche oder juristische Person, die für die Auslegung, Herstellung und Verpackung sowie die Etikettierung eines Produkts im Hinblick auf das 'Inverkehrbringen' im eigenen Namen verantwortlich ist</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -705,7 +699,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -755,7 +748,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -795,14 +787,12 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -822,7 +812,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -858,7 +847,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -909,7 +897,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -960,7 +947,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -999,7 +985,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1023,7 +1008,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1075,7 +1059,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1099,7 +1082,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1125,7 +1107,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1151,7 +1132,6 @@
                   <aas:text>Details of the Asset Administration Shell – Ein Beispiel für eine extern referenzierte Datei</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1177,7 +1157,6 @@
                   <aas:text>Beispiel SubmodelElementList Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1222,7 +1201,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1382,7 +1360,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Instance</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1430,7 +1407,6 @@
                   <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:referredSemanticId>
@@ -1482,7 +1458,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1509,7 +1484,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -1543,7 +1517,6 @@
       <aas:submodelElements>
         <aas:relationshipElement>
           <aas:idShort>ExampleRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1573,7 +1546,6 @@
         </aas:relationshipElement>
         <aas:annotatedRelationshipElement>
           <aas:idShort>ExampleAnnotatedRelationshipElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:first>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1603,15 +1575,12 @@
         </aas:annotatedRelationshipElement>
         <aas:operation>
           <aas:idShort>ExampleOperation</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:operation>
         <aas:capability>
           <aas:idShort>ExampleCapability</aas:idShort>
-          <aas:kind>Instance</aas:kind>
         </aas:capability>
         <aas:basicEventElement>
           <aas:idShort>ExampleBasicEventElement</aas:idShort>
-          <aas:kind>Instance</aas:kind>
           <aas:observed>
             <aas:type>ModelReference</aas:type>
             <aas:keys>
@@ -1633,45 +1602,37 @@
           <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
               <aas:value>
                 <aas:blob>
                   <aas:idShort>ExampleBlob</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:value/>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:blob>
                 <aas:file>
                   <aas:idShort>ExampleFile</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:contentType>application/pdf</aas:contentType>
                 </aas:file>
                 <aas:multiLanguageProperty>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleMultiLanguageProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:multiLanguageProperty>
                 <aas:property>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleProperty</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:property>
                 <aas:range>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleRange</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                   <aas:valueType>xs:int</aas:valueType>
                 </aas:range>
                 <aas:referenceElement>
                   <aas:category>PARAMETER</aas:category>
                   <aas:idShort>ExampleReferenceElement</aas:idShort>
-                  <aas:kind>Instance</aas:kind>
                 </aas:referenceElement>
               </aas:value>
             </aas:submodelElementCollection>
             <aas:submodelElementCollection>
-              <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
         </aas:submodelElementList>
@@ -1726,7 +1687,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1776,7 +1736,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1816,7 +1775,6 @@
             <aas:range>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedRange</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:integer</aas:valueType>
               <aas:min>1</aas:min>
               <aas:max>5</aas:max>
@@ -1824,7 +1782,6 @@
             <aas:property>
               <aas:category>PARAMETER</aas:category>
               <aas:idShort>ExampleAnnotatedProperty</aas:idShort>
-              <aas:kind>Instance</aas:kind>
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>exampleValue</aas:value>
             </aas:property>
@@ -1843,7 +1800,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -1879,7 +1835,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1930,7 +1885,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -1981,7 +1935,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2020,7 +1973,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2044,7 +1996,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2096,7 +2047,6 @@
               <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Instance</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2120,7 +2070,6 @@
                   <aas:text>Beispiel Blob Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2146,7 +2095,6 @@
                   <aas:text>Beispiel File Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2172,7 +2120,6 @@
                   <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2206,7 +2153,6 @@
                   <aas:text>Beispiel Property Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2238,7 +2184,6 @@
                   <aas:text>Beispiel Range Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2265,7 +2210,6 @@
                   <aas:text>Beispiel Reference Element Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Instance</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2334,7 +2278,6 @@
               <aas:text>Beispiel RelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2384,7 +2327,6 @@
               <aas:text>Beispiel AnnotatedRelationshipElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2434,7 +2376,6 @@
               <aas:text>Beispiel Operation Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2460,7 +2401,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2491,7 +2431,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2522,7 +2461,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2551,7 +2489,6 @@
               <aas:text>Beispiel Capability Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2575,7 +2512,6 @@
               <aas:text>Beispiel BasicEventElement Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2627,7 +2563,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>
@@ -2661,7 +2596,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2685,7 +2619,6 @@
                       <aas:text>Beispiel Property Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2710,7 +2643,6 @@
                       <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2734,7 +2666,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2760,7 +2691,6 @@
                       <aas:text>Beispiel Range Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2786,7 +2716,6 @@
                       <aas:text>Beispiel Blob Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2812,7 +2741,6 @@
                       <aas:text>Beispiel File Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2837,7 +2765,6 @@
                       <aas:text>Beispiel Reference Element Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
-                  <aas:kind>Template</aas:kind>
                   <aas:semanticId>
                     <aas:type>ExternalReference</aas:type>
                     <aas:keys>
@@ -2862,7 +2789,6 @@
                   <aas:text>Beispiel SubmodelElementCollection Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
-              <aas:kind>Template</aas:kind>
               <aas:semanticId>
                 <aas:type>ExternalReference</aas:type>
                 <aas:keys>
@@ -2888,7 +2814,6 @@
               <aas:text>Beispiel SubmodelElementList Element</aas:text>
             </aas:langStringTextType>
           </aas:description>
-          <aas:kind>Template</aas:kind>
           <aas:semanticId>
             <aas:type>ExternalReference</aas:type>
             <aas:keys>

--- a/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -355,13 +355,15 @@
               <aas:valueType>xs:string</aas:valueType>
               <aas:value>ExampleExtensionValue</aas:value>
               <aas:refersTo>
+                <aas:reference>
                 <aas:type>ModelReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>AssetAdministrationShell</aas:type>
-                    <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
-                  </aas:key>
-                </aas:keys>
+                  <aas:keys>
+                    <aas:key>
+                      <aas:type>AssetAdministrationShell</aas:type>
+                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                    </aas:key>
+                  </aas:keys>
+                </aas:reference>
               </aas:refersTo>
             </aas:extension>
           </aas:extensions>

--- a/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/test/compliance_tool/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -1188,6 +1188,17 @@
                 </aas:keys>
               </aas:semanticId>
               <aas:orderRelevant>true</aas:orderRelevant>
+              <aas:semanticIdListElement>
+                <aas:type>ExternalReference</aas:type>
+                <aas:keys>
+                  <aas:key>
+                    <aas:type>GlobalReference</aas:type>
+                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                  </aas:key>
+                </aas:keys>
+              </aas:semanticIdListElement>
+              <aas:typeValueListElement>Property</aas:typeValueListElement>
+              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
               <aas:value>
                 <aas:property>
                   <aas:category>CONSTANT</aas:category>
@@ -1405,17 +1416,6 @@
                   </aas:valueId>
                 </aas:property>
               </aas:value>
-              <aas:semanticIdListElement>
-                <aas:type>ExternalReference</aas:type>
-                <aas:keys>
-                  <aas:key>
-                    <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
-                  </aas:key>
-                </aas:keys>
-              </aas:semanticIdListElement>
-              <aas:typeValueListElement>Property</aas:typeValueListElement>
-              <aas:valueTypeListElement>xs:string</aas:valueTypeListElement>
             </aas:submodelElementList>
             <aas:multiLanguageProperty>
               <aas:category>CONSTANT</aas:category>
@@ -1630,6 +1630,7 @@
         </aas:basicEventElement>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList</aas:idShort>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:kind>Instance</aas:kind>
@@ -1673,7 +1674,6 @@
               <aas:kind>Instance</aas:kind>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:idShort>ExampleSubmodelList2</aas:idShort>
@@ -2638,6 +2638,16 @@
             </aas:keys>
           </aas:semanticId>
           <aas:orderRelevant>true</aas:orderRelevant>
+          <aas:semanticIdListElement>
+            <aas:type>ExternalReference</aas:type>
+            <aas:keys>
+              <aas:key>
+                <aas:type>GlobalReference</aas:type>
+                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+              </aas:key>
+            </aas:keys>
+          </aas:semanticIdListElement>
+          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
           <aas:value>
             <aas:submodelElementCollection>
               <aas:category>PARAMETER</aas:category>
@@ -2864,16 +2874,6 @@
               </aas:semanticId>
             </aas:submodelElementCollection>
           </aas:value>
-          <aas:semanticIdListElement>
-            <aas:type>ExternalReference</aas:type>
-            <aas:keys>
-              <aas:key>
-                <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
-              </aas:key>
-            </aas:keys>
-          </aas:semanticIdListElement>
-          <aas:typeValueListElement>SubmodelElementCollection</aas:typeValueListElement>
         </aas:submodelElementList>
         <aas:submodelElementList>
           <aas:category>PARAMETER</aas:category>


### PR DESCRIPTION
The methods for handling attributes of abstract classes seemed to me too big. 

In this PR these methods are refactored.  Mostly a method extraction refactoring was done, to simplify the methods and to keep less abstraction levels in a single method

The function `_expect_type` was renamed to `_is_of_type` as it represents clearer what the func does.

This PR is not relevant for the V3.0 release and can be merged later