### PR TITLE
`adapter.{json,xml}`: make (de-)serialization interfaces coherent

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ from basyx.aas.adapter.xml import write_aas_xml_file
 
 data: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
 data.add(submodel)
-with open('Simple_Submodel.xml', 'wb') as f:
-    write_aas_xml_file(file=f, data=data)
+write_aas_xml_file(file='Simple_Submodel.xml', data=data)
 ```
 
 

--- a/basyx/aas/adapter/_generic.py
+++ b/basyx/aas/adapter/_generic.py
@@ -8,9 +8,16 @@
 The dicts defined in this module are used in the json and xml modules to translate enum members of our
 implementation to the respective string and vice versa.
 """
-from typing import Dict, Type
+import os
+from typing import BinaryIO, Dict, IO, Type, Union
 
 from basyx.aas import model
+
+# type aliases for path-like objects and IO
+# used by write_aas_xml_file, read_aas_xml_file, write_aas_json_file, read_aas_json_file
+Path = Union[str, bytes, os.PathLike]
+PathOrBinaryIO = Union[Path, BinaryIO]
+PathOrIO = Union[Path, IO]  # IO is TextIO or BinaryIO
 
 # XML Namespace definition
 XML_NS_MAP = {"aas": "https://admin-shell.io/aas/3/0"}

--- a/basyx/aas/adapter/json/json_deserialization.py
+++ b/basyx/aas/adapter/json/json_deserialization.py
@@ -815,6 +815,13 @@ def read_aas_json_file_into(object_store: model.AbstractObjectStore, file: PathO
                      See https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91
                      This parameter is ignored if a decoder class is specified.
     :param decoder: The decoder class used to decode the JSON objects
+    :raises KeyError: **Non-failsafe**: Encountered a duplicate identifier
+    :raises KeyError: Encountered an identifier that already exists in the given ``object_store`` with both
+                     ``replace_existing`` and ``ignore_existing`` set to ``False``
+    :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError, TypeError): **Non-failsafe**:
+        Errors during construction of the objects
+    :raises TypeError: **Non-failsafe**: Encountered an element in the wrong list
+                                         (e.g. an AssetAdministrationShell in ``submodels``)
     :return: A set of :class:`Identifiers <basyx.aas.model.base.Identifier>` that were added to object_store
     """
     ret: Set[model.Identifier] = set()
@@ -884,6 +891,11 @@ def read_aas_json_file(file: PathOrIO, **kwargs) -> model.DictObjectStore[model.
 
     :param file: A filename or file-like object to read the JSON-serialized data from
     :param kwargs: Keyword arguments passed to :meth:`read_aas_json_file_into`
+    :raises KeyError: **Non-failsafe**: Encountered a duplicate identifier
+    :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError, TypeError): **Non-failsafe**:
+        Errors during construction of the objects
+    :raises TypeError: **Non-failsafe**: Encountered an element in the wrong list
+                                         (e.g. an AssetAdministrationShell in ``submodels``)
     :return: A :class:`~basyx.aas.model.provider.DictObjectStore` containing all AAS objects from the JSON file
     """
     object_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()

--- a/basyx/aas/adapter/xml/__init__.py
+++ b/basyx/aas/adapter/xml/__init__.py
@@ -11,7 +11,8 @@ This package contains functionality for serialization and deserialization of BaS
 """
 import os.path
 
-from .xml_serialization import write_aas_xml_file
+from .xml_serialization import object_store_to_xml_element, write_aas_xml_file, object_to_xml_element, \
+    write_aas_xml_element
 from .xml_deserialization import AASFromXmlDecoder, StrictAASFromXmlDecoder, StrippedAASFromXmlDecoder, \
     StrictStrippedAASFromXmlDecoder, XMLConstructables, read_aas_xml_file, read_aas_xml_file_into, read_aas_xml_element
 

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -47,10 +47,10 @@ import logging
 import base64
 import enum
 
-from typing import Any, Callable, Dict, IO, Iterable, Optional, Set, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Iterable, Optional, Set, Tuple, Type, TypeVar
 from .._generic import XML_NS_MAP, XML_NS_AAS, MODELLING_KIND_INVERSE, ASSET_KIND_INVERSE, KEY_TYPES_INVERSE, \
     ENTITY_TYPES_INVERSE, IEC61360_DATA_TYPES_INVERSE, IEC61360_LEVEL_TYPES_INVERSE, KEY_TYPES_CLASSES_INVERSE, \
-    REFERENCE_TYPES_INVERSE, DIRECTION_INVERSE, STATE_OF_EVENT_INVERSE, QUALIFIER_KIND_INVERSE
+    REFERENCE_TYPES_INVERSE, DIRECTION_INVERSE, STATE_OF_EVENT_INVERSE, QUALIFIER_KIND_INVERSE, PathOrIO
 
 NS_AAS = XML_NS_AAS
 REQUIRED_NAMESPACES: Set[str] = {XML_NS_MAP["aas"]}
@@ -1186,7 +1186,7 @@ class StrictStrippedAASFromXmlDecoder(StrictAASFromXmlDecoder, StrippedAASFromXm
     pass
 
 
-def _parse_xml_document(file: IO, failsafe: bool = True, **parser_kwargs: Any) -> Optional[etree.Element]:
+def _parse_xml_document(file: PathOrIO, failsafe: bool = True, **parser_kwargs: Any) -> Optional[etree.Element]:
     """
     Parse an XML document into an element tree
 
@@ -1289,7 +1289,7 @@ class XMLConstructables(enum.Enum):
     DATA_SPECIFICATION_IEC61360 = enum.auto()
 
 
-def read_aas_xml_element(file: IO, construct: XMLConstructables, failsafe: bool = True, stripped: bool = False,
+def read_aas_xml_element(file: PathOrIO, construct: XMLConstructables, failsafe: bool = True, stripped: bool = False,
                          decoder: Optional[Type[AASFromXmlDecoder]] = None, **constructor_kwargs) -> Optional[object]:
     """
     Construct a single object from an XML string. The namespaces have to be declared on the object itself, since there
@@ -1397,7 +1397,7 @@ def read_aas_xml_element(file: IO, construct: XMLConstructables, failsafe: bool 
     return _failsafe_construct(element, constructor, decoder_.failsafe, **constructor_kwargs)
 
 
-def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identifiable], file: IO,
+def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identifiable], file: PathOrIO,
                            replace_existing: bool = False, ignore_existing: bool = False, failsafe: bool = True,
                            stripped: bool = False, decoder: Optional[Type[AASFromXmlDecoder]] = None,
                            **parser_kwargs: Any) -> Set[model.Identifier]:
@@ -1470,7 +1470,7 @@ def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identif
     return ret
 
 
-def read_aas_xml_file(file: IO, **kwargs: Any) -> model.DictObjectStore[model.Identifiable]:
+def read_aas_xml_file(file: PathOrIO, **kwargs: Any) -> model.DictObjectStore[model.Identifiable]:
     """
     A wrapper of :meth:`~basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into`, that reads all objects in an
     empty :class:`~basyx.aas.model.provider.DictObjectStore`. This function supports

--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1194,6 +1194,8 @@ def _parse_xml_document(file: PathOrIO, failsafe: bool = True, **parser_kwargs: 
     :param failsafe: If True, the file is parsed in a failsafe way: Instead of raising an Exception if the document
                      is malformed, parsing is aborted, an error is logged and None is returned
     :param parser_kwargs: Keyword arguments passed to the XMLParser constructor
+    :raises ~lxml.etree.XMLSyntaxError: **Non-failsafe**: If the given file(-handle) has invalid XML
+    :raises KeyError: **Non-failsafe**: If a required namespace has not been declared on the XML document
     :return: The root element of the element tree
     """
 
@@ -1293,7 +1295,7 @@ def read_aas_xml_element(file: PathOrIO, construct: XMLConstructables, failsafe:
                          decoder: Optional[Type[AASFromXmlDecoder]] = None, **constructor_kwargs) -> Optional[object]:
     """
     Construct a single object from an XML string. The namespaces have to be declared on the object itself, since there
-    is no surrounding aasenv element.
+    is no surrounding environment element.
 
     :param file: A filename or file-like object to read the XML-serialized data from
     :param construct: A member of the enum :class:`~.XMLConstructables`, specifying which type to construct.
@@ -1305,6 +1307,10 @@ def read_aas_xml_element(file: PathOrIO, construct: XMLConstructables, failsafe:
                      This parameter is ignored if a decoder class is specified.
     :param decoder: The decoder class used to decode the XML elements
     :param constructor_kwargs: Keyword arguments passed to the constructor function
+    :raises ~lxml.etree.XMLSyntaxError: **Non-failsafe**: If the given file(-handle) has invalid XML
+    :raises KeyError: **Non-failsafe**: If a required namespace has not been declared on the XML document
+    :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError): **Non-failsafe**: Errors during
+                                                                                  construction of the objects
     :return: The constructed object or None, if an error occurred in failsafe mode.
     """
     decoder_ = _select_decoder(failsafe, stripped, decoder)
@@ -1419,6 +1425,14 @@ def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identif
                      This parameter is ignored if a decoder class is specified.
     :param decoder: The decoder class used to decode the XML elements
     :param parser_kwargs: Keyword arguments passed to the XMLParser constructor
+    :raises ~lxml.etree.XMLSyntaxError: **Non-failsafe**: If the given file(-handle) has invalid XML
+    :raises KeyError: **Non-failsafe**: If a required namespace has not been declared on the XML document
+    :raises KeyError: **Non-failsafe**: Encountered a duplicate identifier
+    :raises KeyError: Encountered an identifier that already exists in the given ``object_store`` with both
+                     ``replace_existing`` and ``ignore_existing`` set to ``False``
+    :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError): **Non-failsafe**: Errors during
+                                                                                  construction of the objects
+    :raises TypeError: **Non-failsafe**: Encountered an undefined top-level list (e.g. ``<aas:submodels1>``)
     :return: A set of :class:`Identifiers <basyx.aas.model.base.Identifier>` that were added to object_store
     """
     ret: Set[model.Identifier] = set()
@@ -1478,6 +1492,12 @@ def read_aas_xml_file(file: PathOrIO, **kwargs: Any) -> model.DictObjectStore[mo
 
     :param file: A filename or file-like object to read the XML-serialized data from
     :param kwargs: Keyword arguments passed to :meth:`~basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into`
+    :raises ~lxml.etree.XMLSyntaxError: **Non-failsafe**: If the given file(-handle) has invalid XML
+    :raises KeyError: **Non-failsafe**: If a required namespace has not been declared on the XML document
+    :raises KeyError: **Non-failsafe**: Encountered a duplicate identifier
+    :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError): **Non-failsafe**: Errors during
+                                                                                  construction of the objects
+    :raises TypeError: **Non-failsafe**: Encountered an undefined top-level list (e.g. ``<aas:submodels1>``)
     :return: A :class:`~basyx.aas.model.provider.DictObjectStore` containing all AAS objects from the XML file
     """
     object_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()

--- a/basyx/aas/adapter/xml/xml_serialization.py
+++ b/basyx/aas/adapter/xml/xml_serialization.py
@@ -16,10 +16,21 @@ How to use:
 - For serializing any object to an XML fragment, that fits the XML specification from 'Details of the
   Asset Administration Shell', chapter 5.4, check out ``<class_name>_to_xml()``. These functions return
   an :class:`~lxml.etree.Element` object to be serialized into XML.
+
+.. attention::
+    Unlike the XML deserialization and the JSON (de-)serialization, the XML serialization only supports
+    :class:`~typing.BinaryIO` and not :class:`~typing.TextIO`. Thus, if you open files by yourself, you have to open
+    them in binary mode, see the mode table of :func:`open`.
+
+    .. code:: python
+
+        # wb = open for writing + binary mode
+        with open("example.xml", "wb") as fp:
+            write_aas_xml_file(fp, object_store)
 """
 
 from lxml import etree  # type: ignore
-from typing import Dict, IO, Optional, Type
+from typing import Dict, Optional, Type
 import base64
 
 from basyx.aas import model
@@ -840,14 +851,14 @@ def basic_event_element_to_xml(obj: model.BasicEventElement, tag: str = NS_AAS+"
 # ##############################################################
 
 
-def write_aas_xml_file(file: IO,
+def write_aas_xml_file(file: _generic.PathOrBinaryIO,
                        data: model.AbstractObjectStore,
                        **kwargs) -> None:
     """
     Write a set of AAS objects to an Asset Administration Shell XML file according to 'Details of the Asset
     Administration Shell', chapter 5.4
 
-    :param file: A file-like object to write the XML-serialized data to
+    :param file: A filename or file-like object to write the XML-serialized data to
     :param data: :class:`ObjectStore <basyx.aas.model.provider.AbstractObjectStore>` which contains different objects of
                  the AAS meta model which should be serialized to an XML file
     :param kwargs: Additional keyword arguments to be passed to :meth:`~lxml.etree.ElementTree.write`

--- a/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -108,18 +108,13 @@ submodel.update()
 aashell.update()
 
 # step 4.3: writing the contents of the ObjectStore to a JSON file
-# Heads up! It is important to open the file in text-mode with utf-8 encoding!
-with open('data.json', 'w', encoding='utf-8') as json_file:
-    basyx.aas.adapter.json.write_aas_json_file(json_file, obj_store)
+basyx.aas.adapter.json.write_aas_json_file('data.json', obj_store)
 
 # We can pass the additional keyword argument `indent=4` to `write_aas_json_file()` to format the JSON file in a more
 # human-readable (but much more space-consuming) manner.
 
 # step 4.4: writing the contents of the ObjectStore to an XML file
-# Heads up! For writing XML files -- in contrast to writing JSON --, the file must be opened in binary mode! The XML
-# writer will handle character encoding internally.
-with open('data.xml', 'wb') as xml_file:
-    basyx.aas.adapter.xml.write_aas_xml_file(xml_file, obj_store)
+basyx.aas.adapter.xml.write_aas_xml_file('data.xml', obj_store)
 
 
 ##################################################################
@@ -127,19 +122,13 @@ with open('data.xml', 'wb') as xml_file:
 ##################################################################
 
 # step 5.1: reading contents of the JSON file as an ObjectStore
-# Heads up! It is important to open the file in text-mode with utf-8 encoding! Using 'utf-8-sig' is recommended to
-# handle unicode Byte Order Marks (BOM) correctly.
-with open('data.json', encoding='utf-8-sig') as json_file:
-    json_file_data = basyx.aas.adapter.json.read_aas_json_file(json_file)
+json_file_data = basyx.aas.adapter.json.read_aas_json_file('data.json')
 
 # By passing the `failsafe=False` argument to `read_aas_json_file()`, we can switch to the `StrictAASFromJsonDecoder`
 # (see step 3) for a stricter error reporting.
 
 # step 5.2: reading contents of the XML file as an ObjectStore
-# Heads up! For reading XML files -- in contrast to reading JSON --, the file must be opened in binary mode! The XML
-# writer will handle character encoding internally.
-with open('data.xml', 'rb') as xml_file:
-    xml_file_data = basyx.aas.adapter.xml.read_aas_xml_file(xml_file)
+xml_file_data = basyx.aas.adapter.xml.read_aas_xml_file('data.xml')
 
 # Again, we can use `failsafe=False` for switching on stricter error reporting in the parser.
 

--- a/test/adapter/json/test_json_serialization_deserialization.py
+++ b/test/adapter/json/test_json_serialization_deserialization.py
@@ -16,6 +16,8 @@ from basyx.aas.examples.data import example_aas_missing_attributes, example_aas,
     example_aas_mandatory_attributes, example_submodel_template, create_example
 from basyx.aas.examples.data._helper import AASDataChecker
 
+from typing import Iterable, IO
+
 
 class JsonSerializationDeserializationTest(unittest.TestCase):
     def test_random_object_serialization_deserialization(self) -> None:
@@ -41,15 +43,17 @@ class JsonSerializationDeserializationTest(unittest.TestCase):
         json_object_store = read_aas_json_file(io.StringIO(json_data), failsafe=False)
 
     def test_example_serialization_deserialization(self) -> None:
-        data = example_aas.create_full_example()
-        file = io.StringIO()
-        write_aas_json_file(file=file, data=data)
+        # test with TextIO and BinaryIO, which should both be supported
+        t: Iterable[IO] = (io.StringIO(), io.BytesIO())
+        for file in t:
+            data = example_aas.create_full_example()
+            write_aas_json_file(file=file, data=data)
 
-        # try deserializing the json string into a DictObjectStore of AAS objects with help of the json module
-        file.seek(0)
-        json_object_store = read_aas_json_file(file, failsafe=False)
-        checker = AASDataChecker(raise_immediately=True)
-        example_aas.check_full_example(checker, json_object_store)
+            # try deserializing the json string into a DictObjectStore of AAS objects with help of the json module
+            file.seek(0)
+            json_object_store = read_aas_json_file(file, failsafe=False)
+            checker = AASDataChecker(raise_immediately=True)
+            example_aas.check_full_example(checker, json_object_store)
 
 
 class JsonSerializationDeserializationTest2(unittest.TestCase):

--- a/test/adapter/xml/test_xml_serialization_deserialization.py
+++ b/test/adapter/xml/test_xml_serialization_deserialization.py
@@ -9,7 +9,8 @@ import io
 import unittest
 
 from basyx.aas import model
-from basyx.aas.adapter.xml import write_aas_xml_file, read_aas_xml_file
+from basyx.aas.adapter.xml import write_aas_xml_file, read_aas_xml_file, write_aas_xml_element, read_aas_xml_element, \
+    XMLConstructables
 
 from basyx.aas.examples.data import example_aas_missing_attributes, example_aas, \
     example_aas_mandatory_attributes, example_submodel_template, create_example
@@ -53,3 +54,15 @@ class XMLSerializationDeserializationTest(unittest.TestCase):
         object_store = _serialize_and_deserialize(data)
         checker = AASDataChecker(raise_immediately=True)
         checker.check_object_store(object_store, data)
+
+
+class XMLSerializationDeserializationSingleObjectTest(unittest.TestCase):
+    def test_submodel_serialization_deserialization(self) -> None:
+        submodel: model.Submodel = example_submodel_template.create_example_submodel_template()
+        bytes_io = io.BytesIO()
+        write_aas_xml_element(bytes_io, submodel)
+        bytes_io.seek(0)
+        submodel2: model.Submodel = read_aas_xml_element(bytes_io,  # type: ignore[assignment]
+                                                         XMLConstructables.SUBMODEL, failsafe=False)
+        checker = AASDataChecker(raise_immediately=True)
+        checker.check_submodel_equal(submodel2, submodel)


### PR DESCRIPTION
lxml supports paths already, no modification is necessary there.
However, the `lxml.etree.ElementTree.write()` function requires
`BinaryIO`, i.e. files opened with the 'b' mode. While it would be
possible to access the underlying binary buffer of files opened in text
mode via `open()`, this isn't possible for `io.StringIO()`, as it
doesn't have the `buffer` property. Thus, even if we could support files
opened via `open()` in text mode, we couldn't annotate the XML
serialization functions with `TextIO`, as `io.StringIO()` remains
unsupported. Because of that, I decided to not support `TextIO` for the
XML serialization.

The builtin JSON module only supports file handles, with the
`json.dump()` method only supporting `TextIO` and `json.load()`
supporting `TextIO` and `BinaryIO`. Thus, the JSON adapter is modified
to `open()` given paths, while the JSON serialization is additionally
modified to wrap `BinaryIO` with `io.TextIOWrapper`.

Fix https://github.com/eclipse-basyx/basyx-python-sdk/issues/42