### PR TITLE
test.adapter.xml: remove 'type: ignore' comments

### DIFF
--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -51,7 +51,7 @@ class XmlDeserializationTest(unittest.TestCase):
             read_aas_xml_file(bytes_io, failsafe=False)
         cause = _root_cause(err_ctx.exception)
         for s in strings:
-            self.assertIn(s, log_ctx.output[0])  # type: ignore
+            self.assertIn(s, log_ctx.output[0])
             self.assertIn(s, str(cause))
 
     def test_malformed_xml(self) -> None:
@@ -173,7 +173,7 @@ class XmlDeserializationTest(unittest.TestCase):
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
         for s in ("SUBMODEL", "http://acplt.org/test_ref", "AssetAdministrationShell"):
-            self.assertIn(s, context.output[0])  # type: ignore
+            self.assertIn(s, context.output[0])
 
     def test_invalid_submodel_element(self) -> None:
         xml = _xml_wrap("""
@@ -255,7 +255,7 @@ class XmlDeserializationTest(unittest.TestCase):
         """)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.BytesIO(xml.encode("utf-8")), failsafe=False)
-        self.assertIn("aas:value", context.output[0])  # type: ignore
+        self.assertIn("aas:value", context.output[0])
         self.assertIn("more than one submodel element", context.output[0])
 
     def test_duplicate_identifier(self) -> None:


### PR DESCRIPTION
These comments were mistakenly re-added in a previous merge of main into improve/V30.