### PR TITLE
move version declaration to basyx.aas module

### DIFF
--- a/basyx/aas/__init__.py
+++ b/basyx/aas/__init__.py
@@ -6,3 +6,5 @@ The subpackage 'model' is an implementation of the meta-model of the AAS,
 in 'adapter', you can find JSON and XML adapters to translate between BaSyx Python SDK objects and JSON/XML schemas;
 and in 'util', some helpful functionality to actually use the AAS meta-model you created with 'model' is located.
 """
+
+__version__ = "1.0.0"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import datetime
 
 
 sys.path.insert(0, os.path.abspath('../..'))
+from basyx.aas import __version__
 
 
 # -- Project information -----------------------------------------------------
@@ -25,7 +26,7 @@ copyright = str(datetime.datetime.now().year) + ', the Eclipse BaSyx Authors'
 author = 'The Eclipse BaSyx Authors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.0'
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,14 @@
 # SPDX-License-Identifier: MIT
 
 import setuptools
+from basyx.aas import __version__
 
 with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="basyx-python-sdk",
-    version="1.0.0",
+    version=__version__,
     author="The Eclipse BaSyx Authors",
     description="The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell for Industry 4.0 "
                 "systems",


### PR DESCRIPTION
This moves the version declaration to the basyx.aas module and imports it from there in the docs configuration and setup.py. This avoid having to change the version number in multiple locations.