### PR TITLE
ci: use `X_PYTHON_VERSION` for package job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ env.X_PYTHON_VERSION }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This avoids having to update the CI python version in multiple places.