### PR TITLE
`adapter.xml`: minor improvements

### DIFF
--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -315,8 +315,8 @@ def _failsafe_construct_mandatory(element: etree.Element, constructor: Callable[
     """
     constructed = _failsafe_construct(element, constructor, False, **kwargs)
     if constructed is None:
-        raise TypeError("The result of a non-failsafe _failsafe_construct() call was None! "
-                        "This is a bug in the Eclipse BaSyx Python SDK XML deserialization, please report it!")
+        raise AssertionError("The result of a non-failsafe _failsafe_construct() call was None! "
+                             "This is a bug in the Eclipse BaSyx Python SDK XML deserialization, please report it!")
     return constructed
 
 

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -333,6 +333,22 @@ class XmlDeserializationTest(unittest.TestCase):
         submodel = read_aas_xml_element(bytes_io, XMLConstructables.SUBMODEL)
         self.assertIsInstance(submodel, model.Submodel)
 
+    def test_no_namespace_prefix(self) -> None:
+        def xml(id_: str) -> str:
+            return f"""
+            <environment xmlns="{XML_NS_MAP["aas"]}">
+                <submodels>
+                    <submodel>
+                        <id>{id_}</id>
+                    </submodel>
+                </submodels>
+            </environment>
+            """
+
+        self._assertInExceptionAndLog(xml(""), f'{{{XML_NS_MAP["aas"]}}}id on line 5 has no text', KeyError,
+                                      logging.ERROR)
+        read_aas_xml_file(io.StringIO(xml("urn:x-test:test-submodel")))
+
 
 class XmlDeserializationStrippedObjectsTest(unittest.TestCase):
     def test_stripped_qualifiable(self) -> None:


### PR DESCRIPTION
The type of an exception is changed from `TypeError` to `AssertionError`. The exception marks an error in the program, the previous declaration as `TypeError` was incorrect.

Furthermore, a test for XML without namespace prefixes is added, which wasn't tested previously (see #33).