### PR TITLE
compliance_tool: add verification and fix deserialization of `Extensions`

### DIFF
--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -543,8 +543,8 @@ class AASFromJsonDecoder(json.JSONDecoder):
         if 'value' in dct:
             ret.value = model.datatypes.from_xsd(_get_ts(dct, 'value', str), ret.value_type)
         if 'refersTo' in dct:
-            ret.refers_to = [cls._construct_model_reference(refers_to, model.Referable)  # type: ignore
-                             for refers_to in _get_ts(dct, 'refersTo', list)]
+            ret.refers_to = {cls._construct_model_reference(refers_to, model.Referable)  # type: ignore
+                             for refers_to in _get_ts(dct, 'refersTo', list)}
         return ret
 
     @classmethod

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -478,9 +478,10 @@ class AASFromXmlDecoder:
                                                         cls.construct_embedded_data_specification, cls.failsafe):
                     obj.embedded_data_specifications.append(eds)
         if isinstance(obj, model.HasExtension) and not cls.stripped:
-            extension_elem = element.find(NS_AAS + "extension")
+            extension_elem = element.find(NS_AAS + "extensions")
             if extension_elem is not None:
-                for extension in _failsafe_construct_multiple(extension_elem, cls.construct_extension, cls.failsafe):
+                for extension in _child_construct_multiple(extension_elem, NS_AAS + "extension",
+                                                           cls.construct_extension, cls.failsafe):
                     obj.extension.add(extension)
 
     @classmethod

--- a/basyx/aas/compliance_tool/cli.py
+++ b/basyx/aas/compliance_tool/cli.py
@@ -82,6 +82,7 @@ def parse_cli_arguments() -> argparse.ArgumentParser:
     group.add_argument('--xml', help="Use AAS xml format when checking or creating files", action='store_true')
     parser.add_argument('-l', '--logfile', help="Log file to be created in addition to output to stdout", default=None)
     parser.add_argument('--aasx', help="Create or read AASX files", action='store_true')
+    parser.add_argument('--dont-check-extensions', help="Don't compare Extensions", action='store_false')
     return parser
 
 
@@ -95,6 +96,10 @@ def main():
     logger = logging.getLogger(__name__)
     logger.propagate = False
     logger.addHandler(manager)
+
+    data_checker_kwargs = {
+        'check_extensions': args.dont_check_extensions
+    }
 
     if args.action == 'create' or args.action == 'c':
         manager.add_step('Create example data')
@@ -154,19 +159,22 @@ def main():
             compliance_tool_xml.check_deserialization(args.file_1, manager)
     elif args.action == 'example' or args.action == 'e':
         if args.aasx:
-            compliance_tool_aasx.check_aas_example(args.file_1, manager)
+            compliance_tool_aasx.check_aas_example(args.file_1, manager, **data_checker_kwargs)
         elif args.json:
-            compliance_tool_json.check_aas_example(args.file_1, manager)
+            compliance_tool_json.check_aas_example(args.file_1, manager, **data_checker_kwargs)
         elif args.xml:
-            compliance_tool_xml.check_aas_example(args.file_1, manager)
+            compliance_tool_xml.check_aas_example(args.file_1, manager, **data_checker_kwargs)
     elif args.action == 'files' or args.action == 'f':
         if args.file_2:
             if args.aasx:
-                compliance_tool_aasx.check_aasx_files_equivalence(args.file_1, args.file_2, manager)
+                compliance_tool_aasx.check_aasx_files_equivalence(args.file_1, args.file_2, manager,
+                                                                  **data_checker_kwargs)
             elif args.json:
-                compliance_tool_json.check_json_files_equivalence(args.file_1, args.file_2, manager)
+                compliance_tool_json.check_json_files_equivalence(args.file_1, args.file_2, manager,
+                                                                  **data_checker_kwargs)
             elif args.xml:
-                compliance_tool_xml.check_xml_files_equivalence(args.file_1, args.file_2, manager)
+                compliance_tool_xml.check_xml_files_equivalence(args.file_1, args.file_2, manager,
+                                                                **data_checker_kwargs)
         else:
             parser.error("f or files requires two file path.")
             exit()

--- a/basyx/aas/compliance_tool/compliance_check_aasx.py
+++ b/basyx/aas/compliance_tool/compliance_check_aasx.py
@@ -158,7 +158,7 @@ def check_schema(file_path: str, state_manager: ComplianceToolStateManager) -> N
         reader.close()
 
 
-def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager) -> None:
+def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager, **kwargs) -> None:
     """
     Checks if a file contains all elements of the aas example and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -168,6 +168,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
 
     :param file_path: Given file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     logger = logging.getLogger('compliance_check')
     logger.addHandler(state_manager)
@@ -189,7 +190,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
 
     state_manager.add_step('Check if data is equal to example data')
     example_data = create_example_aas_binding()
@@ -267,7 +268,8 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
         state_manager.set_step_status(Status.SUCCESS)
 
 
-def check_aasx_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager) -> None:
+def check_aasx_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager,
+                                 **kwargs) -> None:
     """
     Checks if two aasx files contain the same elements in any order and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -278,6 +280,7 @@ def check_aasx_files_equivalence(file_path_1: str, file_path_2: str, state_manag
     :param file_path_1: Given first file which should be checked
     :param file_path_2: Given second file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     logger = logging.getLogger('compliance_check')
     logger.addHandler(state_manager)
@@ -295,7 +298,7 @@ def check_aasx_files_equivalence(file_path_1: str, file_path_2: str, state_manag
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
     try:
         state_manager.add_step('Check if data in files are equal')
         checker.check_object_store(obj_store_1, obj_store_2)

--- a/basyx/aas/compliance_tool/compliance_check_json.py
+++ b/basyx/aas/compliance_tool/compliance_check_json.py
@@ -162,7 +162,7 @@ def check_deserialization(file_path: str, state_manager: ComplianceToolStateMana
     return obj_store
 
 
-def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager) -> None:
+def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager, **kwargs) -> None:
     """
     Checks if a file contains all elements of the aas example and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -172,6 +172,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
 
     :param file_path: Given file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     # create handler to get logger info
     logger_example = logging.getLogger(example_aas.__name__)
@@ -186,7 +187,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
 
     state_manager.add_step('Check if data is equal to example data')
     checker.check_object_store(obj_store, create_example())
@@ -194,7 +195,8 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
     state_manager.add_log_records_from_data_checker(checker)
 
 
-def check_json_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager) -> None:
+def check_json_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager,
+                                 **kwargs) -> None:
     """
     Checks if two json files contain the same elements in any order and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -205,6 +207,7 @@ def check_json_files_equivalence(file_path_1: str, file_path_2: str, state_manag
     :param file_path_1: Given first file which should be checked
     :param file_path_2: Given second file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     logger = logging.getLogger('compliance_check')
     logger.addHandler(state_manager)
@@ -220,7 +223,7 @@ def check_json_files_equivalence(file_path_1: str, file_path_2: str, state_manag
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
     try:
         state_manager.add_step('Check if data in files are equal')
         checker.check_object_store(obj_store_1, obj_store_2)

--- a/basyx/aas/compliance_tool/compliance_check_xml.py
+++ b/basyx/aas/compliance_tool/compliance_check_xml.py
@@ -162,7 +162,7 @@ def check_deserialization(file_path: str, state_manager: ComplianceToolStateMana
     return obj_store
 
 
-def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager) -> None:
+def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager, **kwargs) -> None:
     """
     Checks if a file contains all elements of the aas example and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -172,6 +172,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
 
     :param file_path: Given file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     # create handler to get logger info
     logger_example = logging.getLogger(example_aas.__name__)
@@ -186,7 +187,7 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
 
     state_manager.add_step('Check if data is equal to example data')
     checker.check_object_store(obj_store, create_example())
@@ -194,7 +195,8 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager)
     state_manager.add_log_records_from_data_checker(checker)
 
 
-def check_xml_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager) -> None:
+def check_xml_files_equivalence(file_path_1: str, file_path_2: str, state_manager: ComplianceToolStateManager,
+                                **kwargs) -> None:
     """
     Checks if two xml files contain the same elements in any order and reports any issues using the given
     :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager`
@@ -205,6 +207,7 @@ def check_xml_files_equivalence(file_path_1: str, file_path_2: str, state_manage
     :param file_path_1: Given first file which should be checked
     :param file_path_2: Given second file which should be checked
     :param state_manager: :class:`~aas.compliance_tool.state_manager.ComplianceToolStateManager` to log the steps
+    :param kwargs: Additional arguments to pass to :class:`~aas.examples.data._helper.AASDataChecker`
     """
     logger = logging.getLogger('compliance_check')
     logger.addHandler(state_manager)
@@ -220,7 +223,7 @@ def check_xml_files_equivalence(file_path_1: str, file_path_2: str, state_manage
         state_manager.set_step_status(Status.NOT_EXECUTED)
         return
 
-    checker = AASDataChecker(raise_immediately=False)
+    checker = AASDataChecker(raise_immediately=False, **kwargs)
     try:
         state_manager.add_step('Check if data in files are equal')
         checker.check_object_store(obj_store_1, obj_store_2)

--- a/test/examples/test_helpers.py
+++ b/test/examples/test_helpers.py
@@ -61,7 +61,7 @@ class AASDataCheckerTest(unittest.TestCase):
 
         checker.check_property_equal(property, property_expected)
         self.assertEqual(2, sum(1 for _ in checker.failed_checks))
-        self.assertEqual(12, sum(1 for _ in checker.successful_checks))
+        self.assertEqual(14, sum(1 for _ in checker.successful_checks))
         checker_iterator = checker.failed_checks
         self.assertEqual("FAIL: Attribute qualifier of Property[Prop1] must contain 1 Qualifiers (count=0)",
                          repr(next(checker_iterator)))


### PR DESCRIPTION
Previously, the compliance tool would ignore `Extensions` of objects.
However, during the update to V3.0 and the changes to the JSON/XML
formats, we noticed that the adapters aren't properly tested this way.

The validation of `Extensions` can be disabled via the flag
`--dont-check-extensions` or the keyword argument `check_extensions` to
`AASDataChecker`, since many users are probably only interested in
comparing the main model, without any extensions.

Furthermore, the deserialization is fixed.