### PR TITLE
adapter.aasx: improve error messages

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -69,13 +69,16 @@ class AASXReader:
         closing under any circumstances.
 
         :param file: A filename, file path or an open file-like object in binary mode
+        :raises FileNotFoundError: If the file does not exist
         :raises ValueError: If the file is not a valid OPC zip package
         """
         try:
             logger.debug("Opening {} as AASX pacakge for reading ...".format(file))
             self.reader = pyecma376_2.ZipPackageReader(file)
+        except FileNotFoundError:
+            raise
         except Exception as e:
-            raise ValueError("{} is not a valid ECMA376-2 (OPC) file".format(file)) from e
+            raise ValueError("{} is not a valid ECMA376-2 (OPC) file: {}".format(file, e)) from e
 
     def get_core_properties(self) -> pyecma376_2.OPCCoreProperties:
         """

--- a/basyx/aas/compliance_tool/compliance_check_aasx.py
+++ b/basyx/aas/compliance_tool/compliance_check_aasx.py
@@ -63,7 +63,7 @@ def check_deserialization(file_path: str, state_manager: ComplianceToolStateMana
         # open given file
         reader = aasx.AASXReader(file_path)
         state_manager.set_step_status_from_log()
-    except ValueError as error:
+    except (FileNotFoundError, ValueError) as error:
         logger.error(error)
         state_manager.set_step_status_from_log()
         state_manager.add_step('Read file')

--- a/test/compliance_tool/test_compliance_check_aasx.py
+++ b/test/compliance_tool/test_compliance_check_aasx.py
@@ -20,7 +20,7 @@ class ComplianceToolAASXTest(unittest.TestCase):
         compliance_tool.check_deserialization(file_path_1, manager)
         self.assertEqual(2, len(manager.steps))
         self.assertEqual(Status.FAILED, manager.steps[0].status)
-        self.assertIn("is not a valid ECMA376-2 (OPC) file", manager.format_step(0, verbose_level=1))
+        self.assertIn("No such file or directory", manager.format_step(0, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[1].status)
 
         # Todo add more tests for checking wrong aasx files


### PR DESCRIPTION
A `FileNotFoundError` is no longer converted to a `ValueError`, but re-raised instead. Furthermore, the message of the `ValueError` now contains more information as to why a file is not a valid OPC package.

Fix #221