### PR TITLE
adapter.xml: improve error messages in case of incorrect namespace declarations

### DIFF
--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -98,7 +98,7 @@ def _element_pretty_identifier(element: etree.Element) -> str:
     Returns a pretty element identifier for a given XML element.
 
     If the prefix is known, the namespace in the element tag is replaced by the prefix.
-    If additionally also the sourceline is known, is is added as a suffix to name.
+    If additionally also the sourceline is known, it is added as a suffix to name.
     For example, instead of "{https://admin-shell.io/aas/3/0}assetAdministrationShell" this function would return
     "aas:assetAdministrationShell on line $line", if both, prefix and sourceline, are known.
 
@@ -107,7 +107,11 @@ def _element_pretty_identifier(element: etree.Element) -> str:
     """
     identifier = element.tag
     if element.prefix is not None:
-        identifier = element.prefix + ":" + element.tag.split("}")[1]
+        # Only replace the namespace by the prefix if it matches our known namespaces,
+        # so the replacement by the prefix doesn't mask errors such as incorrect namespaces.
+        namespace, tag = element.tag.split("}", 1)
+        if namespace[1:] in XML_NS_MAP.values():
+            identifier = element.prefix + ":" + tag
     if element.sourceline is not None:
         identifier += f" on line {element.sourceline}"
     return identifier


### PR DESCRIPTION
Previously, if the elements of an XML document are part of an unknown
namespace, this would lead to cryptic error messages such as:

Unexpected top-level list aas:assetAdministrationShells on line 3

where, the correct expected element is indeed
aas:assetAdministrationShells, leaving the user wondering about what
could possibly be wrong. The only difference is the namespace, which
isn't part of the error message, because it gets replaced by the prefix.

To improve the error messages in this case, a check that compares the
namespaces declared on the document against the ones required by the
deserialization, and errors if a required namespace isn't declared.

Furthermore, the namespace of an element would always be replaced by its
prefix if the prefix is known. However, this turned out to mask errors
in case the namespace is different from the one used by our SDK.
Thus, the function `_element_pretty_identifier()` is adjusted such that
it only replaces the namespace if it matches one of the namespaces known
to our SDK.

Fix #190 