### PR TITLE
Fix "contributing" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Additionally, security fixes may be released at any point.
 
 ## Contributing
 
-For contributing with issues and code, please see our [Contribution Guideline](../CONTRIBUTING.md).
+For contributing with issues and code, please see our [Contribution Guideline](./CONTRIBUTING.md).
 
 ### Eclipse Contributor Agreement
 


### PR DESCRIPTION
We fix a broken link in the toplevel `README.md`,  namely the one to the `CONTRIBUTING.md`

Fixes #321