### PR TITLE
chore: drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: ci
 on: [push, pull_request]
 
 env:
-  X_PYTHON_VERSION: "3.10"
+  X_PYTHON_VERSION: "3.12"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.11"]
+        python-version: ["3.8", "3.10", "3.12"]
     env:
       COUCHDB_ADMIN_PASSWORD: "yo0Quai3"
     services:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
             "aas-compliance-check = basyx.aas.compliance_tool.cli:main"
         ]
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'python-dateutil>=2.8,<3',
         'lxml>=4.2,<5',


### PR DESCRIPTION
Drop support for Python 3.7 and support Python 3.12 instead. Python 3.7 is EOL since 6.6.2023 and the latest version of Werkzeug (a dependency of the http api) has already dropped support for it. Thus, by using the latest version of Werkzeug, we can't guarantee support for Python 3.7.