### PR TITLE
aas.backend: Support urllib3 version 2

### DIFF
--- a/basyx/aas/backend/couchdb.py
+++ b/basyx/aas/backend/couchdb.py
@@ -13,7 +13,7 @@ The :class:`~.CouchDBBackend` takes care of updating and committing objects from
 """
 import threading
 import weakref
-from typing import List, Dict, Any, Optional, Iterator, Iterable, Union, Tuple
+from typing import List, Dict, Any, Optional, Iterator, Iterable, Union, Tuple, MutableMapping
 import urllib.parse
 import urllib.request
 import urllib.error
@@ -108,7 +108,7 @@ class CouchDBBackend(backends.Backend):
 
     @classmethod
     def do_request(cls, url: str, method: str = "GET", additional_headers: Dict[str, str] = {},
-                   body: Optional[bytes] = None) -> Dict[str, Any]:
+                   body: Optional[bytes] = None) -> MutableMapping[str, Any]:
         """
         Perform an HTTP(S) request to the CouchDBServer, parse the result and handle errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.8"
 dependencies = [
     "python-dateutil>=2.8,<3",
     "lxml>=4.2,<5",
-    "urllib3>=1.26,<2.0",
+    "urllib3>=1.26,<3",
     "pyecma376-2>=0.2.4"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ lxml>=4.2,<5
 python-dateutil>=2.8,<3.0
 types-python-dateutil
 pyecma376-2>=0.2.4
-urllib3>=1.26,<2.0
+urllib3>=1.26,<3
 Werkzeug>=3.0.3,<4
 schemathesis~=3.7
 hypothesis~=6.13


### PR DESCRIPTION
The previous version contraint `urllib3>=1.26,<2.0` is verry restrictive.
I need to use the SDK in a project together with other libs (e.g. gradio) that require urlib3 >= 2.

I widened the version constraint according to [urllib3 migration guide](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#migrating-as-a-package-maintainer) and did't see any deprecation warnings (hopefully i turned them on correctly).