### PR TITLE
Use dir() instead of vars() in `Referable.update_from()`

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -811,15 +811,25 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         :param update_source: Update the source attribute with the other's source attribute. This is not propagated
                               recursively
         """
-        for name, var in vars(other).items():
-            # do not update the parent, namespace_element_sets or source (depending on update_source parameter)
-            if name in ("parent", "namespace_element_sets") or name == "source" and not update_source:
+        for name in dir(other):
+            # Skip private and protected attributes
+            if name.startswith('_'):
                 continue
-            if isinstance(var, NamespaceSet):
+
+            # Do not update 'parent', 'namespace_element_sets', or 'source' (depending on update_source parameter)
+            if name in ("parent", "namespace_element_sets") or (name == "source" and not update_source):
+                continue
+
+            # Skip methods
+            attr = getattr(other, name)
+            if callable(attr):
+                continue
+
+            if isinstance(attr, NamespaceSet):
                 # update the elements of the NameSpaceSet
-                vars(self)[name].update_nss_from(var)
+                getattr(self, name).update_nss_from(attr)
             else:
-                vars(self)[name] = var  # that variable is not a NameSpaceSet, so it isn't Referable
+                setattr(self, name, attr)  # that variable is not a NameSpaceSet, so it isn't Referable
 
     def commit(self) -> None:
         """
@@ -2068,11 +2078,11 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
                 elif isinstance(other_object, Qualifier):
                     backend, case_sensitive = self._backend["type"]
                     qualifier = backend[other_object.type if case_sensitive else other_object.type.upper()]
-                    # qualifier.update_from(other_object, update_source=True) # TODO: What should happend here?
+                    # qualifier.update_from(other_object, update_source=True) # TODO: What should happen here?
                 elif isinstance(other_object, Extension):
                     backend, case_sensitive = self._backend["name"]
                     extension = backend[other_object.name if case_sensitive else other_object.name.upper()]
-                    # extension.update_from(other_object, update_source=True) # TODO: What should happend here?
+                    # extension.update_from(other_object, update_source=True) # TODO: What should happen here?
                 else:
                     raise TypeError("Type not implemented")
             except KeyError:


### PR DESCRIPTION
vars() only retrieves the instance's
__dict__—that is, the object's
 attributes—but does not include
  properties.
As a result, when you use vars(other),
 you get the _id_short attribute instead
  of the id_short property.

  dir() iterates over all attributes and
   properties of the object.
   We skip callables and private attrs.
   We use setattr() to set attributes and
    properties, so setter funcs will be
    used.

Fixes #215 