### PR TITLE
setup: Update development status to Production/Stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Following the guidelines of https://pypi.org/classifiers/ our current development status should not be "alpha", but "Production/Stable"

Fix #223 