### PR TITLE
cleanup and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,8 @@ dependencies (MIT License, Apache License, PSF License)
 
 Development/testing/documentation/example dependencies (see `requirements.txt`):
 * `jsonschema` and its dependencies (MIT License, Apache License, PSF License)
-* `Sphinx` and its dependencies (multiple licenses)
-* `sphinx-rtd-theme` and its dependencies
-* `sphinx-argparse` (MIT License)
 
-Dependencies for building the documentation:
+Dependencies for building the documentation (see `docs/add-requirements.txt`):
 * `Sphinx` and its dependencies (BSD 2-clause License, MIT License, Apache License)
 * `sphinx-rtd-theme` and its dependencies (MIT License, PSF License)
 * `sphinx-argparse` (MIT License)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ dependencies (MIT License, Apache License, PSF License)
 
 Development/testing/documentation/example dependencies (see `requirements.txt`):
 * `jsonschema` and its dependencies (MIT License, Apache License, PSF License)
-* `psutil` (BSD 3-clause License)
 * `Sphinx` and its dependencies (multiple licenses)
 * `sphinx-rtd-theme` and its dependencies
 * `sphinx-argparse` (MIT License)

--- a/docs/add-requirements.txt
+++ b/docs/add-requirements.txt
@@ -1,4 +1,4 @@
 # Additional requirements for building the docs
-sphinx~=4.4
-sphinx-rtd-theme~=1.0
-sphinx-argparse~=0.3.1
+sphinx~=7.2
+sphinx-rtd-theme~=2.0
+sphinx-argparse~=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ lxml>=4.2,<5
 python-dateutil>=2.8,<3.0
 types-python-dateutil
 pyecma376-2>=0.2.4
-psutil>=5.4.8
 urllib3>=1.26,<2.0
 Sphinx~=3.5.3
 sphinx-rtd-theme~=0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,3 @@ python-dateutil>=2.8,<3.0
 types-python-dateutil
 pyecma376-2>=0.2.4
 urllib3>=1.26,<2.0
-Sphinx~=3.5.3
-sphinx-rtd-theme~=0.5.1
-sphinx-argparse~=0.2.3


### PR DESCRIPTION
This removes the unnecessary `psutil` dependency and the duplicate dependency on `sphinx` and its extensions. Furthermore, the `sphinx` packages are updated to the latest version.