### PR TITLE
docs: improve the documentation of the `PyECMA376-2` intersphinx workaround

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,8 @@ intersphinx_mapping = {
 
 def on_missing_reference(app, env, node, contnode):
     path = node["reftarget"].split(".")
-    # pyecma376_2 doesn't have a documentation we can link to, so suppress missing reference warnings.
+    # TODO: pyecma376_2 doesn't have a documentation we can link to, so suppress missing reference warnings.
+    #  see: https://github.com/rwth-iat/PyECMA376-2/issues/3
     if path[0] == "pyecma376_2":
         return contnode
     # lxml uses _Element instead of Element and _ElementTree instead of ElementTree in its documentation,


### PR DESCRIPTION
Since `PyECMA376-2` doesn't have a documentation we can link to, we ignore missing reference warnings caused by this problem. The visibility of this workaround is improved by making it a `TODO` instead of a regular comment. Furthermore, it now links to the corresponding issue.