### PR TITLE
backend, model: remove calls to trivial super().__init__() methods

### DIFF
--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -246,7 +246,6 @@ class CouchDBObjectStore(model.AbstractObjectStore):
         :param url: URL to the CouchDB
         :param database: Name of the Database inside the CouchDB
         """
-        super().__init__()
         self.url: str = url
         self.database_name: str = database
 

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -77,7 +77,6 @@ class LocalFileObjectStore(model.AbstractObjectStore):
 
         :param directory_path: Path to the local file backend (the path where you want to store your AAS JSON files)
         """
-        super().__init__()
         self.directory_path: str = directory_path.rstrip("/")
 
         # A dictionary of weak references to local replications of stored objects. Objects are kept in this cache as

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -2377,7 +2377,6 @@ class DataSpecificationIEC61360(DataSpecificationContent):
                  value: Optional[ValueTypeIEC61360] = None,
                  level_types: Iterable[IEC61360LevelType] = ()):
 
-        super().__init__()
         self.preferred_name: PreferredNameTypeIEC61360 = preferred_name
         self.short_name: Optional[ShortNameTypeIEC61360] = short_name
         self.data_type: Optional[DataTypeIEC61360] = data_type

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -86,7 +86,6 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
     :class:`~basyx.aas.model.base.Identifier` → :class:`~basyx.aas.model.base.Identifiable`
     """
     def __init__(self, objects: Iterable[_IT] = ()) -> None:
-        super().__init__()
         self._backend: Dict[Identifier, _IT] = {}
         for x in objects:
             self.add(x)


### PR DESCRIPTION
These are unsafe, according to mypy:
```
error: Call to abstract method "__init__" of "DataSpecificationContent" with trivial body via super() is unsafe  [safe-super]
```