### PR TITLE
Update to Part 1 (Metamodel) version 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ The Eclipse BaSyx Python project focuses on providing a Python implementation of
 for Industry 4.0 Systems. 
 These are the currently implemented specifications:
 
-| Specification                         | Version                                                                                                                                                                        |
-|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Part 1: Metamodel                     | [v3.0 (01001-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/06/IDTA-01001-3-0_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf)                      |
-| Schemata (JSONSchema, XSD)            | [v3.0.8 (IDTA-01001-3-0-1_schemasV3.0.8)](https://github.com/admin-shell-io/aas-specs/releases/tag/IDTA-01001-3-0-1_schemasV3.0.8)                                             |
-| Part 2: API                           | [v3.0 (01002-3-0)](https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2023/06/IDTA-01002-3-0_SpecificationAssetAdministrationShell_Part2_API_.pdf)                |
+| Specification                         | Version                                                                                                                                                                         |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Part 1: Metamodel                     | [v3.0.1 (01001-3-1)](https://industrialdigitaltwin.org/wp-content/uploads/2024/06/IDTA-01001-3-0-1_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf)                   |
+| Schemata (JSONSchema, XSD)            | [v3.0.8 (IDTA-01001-3-0-1_schemasV3.0.8)](https://github.com/admin-shell-io/aas-specs/releases/tag/IDTA-01001-3-0-1_schemasV3.0.8)                                              |
+| Part 2: API                           | [v3.0 (01002-3-0)](https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2023/06/IDTA-01002-3-0_SpecificationAssetAdministrationShell_Part2_API_.pdf)                 |
 | Part 3a: Data Specification IEC 61360 | [v3.0 (01003-a-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01003-a-3-0_SpecificationAssetAdministrationShell_Part3a_DataSpecification_IEC61360.pdf) |
-| Part 5: Package File Format (AASX)    | [v3.0 (01005-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01005-3-0_SpecificationAssetAdministrationShell_Part5_AASXPackageFileFormat.pdf)          |
+| Part 5: Package File Format (AASX)    | [v3.0 (01005-3-0)](https://industrialdigitaltwin.org/wp-content/uploads/2023/04/IDTA-01005-3-0_SpecificationAssetAdministrationShell_Part5_AASXPackageFileFormat.pdf)           |
 
 ## Features
 This repository is structured into separate packages. 

--- a/sdk/basyx/aas/model/_string_constraints.py
+++ b/sdk/basyx/aas/model/_string_constraints.py
@@ -84,7 +84,7 @@ def check_name_type(value: str, type_name: str = "NameType") -> None:
 
 
 def check_path_type(value: str, type_name: str = "PathType") -> None:
-    return check_identifier(value, type_name)
+    return check(value, type_name, 1, 2000)
 
 
 def check_qualifier_type(value: str, type_name: str = "QualifierType") -> None:


### PR DESCRIPTION
This updates the `sdk` to version 3.0.1 of the metamodel. Since this was a minor bugfix release, there are only a handful of changes and only one that actually affects our SDK (as the rest of the changes were editorial):

Remove the pattern check from `PathType`. Effectively, that means we remove the pattern from the  `_string_constraints.check_path_type` method. See: [aas-core#334](https://github.com/aas-core-works/aas-core-meta/pull/334).

Furthermore, we update the version table in the `README.md`.

Here's the link to the [specification changelog](https://industrialdigitaltwin.org/wp-content/uploads/2024/06/IDTA-01001-3-0-1_SpecificationAssetAdministrationShell_Part1_Metamodel.pdf#Page=150)
