### PR TITLE
adapter.xml: rename `XMLConstructables.GLOBAL_REFERENCE`

### DIFF
--- a/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1249,7 +1249,7 @@ class XMLConstructables(enum.Enum):
     KEY = enum.auto()
     REFERENCE = enum.auto()
     MODEL_REFERENCE = enum.auto()
-    GLOBAL_REFERENCE = enum.auto()
+    EXTERNAL_REFERENCE = enum.auto()
     ADMINISTRATIVE_INFORMATION = enum.auto()
     QUALIFIER = enum.auto()
     SECURITY = enum.auto()
@@ -1316,7 +1316,7 @@ def read_aas_xml_element(file: IO, construct: XMLConstructables, failsafe: bool 
         constructor = decoder_.construct_reference
     elif construct == XMLConstructables.MODEL_REFERENCE:
         constructor = decoder_.construct_model_reference
-    elif construct == XMLConstructables.GLOBAL_REFERENCE:
+    elif construct == XMLConstructables.EXTERNAL_REFERENCE:
         constructor = decoder_.construct_external_reference
     elif construct == XMLConstructables.ADMINISTRATIVE_INFORMATION:
         constructor = decoder_.construct_administrative_information


### PR DESCRIPTION
`GlobalReference` has been renamed to `ExternalReference` in V3, but this enum member has been missed in the rename.

This is technically a breaking change (which is why I pushed it to a separate branch), but I doubt that anyone really uses the deserialization of single objects, most people can't even use the normal deserialization due to wrong XML namespaces and OPC relationship types.