### PR TITLE
model.datatypes: fix error when copy Dates

### DIFF
--- a/basyx/aas/model/datatypes.py
+++ b/basyx/aas/model/datatypes.py
@@ -78,6 +78,17 @@ class Date(datetime.date):
         other_tzinfo = other.tzinfo if hasattr(other, 'tzinfo') else None  # type: ignore
         return datetime.date.__eq__(self, other) and self.tzinfo == other_tzinfo
 
+    def __copy__(self):
+        cls = self.__class__
+        result = cls.__new__(cls, self.year, self.month, self.day, self.tzinfo)
+        return result
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls, self.year, self.month, self.day, self.tzinfo)
+        memo[id(self)] = result
+        return result
+
     # TODO override comparsion operators
     # TODO add into_datetime function
     # TODO add includes(:DateTime) -> bool function

--- a/test/model/test_datatypes.py
+++ b/test/model/test_datatypes.py
@@ -7,6 +7,7 @@
 import datetime
 import math
 import unittest
+import copy
 
 import dateutil
 
@@ -176,6 +177,13 @@ class TestDateTimeTypes(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             model.datatypes.from_xsd("10-10", model.datatypes.GYearMonth)
         self.assertEqual("Value is not a valid XSD GYearMonth string", str(cm.exception))
+
+    def test_copy_date(self) -> None:
+        date = model.datatypes.Date(2020, 1, 24)
+        date_copy_shallow = copy.copy(date)
+        self.assertEqual(date, date_copy_shallow)
+        date_copy_deep = copy.deepcopy(date)
+        self.assertEqual(date, date_copy_deep)
 
     def test_serialize_partial_dates(self) -> None:
         self.assertEqual("2019", model.datatypes.xsd_repr(model.datatypes.GYear(2019)))


### PR DESCRIPTION
Currently, the copy of a submodel with Date properties using pythons built-in `copy.copy` or `copy.deepcopy` fails with the following error:

>  File "basyx-python-sdk\basyx\aas\model\datatypes.py", line 49, in __new__
>    res: "Date" = datetime.date.__new__(cls, year, month, day)  # type: ignore  # pickle support is not in typeshed
>TypeError: 'bytes' object cannot be interpreted as an integer

The error can be reproduced with (see test added in this PR):
```py
import copy
from basyx.aas import model

date = model.datatypes.Date(2020, 1, 24)
date_copy_shallow = copy.copy(date) # will Fail
date_copy_deep = copy.deepcopy(date) # will Fail
```

I don't know where the error comes from, but when the class is copied the `year` argument gets a bytestring and `month` as well as `day`are `None`.
However, overwriting `__copy__` for shallow copies and `__deepcopy__` seems to solve the issue.
