### PR TITLE
backport: backend, model: remove calls to trivial super().__init__() methods

### DIFF
--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -244,7 +244,6 @@ class CouchDBObjectStore(model.AbstractObjectStore):
         :param url: URL to the CouchDB
         :param database: Name of the Database inside the CouchDB
         """
-        super().__init__()
         self.url: str = url
         self.database_name: str = database
 

--- a/basyx/aas/backend/local_file.py
+++ b/basyx/aas/backend/local_file.py
@@ -78,7 +78,6 @@ class LocalFileObjectStore(model.AbstractObjectStore):
 
         :param directory_path: Path to the local file backend (the path where you want to store your AAS JSON files)
         """
-        super().__init__()
         self.directory_path: str = directory_path.rstrip("/")
 
         # A dictionary of weak references to local replications of stored objects. Objects are kept in this cache as

--- a/basyx/aas/model/base.py
+++ b/basyx/aas/model/base.py
@@ -867,7 +867,6 @@ class Formula(Constraint):
         """
         TODO: Add instruction what to do after construction
         """
-        super().__init__()
         self.depends_on: Set[Reference] = set() if depends_on is None else depends_on
 
 
@@ -894,7 +893,6 @@ class Qualifier(Constraint, HasSemantics):
         """
         TODO: Add instruction what to do after construction
         """
-        super().__init__()
         self.type: QualifierType = type_
         self.value_type: Type[datatypes.AnyXSDType] = value_type
         self._value: Optional[ValueDataType] = datatypes.trivial_cast(value, value_type) if value is not None else None

--- a/basyx/aas/model/provider.py
+++ b/basyx/aas/model/provider.py
@@ -82,7 +82,6 @@ class DictObjectStore(AbstractObjectStore[_IT], Generic[_IT]):
     :class:`~aas.model.base.Identifier` → :class:`~aas.model.base.Identifiable`
     """
     def __init__(self, objects: Iterable[_IT] = ()) -> None:
-        super().__init__()
         self._backend: Dict[Identifier, _IT] = {}
         for x in objects:
             self.add(x)


### PR DESCRIPTION
These are unsafe, according to mypy:
```
error: Call to abstract method "__init__" of "DataSpecificationContent" with trivial body via super() is unsafe  [safe-super]
```

This is a backport of #261.