### PR TITLE
test_xml_deserialization: Add tests for `_tag_replace_namespace`

### DIFF
--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -12,11 +12,10 @@ import unittest
 from basyx.aas import model
 from basyx.aas.adapter.xml import StrictAASFromXmlDecoder, XMLConstructables, read_aas_xml_file, \
     read_aas_xml_file_into, read_aas_xml_element
+from basyx.aas.adapter.xml.xml_deserialization import _tag_replace_namespace
 from basyx.aas.adapter._generic import XML_NS_MAP
 from lxml import etree
 from typing import Iterable, Type, Union
-
-from basyx.aas.adapter.xml.xml_deserialization import _tag_replace_namespace
 
 
 def _xml_wrap(xml: str) -> str:

--- a/test/adapter/xml/test_xml_deserialization.py
+++ b/test/adapter/xml/test_xml_deserialization.py
@@ -16,6 +16,8 @@ from basyx.aas.adapter._generic import XML_NS_MAP
 from lxml import etree
 from typing import Iterable, Type, Union
 
+from basyx.aas.adapter.xml.xml_deserialization import _tag_replace_namespace
+
 
 def _xml_wrap(xml: str) -> str:
     return f'<aas:environment xmlns:aas="{XML_NS_MAP["aas"]}">{xml}</aas:environment>'
@@ -449,3 +451,29 @@ class XmlDeserializationDerivingTest(unittest.TestCase):
         self.assertIsInstance(submodel, EnhancedSubmodel)
         assert isinstance(submodel, EnhancedSubmodel)
         self.assertEqual(submodel.enhanced_attribute, "fancy!")
+
+
+class TestTagReplaceNamespace(unittest.TestCase):
+    def test_known_namespace(self):
+        tag = '{https://admin-shell.io/aas/3/0}tag'
+        expected = 'aas:tag'
+        self.assertEqual(_tag_replace_namespace(tag, XML_NS_MAP), expected)
+
+    def test_empty_prefix(self):
+        # Empty prefix should not be replaced as otherwise it would apply everywhere
+        tag = '{https://admin-shell.io/aas/3/0}tag'
+        nsmap = {"": "https://admin-shell.io/aas/3/0"}
+        expected = '{https://admin-shell.io/aas/3/0}tag'
+        self.assertEqual(_tag_replace_namespace(tag, nsmap), expected)
+
+    def test_empty_namespace(self):
+        # Empty namespaces should also have no effect
+        tag = '{https://admin-shell.io/aas/3/0}tag'
+        nsmap = {"aas": ""}
+        expected = '{https://admin-shell.io/aas/3/0}tag'
+        self.assertEqual(_tag_replace_namespace(tag, nsmap), expected)
+
+    def test_unknown_namespace(self):
+        tag = '{http://unknownnamespace.com}unknown'
+        expected = '{http://unknownnamespace.com}unknown'  # Unknown namespace should remain unchanged
+        self.assertEqual(_tag_replace_namespace(tag, XML_NS_MAP), expected)


### PR DESCRIPTION
Added new tests covering the `_tag_replace_namespace` function in `xml_deserialisation.py` therefore improving test coverage:

Before:
```
basyx\aas\adapter\xml\xml_deserialization.py                     764     83    458     60    85% 90->89, 92,
```
After:
```
basyx\aas\adapter\xml\xml_deserialization.py                     764     82    458     58    86%
```