### PR TITLE
Soften the language tag constraint

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -288,12 +288,10 @@ class LangStringSet(MutableMapping[str, str]):
     @classmethod
     def _check_language_tag_constraints(cls, ltag: str):
         split = ltag.split("-", 1)
-        if len(split[0]) != 2 or not split[0].isalpha() or not split[0].islower():
-            raise ValueError(f"The language code '{split[0]}' of the language tag '{ltag}' doesn't consist of exactly "
-                             "two lower-case letters!")
-        if len(split) > 1 and (len(split[1]) != 2 or not split[1].isalpha() or not split[1].isupper()):
-            raise ValueError(f"The extension '{split[1]}' of the language tag '{ltag}' doesn't consist of exactly "
-                             "two upper-case letters!")
+        lang_code = split[0]
+        if len(lang_code) != 2 or not lang_code.isalpha() or not lang_code.islower():
+            raise ValueError(f"The language code of the language tag must consist of exactly two lower-case letters! "
+                             f"Given language tag and language code: '{ltag}', '{lang_code}'")
 
     def __getitem__(self, item: str) -> str:
         return self._dict[item]

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -1230,19 +1230,14 @@ class LangStringSetTest(unittest.TestCase):
     def test_language_tag_constraints(self) -> None:
         with self.assertRaises(ValueError) as cm:
             model.LangStringSet({"foo": "bar"})
-        self.assertEqual("The language code 'foo' of the language tag 'foo' doesn't consist of exactly "
-                         "two lower-case letters!", str(cm.exception))
-        with self.assertRaises(ValueError) as cm:
-            model.LangStringSet({"fo-OO-bar": "bar"})
-        self.assertEqual("The extension 'OO-bar' of the language tag 'fo-OO-bar' doesn't consist of exactly "
-                         "two upper-case letters!", str(cm.exception))
-        model.LangStringSet({"fo": "bar"})
+        self.assertEqual("The language code of the language tag must consist of exactly two lower-case letters! "
+                         "Given language tag and language code: 'foo', 'foo'", str(cm.exception))
 
         lss = model.LangStringSet({"fo-OO": "bar"})
         with self.assertRaises(ValueError) as cm:
             lss["foo"] = "bar"
-        self.assertEqual("The language code 'foo' of the language tag 'foo' doesn't consist of exactly "
-                         "two lower-case letters!", str(cm.exception))
+        self.assertEqual("The language code of the language tag must consist of exactly two lower-case letters! "
+                         "Given language tag and language code: 'foo', 'foo'", str(cm.exception))
         self.assertNotIn("foo", lss)
         self.assertNotIn("fo", lss)
         lss["fo"] = "bar"


### PR DESCRIPTION
Soften the language tag constraint

remove constraint, that if the second part of lang tag exists, it must be a region 

See https://github.com/eclipse-basyx/basyx-python-sdk/issues/157