### PR TITLE
backport: ci: add readme codeblock checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push, pull_request]
 
+env:
+  X_PYTHON_VERSION: "3.10"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -46,10 +49,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ env.X_PYTHON_VERSION }}
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -61,6 +64,30 @@ jobs:
     - name: Check code style with PyCodestyle
       run: |
         pycodestyle --count --max-line-length 120 basyx test
+
+  readme-codeblocks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.X_PYTHON_VERSION }}
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pycodestyle mypy codeblocks
+        pip install -r requirements.txt
+    - name: Check typing with MyPy
+      run: |
+        mypy <(codeblocks python README.md)
+    - name: Check code style with PyCodestyle
+      run: |
+        codeblocks --wrap python README.md | pycodestyle --count --max-line-length 120 -
+    - name: Run readme codeblocks with Python
+      run: |
+        codeblocks python README.md | python
 
   package:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ submodel.submodel_element.add(property)
 
 Serialize the `Submodel` to XML:
 ```python
-from basyx.aas.adapter import write_aas_xml_file
+from basyx.aas.adapter.xml import write_aas_xml_file
 
 data: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
 data.add(submodel)
-with open('Simple_Submodel.xml', 'w', encoding='utf-8') as f:
+with open('Simple_Submodel.xml', 'wb') as f:
     write_aas_xml_file(file=f, data=data)
 ```
 


### PR DESCRIPTION
This backports #182 to `v2.0.1`:
>This adds a CI check, which uses the python package `codeblocks` to extract all python codeblocks from the readme to check them with `mypy` and `pycodestyle`, and also run them with `python` itself.