### PR TITLE
adapter.aasx: improve `AASXWriter` docstring

### DIFF
--- a/basyx/aas/adapter/aasx.py
+++ b/basyx/aas/adapter/aasx.py
@@ -285,9 +285,11 @@ class AASXWriter:
                              file_store)
             writer.write_core_properties(cp)
 
-    **Attention:** The AASXWriter must always be closed using the :meth:`~.AASXWriter.close` method or its context
-    manager functionality (as shown above). Otherwise the resulting AASX file will lack important data structures
-    and will not be readable.
+    .. attention::
+
+        The AASXWriter must always be closed using the :meth:`~.AASXWriter.close` method or its context manager
+        functionality (as shown above). Otherwise, the resulting AASX file will lack important data structures
+        and will not be readable.
     """
     AASX_ORIGIN_PART_NAME = "/aasx/aasx-origin"
 


### PR DESCRIPTION
Replace a block of text by an `attention` admonition to highlight it properly. Furthermore, add a missing comma.