### PR TITLE
model.base: add id_short path resolution

### DIFF
--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -1040,7 +1040,7 @@ class ModelReference(Reference, Generic[_RT]):
         # For ModelReferences, the first key must be an AasIdentifiable. So resolve the first key via the provider.
         identifier: Optional[Identifier] = self.key[0].get_identifier()
         if identifier is None:
-            raise AssertionError("Retrieving the identifier of the first key failed.")
+            raise AssertionError(f"Retrieving the identifier of the first {self.key[0]!r} failed.")
 
         try:
             item: Referable = provider_.get_identifiable(identifier)

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -866,7 +866,7 @@ _RT = TypeVar('_RT', bound=Referable)
 
 class UnexpectedTypeError(TypeError):
     """
-    Exception to be raised by :meth:`basyx.aas.model.base.ModelReference.resolve` if the retrieved object has not
+    Exception to be raised by :meth:`.ModelReference.resolve` if the retrieved object has not
     the expected type.
 
     :ivar value: The object of unexpected type
@@ -1029,7 +1029,7 @@ class ModelReference(Reference, Generic[_RT]):
         :return: The referenced object (or a proxy object for it)
         :raises IndexError: If the list of keys is empty
         :raises TypeError: If one of the intermediate objects on the path is not a
-                           :class:`~basyx.aas.model.base.Namespace`
+                           :class:`~.UniqueIdShortNamespace`
         :raises ValueError: If a non-numeric index is given to resolve in a
                             :class:`~basyx.aas.model.submodel.SubmodelElementList`
         :raises UnexpectedTypeError: If the retrieved object is not of the expected type (or one of its subclasses). The

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -503,7 +503,7 @@ class Namespace(metaclass=abc.ABCMeta):
                 return ns_set.get_object_by_attribute(attribute_name, attribute)
             except KeyError:
                 continue
-        raise KeyError(f"{object_type.__name__} with {attribute_name} {attribute} not found in this namespace")
+        raise KeyError(f"{object_type.__name__} with {attribute_name} {attribute} not found in {self!r}")
 
     def _add_object(self, attribute_name: str, obj: _NSO) -> None:
         """
@@ -531,7 +531,7 @@ class Namespace(metaclass=abc.ABCMeta):
                     return
                 except KeyError:
                     continue
-        raise KeyError(f"{object_type.__name__} with {attribute_name} {attribute} not found in this namespace")
+        raise KeyError(f"{object_type.__name__} with {attribute_name} {attribute} not found in {self!r}")
 
 
 class HasExtension(Namespace, metaclass=abc.ABCMeta):
@@ -1737,7 +1737,7 @@ class UniqueIdShortNamespace(Namespace, metaclass=abc.ABCMeta):
             # This is redundant on first iteration, but it's a negligible overhead.
             # Also, ModelReference.resolve() relies on this check.
             if not isinstance(item, UniqueIdShortNamespace):
-                raise TypeError(f"Cannot resolve id_short or index '{id_}', "
+                raise TypeError(f"Cannot resolve id_short or index '{id_}' at {item!r}, "
                                 f"because it is not a {UniqueIdShortNamespace.__name__}!")
             is_submodel_element_list = isinstance(item, SubmodelElementList)
             try:
@@ -1749,10 +1749,10 @@ class UniqueIdShortNamespace(Namespace, metaclass=abc.ABCMeta):
                 else:
                     item = item._get_object(Referable, "id_short", id_)  # type: ignore[type-abstract]
             except ValueError as e:
-                raise ValueError(f"Cannot resolve '{id_}', because it is not a numeric index!") from e
+                raise ValueError(f"Cannot resolve '{id_}' at {item!r}, because it is not a numeric index!") from e
             except (KeyError, IndexError) as e:
-                raise KeyError("Referable with {} {} not found in this namespace".format(
-                    "index" if is_submodel_element_list else "id_short", id_)) from e
+                raise KeyError("Referable with {} {} not found in {}".format(
+                    "index" if is_submodel_element_list else "id_short", id_, repr(item))) from e
         # All UniqueIdShortNamespaces are Referables, and we only ever assign Referable to item.
         return item  # type: ignore[return-value]
 

--- a/test/model/test_base.py
+++ b/test/model/test_base.py
@@ -981,9 +981,15 @@ class ModelReferenceTest(unittest.TestCase):
         self.assertEqual("'Referable with id_short prop_false not found in "
                          "SubmodelElementCollection[urn:x-test:submodel / list[0]]'", str(cm_8.exception))
 
+        ref9 = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:submodel"),
+                                     model.Key(model.KeyTypes.SUBMODEL_ELEMENT_COLLECTION, "list"),
+                                     model.Key(model.KeyTypes.SUBMODEL_ELEMENT_COLLECTION, "collection")),
+                                    model.SubmodelElementCollection)
+
         with self.assertRaises(ValueError) as cm_9:
-            ref9 = model.ModelReference((), model.Submodel)
-        self.assertEqual('A reference must have at least one key!', str(cm_9.exception))
+            ref9.resolve(DummyObjectProvider())
+        self.assertEqual("Cannot resolve 'collection' at SubmodelElementList[urn:x-test:submodel / list], "
+                         "because it is not a numeric index!", str(cm_9.exception))
 
     def test_get_identifier(self) -> None:
         ref = model.ModelReference((model.Key(model.KeyTypes.SUBMODEL, "urn:x-test:x"),), model.Submodel)


### PR DESCRIPTION
Resolution of id_short paths is added via `UniqueIdShortNamespace.get_referable()`, such that it can be used on every object, that spans such a namespace. `ModelReference.resolve()` is simplified to make use of this new functionality. Furthermore, tests for this are added.

Fix #214