### PR TITLE
Fix typos and refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,10 @@ The following guidelines are for the commit or PR message text:
 
 ## Codestyle and Testing
 
-Our code follows the [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
+Our code follows the [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
+with the following exceptions:
+- Line length is allowed to be up to 120 characters, though lines up to 100 characters are preferred.
+
 Additionally, we use [PEP 484 -- Type Hints](https://www.python.org/dev/peps/pep-0484/) throughout the code to enable type checking the code.
 
 Before submitting any changes, make sure to let `mypy` and `pycodestyle` check your code and run the unit tests with

--- a/sdk/basyx/aas/__init__.py
+++ b/sdk/basyx/aas/__init__.py
@@ -2,9 +2,9 @@
 The package consists of the python implementation of the AssetAdministrationShell, as defined in the
 'Details of the Asset Administration Shell' specification of Plattform Industrie 4.0.
 
-The subpackage 'model' is an implementation of the meta-model of the AAS,
+The subpackage 'model' is an implementation of the metamodel of the AAS,
 in 'adapter', you can find JSON and XML adapters to translate between BaSyx Python SDK objects and JSON/XML schemas;
-and in 'util', some helpful functionality to actually use the AAS meta-model you created with 'model' is located.
+and in 'util', some helpful functionality to actually use the AAS metamodel you created with 'model' is located.
 """
 
 __version__ = "1.0.0"

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -147,17 +147,19 @@ class AASXReader:
 
         read_identifiables: Set[model.Identifier] = set()
 
+        no_aas_files_found = True
         # Iterate AAS files
-        for aas_part in self.reader.get_related_parts_by_type(aasx_origin_part)[
-                RELATIONSHIP_TYPE_AAS_SPEC]:
+        for aas_part in self.reader.get_related_parts_by_type(aasx_origin_part)[RELATIONSHIP_TYPE_AAS_SPEC]:
+            no_aas_files_found = False
             self._read_aas_part_into(aas_part, object_store, file_store,
                                      read_identifiables, override_existing, **kwargs)
 
             # Iterate split parts of AAS file
-            for split_part in self.reader.get_related_parts_by_type(aas_part)[
-                    RELATIONSHIP_TYPE_AAS_SPEC_SPLIT]:
+            for split_part in self.reader.get_related_parts_by_type(aas_part)[RELATIONSHIP_TYPE_AAS_SPEC_SPLIT]:
                 self._read_aas_part_into(split_part, object_store, file_store,
                                          read_identifiables, override_existing, **kwargs)
+        if no_aas_files_found:
+            logger.warning("No AAS files found in AASX package")
 
         return read_identifiables
 

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -82,11 +82,11 @@ class AASXReader:
 
     def get_core_properties(self) -> pyecma376_2.OPCCoreProperties:
         """
-        Retrieve the OPC Core Properties (meta data) of the AASX package file.
+        Retrieve the OPC Core Properties (metadata) of the AASX package file.
 
-        If no meta data is provided in the package file, an emtpy OPCCoreProperties object is returned.
+        If no metadata is provided in the package file, an emtpy OPCCoreProperties object is returned.
 
-        :return: The AASX package's meta data
+        :return: The AASX package's metadata
         """
         return self.reader.get_core_properties()
 
@@ -191,7 +191,7 @@ class AASXReader:
         :param read_identifiables: A set of Identifiers of objects which have already been read. New objects'
             Identifiers are added to this set. Objects with already known Identifiers are skipped silently.
         :param override_existing: If True, existing objects in the object store are overridden with objects from the
-            AASX that have the same Identifer. Default behavior is to skip those objects from the AASX.
+            AASX that have the same Identifier. Default behavior is to skip those objects from the AASX.
         """
         for obj in self._parse_aas_part(part_name, **kwargs):
             if obj.id in read_identifiables:
@@ -380,7 +380,7 @@ class AASXWriter:
             except KeyError:
                 raise
             if not isinstance(aas, model.AssetAdministrationShell):
-                raise TypeError(f"Identifier {aas_id} does not belong to an AssetAdminstrationShell object but to "
+                raise TypeError(f"Identifier {aas_id} does not belong to an AssetAdministrationShell object but to "
                                 f"{aas!r}")
 
             # Add the AssetAdministrationShell object to the data part
@@ -407,10 +407,10 @@ class AASXWriter:
                 try:
                     cd = semantic_id.resolve(object_store)
                 except KeyError:
-                    logger.info("ConceptDescription for semantidId %s not found in object store.", str(semantic_id))
+                    logger.info("ConceptDescription for semanticId %s not found in object store.", str(semantic_id))
                     continue
                 except model.UnexpectedTypeError as e:
-                    logger.error("semantidId %s resolves to %s, which is not a ConceptDescription",
+                    logger.error("semanticId %s resolves to %s, which is not a ConceptDescription",
                                  str(semantic_id), e.value)
                     continue
                 concept_descriptions.append(cd)
@@ -457,7 +457,7 @@ class AASXWriter:
         :param write_json: If ``True``, the part is written as a JSON file instead of an XML file. Defaults to
             ``False``.
         :param split_part: If ``True``, no aas-spec relationship is added from the aasx-origin to this part. You must
-            make sure to reference it via a aas-spec-split relationship from another aas-spec part
+            make sure to reference it via an aas-spec-split relationship from another aas-spec part
         :param additional_relationships: Optional OPC/ECMA376 relationships which should originate at the AAS object
             part to be written, in addition to the aas-suppl relationships which are created automatically.
         """
@@ -508,7 +508,7 @@ class AASXWriter:
             ``File`` objects within the written objects.
         :param write_json: If True, the part is written as a JSON file instead of an XML file. Defaults to False.
         :param split_part: If True, no aas-spec relationship is added from the aasx-origin to this part. You must make
-            sure to reference it via a aas-spec-split relationship from another aas-spec part
+            sure to reference it via an aas-spec-split relationship from another aas-spec part
         :param additional_relationships: Optional OPC/ECMA376 relationships which should originate at the AAS object
             part to be written, in addition to the aas-suppl relationships which are created automatically.
         """
@@ -574,12 +574,12 @@ class AASXWriter:
 
     def write_core_properties(self, core_properties: pyecma376_2.OPCCoreProperties):
         """
-        Write OPC Core Properties (meta data) to the AASX package file.
+        Write OPC Core Properties (metadata) to the AASX package file.
 
         .. Attention::
             This method may only be called once for each AASXWriter!
 
-        :param core_properties: The OPCCoreProperties object with the meta data to be written to the package file
+        :param core_properties: The OPCCoreProperties object with the metadata to be written to the package file
         """
         if self._properties_part is not None:
             raise RuntimeError("Core Properties have already been written.")
@@ -720,7 +720,7 @@ class AbstractSupplementaryFileContainer(metaclass=abc.ABCMeta):
     their name. They are used to provide associated documents without embedding their contents (as
     :class:`~basyx.aas.model.submodel.Blob` object) in the AAS.
 
-    A SupplementaryFileContainer keeps track of the name and content_type (MIME type) for each file. Additionally it
+    A SupplementaryFileContainer keeps track of the name and content_type (MIME type) for each file. Additionally, it
     allows to resolve name conflicts by comparing the files' contents and providing an alternative name for a dissimilar
     new file. It also provides each files sha256 hash sum to allow name conflict checking in other classes (e.g. when
     writing AASX files).
@@ -738,7 +738,7 @@ class AbstractSupplementaryFileContainer(metaclass=abc.ABCMeta):
         :param name: The file's proposed name. Should start with a '/'. Should not contain URI-encoded '/' or '\'
         :param file: A binary file-like opened for reading the file contents
         :param content_type: The file's content_type
-        :return: The file name as stored in the SupplementaryFileContainer. Typically ``name`` or a modified version of
+        :return: The file name as stored in the SupplementaryFileContainer. Typically, ``name`` or a modified version of
             ``name`` to resolve conflicts.
         """
         pass  # pragma: no cover

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -662,56 +662,6 @@ class AASXWriter:
         self.writer.write_relationships(package_relationships)
 
 
-# TODO remove in future version.
-#   Not required anymore since changes from DotAAS version 2.0.1 to 3.0RC01
-class NameFriendlyfier:
-    """
-    A simple helper class to create unique "AAS friendly names" according to DotAAS, section 7.6.
-
-    Objects of this class store the already created friendly names to avoid name collisions within one set of names.
-    """
-    RE_NON_ALPHANUMERICAL = re.compile(r"[^a-zA-Z0-9]")
-
-    def __init__(self) -> None:
-        self.issued_names: Set[str] = set()
-
-    def get_friendly_name(self, identifier: model.Identifier):
-        """
-        Generate a friendly name from an AAS identifier.
-
-        TODO: This information is outdated. The whole class is no longer needed.
-
-        According to section 7.6 of "Details of the Asset Administration Shell", all non-alphanumerical characters are
-        replaced with underscores. We also replace all non-ASCII characters to generate valid URIs as the result.
-        If this replacement results in a collision with a previously generated friendly name of this NameFriendlifier,
-        a number is appended with underscore to the friendly name.
-
-        Example:
-
-        .. code-block:: python
-
-            friendlyfier = NameFriendlyfier()
-            friendlyfier.get_friendly_name("http://example.com/AAS-a")
-             > "http___example_com_AAS_a"
-
-            friendlyfier.get_friendly_name("http://example.com/AAS+a")
-             >  "http___example_com_AAS_a_1"
-
-        """
-        # friendlify name
-        raw_name = self.RE_NON_ALPHANUMERICAL.sub('_', identifier)
-
-        # Unify name (avoid collisions)
-        amended_name = raw_name
-        i = 1
-        while amended_name in self.issued_names:
-            amended_name = "{}_{}".format(raw_name, i)
-            i += 1
-
-        self.issued_names.add(amended_name)
-        return amended_name
-
-
 class AbstractSupplementaryFileContainer(metaclass=abc.ABCMeta):
     """
     Abstract interface for containers of supplementary files for AASs.

--- a/sdk/basyx/aas/adapter/http.py
+++ b/sdk/basyx/aas/adapter/http.py
@@ -721,9 +721,7 @@ class WSGIApp:
 
         try:
             endpoint, values = map_adapter.match()
-            # TODO: remove this 'type: ignore' comment once the werkzeug type annotations have been fixed
-            #  https://github.com/pallets/werkzeug/issues/2836
-            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)  # type: ignore[operator]
+            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)
 
         # any raised error that leaves this function will cause a 500 internal server error
         # so catch raised http exceptions and return them

--- a/sdk/basyx/aas/adapter/http.py
+++ b/sdk/basyx/aas/adapter/http.py
@@ -721,9 +721,7 @@ class WSGIApp:
 
         try:
             endpoint, values = map_adapter.match()
-            # TODO: remove this 'type: ignore' comment once the werkzeug type annotations have been fixed
-            #  https://github.com/pallets/werkzeug/issues/2836
-            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)  # type: ignore[operator]
+            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)
 
         # any raised error that leaves this function will cause a 500 internal server error
         # so catch raised http exceptions and return them
@@ -954,10 +952,8 @@ class WSGIApp:
         parent = self._get_submodel_or_nested_submodel_element(url_args)
         if not isinstance(parent, model.UniqueIdShortNamespace):
             raise BadRequest(f"{parent!r} is not a namespace, can't add child submodel element!")
-        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         new_submodel_element = HTTPApiDecoder.request_body(request,
-                                                           model.SubmodelElement,  # type: ignore[type-abstract]
+                                                           model.SubmodelElement,
                                                            is_stripped_request(request))
         try:
             parent.add_referable(new_submodel_element)
@@ -978,10 +974,8 @@ class WSGIApp:
                                                      response_t: Type[APIResponse],
                                                      **_kwargs) -> Response:
         submodel_element = self._get_submodel_submodel_elements_id_short_path(url_args)
-        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         new_submodel_element = HTTPApiDecoder.request_body(request,
-                                                           model.SubmodelElement,  # type: ignore[type-abstract]
+                                                           model.SubmodelElement,
                                                            is_stripped_request(request))
         submodel_element.update_from(new_submodel_element)
         submodel_element.commit()

--- a/sdk/basyx/aas/adapter/http.py
+++ b/sdk/basyx/aas/adapter/http.py
@@ -721,7 +721,9 @@ class WSGIApp:
 
         try:
             endpoint, values = map_adapter.match()
-            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)
+            # TODO: remove this 'type: ignore' comment once the werkzeug type annotations have been fixed
+            #  https://github.com/pallets/werkzeug/issues/2836
+            return endpoint(request, values, response_t=response_t, map_adapter=map_adapter)  # type: ignore[operator]
 
         # any raised error that leaves this function will cause a 500 internal server error
         # so catch raised http exceptions and return them
@@ -952,8 +954,10 @@ class WSGIApp:
         parent = self._get_submodel_or_nested_submodel_element(url_args)
         if not isinstance(parent, model.UniqueIdShortNamespace):
             raise BadRequest(f"{parent!r} is not a namespace, can't add child submodel element!")
+        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
         new_submodel_element = HTTPApiDecoder.request_body(request,
-                                                           model.SubmodelElement,
+                                                           model.SubmodelElement,  # type: ignore[type-abstract]
                                                            is_stripped_request(request))
         try:
             parent.add_referable(new_submodel_element)
@@ -974,8 +978,10 @@ class WSGIApp:
                                                      response_t: Type[APIResponse],
                                                      **_kwargs) -> Response:
         submodel_element = self._get_submodel_submodel_elements_id_short_path(url_args)
+        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
         new_submodel_element = HTTPApiDecoder.request_body(request,
-                                                           model.SubmodelElement,
+                                                           model.SubmodelElement,  # type: ignore[type-abstract]
                                                            is_stripped_request(request))
         submodel_element.update_from(new_submodel_element)
         submodel_element.commit()

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -263,10 +263,12 @@ class AASFromJsonDecoder(json.JSONDecoder):
             if 'embeddedDataSpecifications' in dct:
                 for dspec in _get_ts(dct, 'embeddedDataSpecifications', list):
                     obj.embedded_data_specifications.append(
+                        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
+                        # see https://github.com/python/mypy/issues/5374
                         model.EmbeddedDataSpecification(
                             data_specification=cls._construct_reference(_get_ts(dspec, 'dataSpecification', dict)),
                             data_specification_content=_get_ts(dspec, 'dataSpecificationContent',
-                                                               model.DataSpecificationContent)
+                                                               model.DataSpecificationContent)  # type: ignore
                         )
                     )
         if isinstance(obj, model.HasExtension) and not cls.stripped:
@@ -368,7 +370,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
         Since we don't implement ``OperationVariable``, this constructor discards the wrapping ``OperationVariable``
         object and just returns the contained :class:`~basyx.aas.model.submodel.SubmodelElement`.
         """
-        return _get_ts(dct, 'value', model.SubmodelElement)
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
+        return _get_ts(dct, 'value', model.SubmodelElement)  # type: ignore
 
     @classmethod
     def _construct_lang_string_set(cls, lst: List[Dict[str, object]], object_class: Type[LSS]) -> LSS:
@@ -564,9 +568,11 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_basic_event_element(cls, dct: Dict[str, object], object_class=model.BasicEventElement) \
             -> model.BasicEventElement:
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
         ret = object_class(id_short=None,
                            observed=cls._construct_model_reference(_get_ts(dct, 'observed', dict),
-                                                                   model.Referable),
+                                                                   model.Referable),  # type: ignore
                            direction=DIRECTION_INVERSE[_get_ts(dct, "direction", str)],
                            state=STATE_OF_EVENT_INVERSE[_get_ts(dct, "state", str)])
         cls._amend_abstract_attributes(ret, dct)
@@ -607,6 +613,8 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_relationship_element(
             cls, dct: Dict[str, object], object_class=model.RelationshipElement) -> model.RelationshipElement:
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
         ret = object_class(id_short=None,
                            first=cls._construct_reference(_get_ts(dct, 'first', dict)),
                            second=cls._construct_reference(_get_ts(dct, 'second', dict)))
@@ -617,6 +625,8 @@ class AASFromJsonDecoder(json.JSONDecoder):
     def _construct_annotated_relationship_element(
             cls, dct: Dict[str, object], object_class=model.AnnotatedRelationshipElement)\
             -> model.AnnotatedRelationshipElement:
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
         ret = object_class(
             id_short=None,
             first=cls._construct_reference(_get_ts(dct, 'first', dict)),

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -12,7 +12,7 @@ Module for deserializing Asset Administration Shell data from the official JSON 
 The module provides custom JSONDecoder classes :class:`~.AASFromJsonDecoder` and :class:`~.StrictAASFromJsonDecoder` to
 be used with the Python standard :mod:`json` module.
 
-Furthermore it provides two classes :class:`~basyx.aas.adapter.json.json_deserialization.StrippedAASFromJsonDecoder` and
+Furthermore, it provides two classes :class:`~basyx.aas.adapter.json.json_deserialization.StrippedAASFromJsonDecoder` and
 :class:`~basyx.aas.adapter.json.json_deserialization.StrictStrippedAASFromJsonDecoder` for parsing stripped
 JSON objects, which are used in the http adapter (see https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91).
 The classes contain a custom :meth:`~basyx.aas.adapter.json.json_deserialization.AASFromJsonDecoder.object_hook`
@@ -83,12 +83,12 @@ def _expect_type(object_: object, type_: Type, context: str, failsafe: bool) -> 
       if _expect_type(element, model.SubmodelElement, str(submodel), failsafe):
           submodel.submodel_element.add(element)
 
-    :param object_: The object to by type-checked
+    :param object_: The object to be type-checked
     :param type_: The expected type
     :param context: A string to add to the exception message / log message, that describes the context in that the
                     object has been found
     :param failsafe: Log error and return false instead of raising a TypeError
-    :return: True if the
+    :return: True if the object is of the expected type
     :raises TypeError: If the object is not of the expected type and the failsafe mode is not active
     """
     if isinstance(object_, type_):
@@ -226,7 +226,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _amend_abstract_attributes(cls, obj: object, dct: Dict[str, object]) -> None:
         """
-        Utility method to add the optional attributes of the abstract meta classes Referable, Identifiable,
+        Utility method to add the optional attributes of the abstract metaclasses Referable, Identifiable,
         HasSemantics, HasKind and Qualifiable to an object inheriting from any of these classes, if present
 
         :param obj: The object to amend its attributes
@@ -414,7 +414,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
     # Direct Constructor Methods (for classes with `modelType`) starting from here
     # #############################################################################
 
-    # These constructor methods create objects that *are* identified by a 'modelType' JSON attribute, so they can be
+    # These constructor methods create objects that *are* identified by a 'modelType' JSON attribute, so they can
     # be called from the object_hook() method directly.
 
     @classmethod

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -613,8 +613,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_relationship_element(
             cls, dct: Dict[str, object], object_class=model.RelationshipElement) -> model.RelationshipElement:
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         ret = object_class(id_short=None,
                            first=cls._construct_reference(_get_ts(dct, 'first', dict)),
                            second=cls._construct_reference(_get_ts(dct, 'second', dict)))
@@ -625,8 +623,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
     def _construct_annotated_relationship_element(
             cls, dct: Dict[str, object], object_class=model.AnnotatedRelationshipElement)\
             -> model.AnnotatedRelationshipElement:
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         ret = object_class(
             id_short=None,
             first=cls._construct_reference(_get_ts(dct, 'first', dict)),

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -12,8 +12,8 @@ Module for deserializing Asset Administration Shell data from the official JSON 
 The module provides custom JSONDecoder classes :class:`~.AASFromJsonDecoder` and :class:`~.StrictAASFromJsonDecoder` to
 be used with the Python standard :mod:`json` module.
 
-Furthermore, it provides two classes :class:`~basyx.aas.adapter.json.json_deserialization.StrippedAASFromJsonDecoder` and
-:class:`~basyx.aas.adapter.json.json_deserialization.StrictStrippedAASFromJsonDecoder` for parsing stripped
+Furthermore, it provides two classes :class:`~basyx.aas.adapter.json.json_deserialization.StrippedAASFromJsonDecoder`
+and :class:`~basyx.aas.adapter.json.json_deserialization.StrictStrippedAASFromJsonDecoder` for parsing stripped
 JSON objects, which are used in the http adapter (see https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91).
 The classes contain a custom :meth:`~basyx.aas.adapter.json.json_deserialization.AASFromJsonDecoder.object_hook`
 function to detect encoded AAS objects within the JSON data and convert them to BaSyx Python SDK objects while parsing.

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -263,12 +263,10 @@ class AASFromJsonDecoder(json.JSONDecoder):
             if 'embeddedDataSpecifications' in dct:
                 for dspec in _get_ts(dct, 'embeddedDataSpecifications', list):
                     obj.embedded_data_specifications.append(
-                        # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
-                        # see https://github.com/python/mypy/issues/5374
                         model.EmbeddedDataSpecification(
                             data_specification=cls._construct_reference(_get_ts(dspec, 'dataSpecification', dict)),
                             data_specification_content=_get_ts(dspec, 'dataSpecificationContent',
-                                                               model.DataSpecificationContent)  # type: ignore
+                                                               model.DataSpecificationContent)
                         )
                     )
         if isinstance(obj, model.HasExtension) and not cls.stripped:
@@ -370,9 +368,7 @@ class AASFromJsonDecoder(json.JSONDecoder):
         Since we don't implement ``OperationVariable``, this constructor discards the wrapping ``OperationVariable``
         object and just returns the contained :class:`~basyx.aas.model.submodel.SubmodelElement`.
         """
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
-        return _get_ts(dct, 'value', model.SubmodelElement)  # type: ignore
+        return _get_ts(dct, 'value', model.SubmodelElement)
 
     @classmethod
     def _construct_lang_string_set(cls, lst: List[Dict[str, object]], object_class: Type[LSS]) -> LSS:
@@ -568,11 +564,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_basic_event_element(cls, dct: Dict[str, object], object_class=model.BasicEventElement) \
             -> model.BasicEventElement:
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         ret = object_class(id_short=None,
                            observed=cls._construct_model_reference(_get_ts(dct, 'observed', dict),
-                                                                   model.Referable),  # type: ignore
+                                                                   model.Referable),
                            direction=DIRECTION_INVERSE[_get_ts(dct, "direction", str)],
                            state=STATE_OF_EVENT_INVERSE[_get_ts(dct, "state", str)])
         cls._amend_abstract_attributes(ret, dct)
@@ -613,8 +607,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_relationship_element(
             cls, dct: Dict[str, object], object_class=model.RelationshipElement) -> model.RelationshipElement:
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         ret = object_class(id_short=None,
                            first=cls._construct_reference(_get_ts(dct, 'first', dict)),
                            second=cls._construct_reference(_get_ts(dct, 'second', dict)))
@@ -625,8 +617,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
     def _construct_annotated_relationship_element(
             cls, dct: Dict[str, object], object_class=model.AnnotatedRelationshipElement)\
             -> model.AnnotatedRelationshipElement:
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
         ret = object_class(
             id_short=None,
             first=cls._construct_reference(_get_ts(dct, 'first', dict)),

--- a/sdk/basyx/aas/adapter/json/json_serialization.py
+++ b/sdk/basyx/aas/adapter/json/json_serialization.py
@@ -9,7 +9,7 @@
 
 Module for serializing Asset Administration Shell objects to the official JSON format
 
-The module provides an custom JSONEncoder classes :class:`AASToJsonEncoder` and :class:`StrippedAASToJsonEncoder`
+The module provides a custom JSONEncoder classes :class:`AASToJsonEncoder` and :class:`StrippedAASToJsonEncoder`
 to be used with the Python standard :mod:`json` module. While the former serializes objects as defined in the
 specification, the latter serializes stripped objects, excluding some attributes
 (see https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91).
@@ -103,7 +103,7 @@ class AASToJsonEncoder(json.JSONEncoder):
     @classmethod
     def _abstract_classes_to_json(cls, obj: object) -> Dict[str, object]:
         """
-        transformation function to serialize abstract classes from model.base which are inherited by many classes
+        Transformation function to serialize abstract classes from model.base which are inherited by many classes
 
         :param obj: object which must be serialized
         :return: dict with the serialized attributes of the abstract classes this object inherits from
@@ -722,7 +722,7 @@ def object_store_to_json(data: model.AbstractObjectStore, stripped: bool = False
     chapter 5.5
 
     :param data: :class:`ObjectStore <basyx.aas.model.provider.AbstractObjectStore>` which contains different objects of
-                 the AAS meta model which should be serialized to a JSON file
+                 the AAS metamodel which should be serialized to a JSON file
     :param stripped: If true, objects are serialized to stripped json objects.
                      See https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91
                      This parameter is ignored if an encoder class is specified.
@@ -750,7 +750,7 @@ def write_aas_json_file(file: _generic.PathOrIO, data: model.AbstractObjectStore
 
     :param file: A filename or file-like object to write the JSON-serialized data to
     :param data: :class:`ObjectStore <basyx.aas.model.provider.AbstractObjectStore>` which contains different objects of
-                 the AAS meta model which should be serialized to a JSON file
+                 the AAS metamodel which should be serialized to a JSON file
     :param stripped: If `True`, objects are serialized to stripped json objects.
                      See https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/91
                      This parameter is ignored if an encoder class is specified.

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -534,7 +534,9 @@ class AASFromXmlDecoder:
         """
         Helper function. Doesn't support the object_class parameter. Overwrite construct_aas_reference instead.
         """
-        return cls.construct_model_reference_expect_type(element, model.Referable, **kwargs)
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
+        return cls.construct_model_reference_expect_type(element, model.Referable, **kwargs)  # type: ignore
 
     @classmethod
     def _construct_operation_variable(cls, element: etree._Element, **kwargs: Any) -> model.SubmodelElement:
@@ -588,7 +590,9 @@ class AASFromXmlDecoder:
         """
         _expect_reference_type(element, model.ModelReference)
         keys = cls._construct_key_tuple(element)
-        type_: Type[model.Referable] = model.Referable
+        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
+        # see https://github.com/python/mypy/issues/5374
+        type_: Type[model.Referable] = model.Referable  # type: ignore
         if len(keys) > 0:
             type_ = KEY_TYPES_CLASSES_INVERSE.get(keys[-1].type, model.Referable)  # type: ignore
         return object_class(keys, type_, _failsafe_construct(element.find(NS_AAS + "referredSemanticId"),

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -208,7 +208,7 @@ def _get_text_or_none(element: Optional[etree._Element]) -> Optional[str]:
     A helper function for getting the text of an element, when it's not clear whether the element exists or not.
 
     This function is useful whenever the text of an optional child element is needed.
-    Then the text can be get with: text = _get_text_or_none(element.find("childElement")
+    Then the text can be gotten with: text = _get_text_or_none(element.find("childElement")
     element.find() returns either the element or None, if it doesn't exist. This is why this function accepts
     an optional element, to reduce the amount of code in the constructor functions below.
 
@@ -274,7 +274,7 @@ def _failsafe_construct(element: Optional[etree._Element], constructor: Callable
     This is the only function of this module where exceptions are caught.
     This is why constructor functions should (in almost all cases) call other constructor functions using this function,
     so errors can be caught and logged in failsafe mode.
-    The functions accepts None as a valid value for element for the same reason _get_text_or_none() does, so it can be
+    The function accepts None as a valid value for element for the same reason _get_text_or_none() does, so it can be
     called like _failsafe_construct(element.find("childElement"), ...), since element.find() can return None.
     This function will also return None in this case.
 
@@ -423,7 +423,7 @@ class AASFromXmlDecoder:
 
     It parses XML documents in a failsafe manner, meaning any errors encountered will be logged and invalid XML elements
     will be skipped.
-    Most member functions support the ``object_class`` parameter. It was introduced so they can be overwritten
+    Most member functions support the ``object_class`` parameter. It was introduced, so they can be overwritten
     in subclasses, which allows constructing instances of subtypes.
     """
     failsafe = True
@@ -807,9 +807,9 @@ class AASFromXmlDecoder:
     @classmethod
     def construct_entity(cls, element: etree._Element, object_class=model.Entity, **_kwargs: Any) -> model.Entity:
         specific_asset_id = set()
-        specific_assset_ids = element.find(NS_AAS + "specificAssetIds")
-        if specific_assset_ids is not None:
-            for id in _child_construct_multiple(specific_assset_ids, NS_AAS + "specificAssetId",
+        specific_asset_ids = element.find(NS_AAS + "specificAssetIds")
+        if specific_asset_ids is not None:
+            for id in _child_construct_multiple(specific_asset_ids, NS_AAS + "specificAssetId",
                                                 cls.construct_specific_asset_id, cls.failsafe):
                 specific_asset_id.add(id)
 
@@ -1002,9 +1002,9 @@ class AASFromXmlDecoder:
     def construct_asset_information(cls, element: etree._Element, object_class=model.AssetInformation, **_kwargs: Any) \
             -> model.AssetInformation:
         specific_asset_id = set()
-        specific_assset_ids = element.find(NS_AAS + "specificAssetIds")
-        if specific_assset_ids is not None:
-            for id in _child_construct_multiple(specific_assset_ids, NS_AAS + "specificAssetId",
+        specific_asset_ids = element.find(NS_AAS + "specificAssetIds")
+        if specific_asset_ids is not None:
+            for id in _child_construct_multiple(specific_asset_ids, NS_AAS + "specificAssetId",
                                                 cls.construct_specific_asset_id, cls.failsafe):
                 specific_asset_id.add(id)
 
@@ -1119,9 +1119,9 @@ class AASFromXmlDecoder:
         unit_id = _failsafe_construct(element.find(NS_AAS + "unitId"), cls.construct_reference, cls.failsafe)
         if unit_id is not None:
             ds_iec.unit_id = unit_id
-        source_of_definiion = _get_text_or_none(element.find(NS_AAS + "sourceOfDefinition"))
-        if source_of_definiion is not None:
-            ds_iec.source_of_definition = source_of_definiion
+        source_of_definition = _get_text_or_none(element.find(NS_AAS + "sourceOfDefinition"))
+        if source_of_definition is not None:
+            ds_iec.source_of_definition = source_of_definition
         symbol = _get_text_or_none(element.find(NS_AAS + "symbol"))
         if symbol is not None:
             ds_iec.symbol = symbol

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -534,9 +534,7 @@ class AASFromXmlDecoder:
         """
         Helper function. Doesn't support the object_class parameter. Overwrite construct_aas_reference instead.
         """
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
-        return cls.construct_model_reference_expect_type(element, model.Referable, **kwargs)  # type: ignore
+        return cls.construct_model_reference_expect_type(element, model.Referable, **kwargs)
 
     @classmethod
     def _construct_operation_variable(cls, element: etree._Element, **kwargs: Any) -> model.SubmodelElement:
@@ -590,9 +588,7 @@ class AASFromXmlDecoder:
         """
         _expect_reference_type(element, model.ModelReference)
         keys = cls._construct_key_tuple(element)
-        # TODO: remove the following type: ignore comments when mypy supports abstract types for Type[T]
-        # see https://github.com/python/mypy/issues/5374
-        type_: Type[model.Referable] = model.Referable  # type: ignore
+        type_: Type[model.Referable] = model.Referable
         if len(keys) > 0:
             type_ = KEY_TYPES_CLASSES_INVERSE.get(keys[-1].type, model.Referable)  # type: ignore
         return object_class(keys, type_, _failsafe_construct(element.find(NS_AAS + "referredSemanticId"),

--- a/sdk/basyx/aas/adapter/xml/xml_serialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_serialization.py
@@ -350,7 +350,7 @@ def value_list_to_xml(obj: model.ValueList,
 # ##############################################################
 
 
-def specific_asset_id_to_xml(obj: model.SpecificAssetId, tag: str = NS_AAS + "specifidAssetId") \
+def specific_asset_id_to_xml(obj: model.SpecificAssetId, tag: str = NS_AAS + "specificAssetId") \
         -> etree._Element:
     """
     Serialization of objects of class :class:`~basyx.aas.model.base.SpecificAssetId` to XML
@@ -972,7 +972,7 @@ def object_store_to_xml_element(data: model.AbstractObjectStore) -> etree._Eleme
     called directly for most use-cases.
 
     :param data: :class:`ObjectStore <basyx.aas.model.provider.AbstractObjectStore>` which contains different objects of
-                 the AAS meta model which should be serialized to an XML file
+                 the AAS metamodel which should be serialized to an XML file
     """
     # separate different kind of objects
     asset_administration_shells = []
@@ -1016,7 +1016,7 @@ def write_aas_xml_file(file: _generic.PathOrBinaryIO,
 
     :param file: A filename or file-like object to write the XML-serialized data to
     :param data: :class:`ObjectStore <basyx.aas.model.provider.AbstractObjectStore>` which contains different objects of
-                 the AAS meta model which should be serialized to an XML file
+                 the AAS metamodel which should be serialized to an XML file
     :param kwargs: Additional keyword arguments to be passed to :meth:`~lxml.etree._ElementTree.write`
     """
     return _write_element(file, object_store_to_xml_element(data), **kwargs)

--- a/sdk/basyx/aas/backend/__init__.py
+++ b/sdk/basyx/aas/backend/__init__.py
@@ -1,6 +1,6 @@
 """
 This module implements a standardized way of integrating data from existing systems into AAS objects. To achieve this,
-the abstract :class:`~basyx.aas.backend.backends.Backend` class implements the classmethods
+the abstract :class:`~basyx.aas.backend.backends.Backend` class implements the class methods
 :meth:`~basyx.aas.backend.backends.Backend.update_object` and :meth:`~basyx.aas.backend.backends.Backend.commit_object`,
 which every implementation of a backend needs to overwrite. For a tutorial on how to implement a backend, see
 :ref:`this tutorial <tutorial_backend_couchdb>`

--- a/sdk/basyx/aas/backend/backends.py
+++ b/sdk/basyx/aas/backend/backends.py
@@ -5,11 +5,11 @@
 #
 # SPDX-License-Identifier: MIT
 """
-This module provides a registry and and abstract base class for Backends. A :class:`~.Backend` is a class that allows to
+This module provides a registry and abstract base class for Backends. A :class:`~.Backend` is a class that allows to
 synchronize Referable AAS objects or their included data with external data sources such as a remote API or a local
 source for real time data. Each backend provides access to one kind of data source.
 
-The data source of an individual object is specified as an URI in its ``source`` attribute. The schema part of that URI
+The data source of an individual object is specified as a URI in its ``source`` attribute. The schema part of that URI
 defines the type of data source and, in consequence, the backend class to use for synchronizing this object.
 
 Custom backends for additional types of data sources can be implemented by subclassing :class:`Backend` and
@@ -49,7 +49,7 @@ class Backend(metaclass=abc.ABCMeta):
         data source) via this backend implementation.
 
         It is automatically called by the :meth:`~basyx.aas.model.base.Referable.commit` implementation, when the source
-        URI of the object or the source URI one of its ancestors in the AAS object containment hierarchy include an
+        URI of the object or the source URI one of its ancestors in the AAS object containment hierarchy include a
         URI schema for which this
         backend has been registered. Both of the objects are passed to this function: the one which shall be committed
         (``committed_object``) and its ancestor with the relevant source URI (``store_object``). They may be the same,
@@ -88,7 +88,7 @@ class Backend(metaclass=abc.ABCMeta):
 
         It is automatically called by the :meth:`~basyx.aas.model.base.Referable.update` implementation,
         when the source URI of the object or the source URI one of its ancestors in the AAS object containment hierarchy
-        include an URI schema for which this backend has been registered. Both of the objects are passed
+        include a URI schema for which this backend has been registered. Both of the objects are passed
         to this function: the one which shall be update (``updated_object``) and its ancestor with
         the relevant source URI (``store_object``). They may be the same, the updated object has a source with
         the relevant schema itself. Additionally, the ``relative_path`` from the ``store_object`` down to

--- a/sdk/basyx/aas/backend/couchdb.py
+++ b/sdk/basyx/aas/backend/couchdb.py
@@ -300,7 +300,7 @@ class CouchDBObjectStore(model.AbstractObjectStore):
                 raise KeyError("No Identifiable with couchdb-id {} found in CouchDB database".format(couchdb_id)) from e
             raise
 
-        # Add CouchDB meta data (for later commits) to object
+        # Add CouchDB metadata (for later commits) to object
         obj = data['data']
         if not isinstance(obj, model.Identifiable):
             raise CouchDBResponseError("The CouchDB document with id {} does not contain an identifiable AAS object."
@@ -491,7 +491,7 @@ class CouchDBObjectStore(model.AbstractObjectStore):
         """
         Helper method to represent an ASS Identifier as a string to be used as CouchDB document id
 
-        :param url_quote: If True, the result id string is url-encoded to be used in a HTTP request URL
+        :param url_quote: If True, the result id string is url-encoded to be used in an HTTP request URL
         """
         if url_quote:
             identifier = urllib.parse.quote(identifier, safe='')
@@ -542,6 +542,5 @@ class CouchDBServerError(CouchDBError):
 
 
 class CouchDBConflictError(CouchDBError):
-    """Exception raised when an object could not be committed due to an concurrent
-    modification in the database"""
+    """Exception raised when an object could not be committed due to a concurrent modification in the database"""
     pass

--- a/sdk/basyx/aas/backend/couchdb.py
+++ b/sdk/basyx/aas/backend/couchdb.py
@@ -107,7 +107,7 @@ class CouchDBBackend(backends.Backend):
         return url
 
     @classmethod
-    def do_request(cls, url: str, method: str = "GET", additional_headers: Dict[str, str] = {},
+    def do_request(cls, url: str, method: str = "GET", additional_headers: Optional[Dict[str, str]] = None,
                    body: Optional[bytes] = None) -> MutableMapping[str, Any]:
         """
         Perform an HTTP(S) request to the CouchDBServer, parse the result and handle errors
@@ -126,7 +126,7 @@ class CouchDBBackend(backends.Backend):
         headers = urllib3.make_headers(keep_alive=True, accept_encoding=True,
                                        basic_auth="{}:{}".format(*auth) if auth else None)
         headers['Accept'] = 'application/json'
-        headers.update(additional_headers)
+        headers.update(additional_headers if additional_headers is not None else {})
         try:
             response = _http_pool_manager.request(method, url, headers=headers, body=body)
         except (urllib3.exceptions.TimeoutError, urllib3.exceptions.SSLError, urllib3.exceptions.ProtocolError) as e:

--- a/sdk/basyx/aas/examples/data/_helper.py
+++ b/sdk/basyx/aas/examples/data/_helper.py
@@ -489,10 +489,10 @@ class AASDataChecker(DataChecker):
 
     def _find_reference(self, object_: model.Reference, search_list: Iterable) -> Union[model.Reference, None]:
         """
-        Find a reference in an list
+        Find a reference in a list
 
-        :param object_: Given reference which should be find in list
-        :param search_list: List in which the given reference should be find
+        :param object_: Given reference which should be found in list
+        :param search_list: List in which the given reference should be found
         :return: the searched reference if found else none
         """
         for element in search_list:
@@ -503,10 +503,10 @@ class AASDataChecker(DataChecker):
     def _find_specific_asset_id(self, object_: model.SpecificAssetId, search_list: Iterable) \
             -> Union[model.SpecificAssetId, None]:
         """
-        Find a SpecificAssetId in an list
+        Find a SpecificAssetId in a list
 
-        :param object_: Given SpecificAssetId which should be find in list
-        :param search_list: List in which the given SpecificAssetId should be find
+        :param object_: Given SpecificAssetId which should be found in list
+        :param search_list: List in which the given SpecificAssetId should be found
         :return: the searched SpecificAssetId if found else none
         """
         for element in search_list:
@@ -516,10 +516,10 @@ class AASDataChecker(DataChecker):
 
     def _find_element_by_attribute(self, object_: object, search_list: Iterable, *attribute: str) -> object:
         """
-        Find an element in an list
+        Find an element in a list
 
-        :param object_: Given object which should be find in list
-        :param search_list: List in which the given object should be find
+        :param object_: Given object which should be found in list
+        :param search_list: List in which the given object should be found
         :param attribute: List of attributes on which the comparison should be done
         :return:
         """
@@ -536,11 +536,11 @@ class AASDataChecker(DataChecker):
     def _find_extra_object(self, object_list: Iterable, search_list: Iterable,
                            type_) -> Union[Set, None]:
         """
-        Find extra object that are in object_list but noch in search_list
+        Find extra objects that are in object_list but still in search_list
 
         :param object_list: List which could contain more objects than the search_list has
         :param search_list: List which should be searched
-        :param type_: type of objects which should be find
+        :param type_: type of objects which should be found
         :return: Set of objects that are in object_list but not in search_list
         """
         found_elements = set()
@@ -666,7 +666,7 @@ class AASDataChecker(DataChecker):
 
         found_elements = self._find_extra_namespace_set_elements_by_id_short(object_.statement,
                                                                              expected_value.statement)
-        self.check(found_elements == set(), f'Enity {repr(object_)} must not have extra statements',
+        self.check(found_elements == set(), f'Entity {repr(object_)} must not have extra statements',
                    value=found_elements)
 
     def _check_specific_asset_ids_equal(self, object_: Iterable[model.SpecificAssetId],
@@ -1003,7 +1003,7 @@ class AASDataChecker(DataChecker):
         Checks if ``object_`` exist in ``parent`` and adds / stores the check result for later analysis.
 
         :param object_: The object which shall be in parent
-        :param parent: The parent in which ``object_`` shall be exist
+        :param parent: The parent in which ``object_`` shall exist
         :param kwargs: Relevant values to add to the check result for further analysis (e.g. the compared values)
         :return: The value of expression to be used in control statements
         """
@@ -1014,7 +1014,7 @@ class AASDataChecker(DataChecker):
     def check_contained_element_length(self, object_: object, attribute_name: str, class_name: Type,
                                        length: int, **kwargs) -> bool:
         """
-        Checks if the ``object_`` has ``lenght`` elements of class ``class_name`` in attribute ``attribute_name`` and
+        Checks if the ``object_`` has ``length`` elements of class ``class_name`` in attribute ``attribute_name`` and
         adds / stores the check result for later analysis.
 
         :param object_: The object of which the attribute shall be checked

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -384,7 +384,7 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_multi_language_property = model.MultiLanguageProperty(
         id_short='ExampleMultiLanguageProperty',
         value=model.MultiLanguageTextType({'en-US': 'Example value of a MultiLanguageProperty element',
-                                           'de': 'Beispielwert für ein MultitLanguageProperty-Element'}),
+                                           'de': 'Beispielwert für ein MultiLanguageProperty-Element'}),
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                     value='http://acplt.org/ValueId/ExampleMultiLanguageValueId'),)),
         category='CONSTANT',

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -67,7 +67,7 @@ def create_full_example() -> model.DictObjectStore:
 def create_example_asset_identification_submodel() -> model.Submodel:
     """
     Creates a :class:`~basyx.aas.model.submodel.Submodel` containing two :class:`~basyx.aas.model.submodel.Property`
-    elements according to 'Verwaltungssschale in der Praxis'
+    elements according to 'Verwaltungsschale in der Praxis'
     https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/2019-verwaltungsschale-in-der-praxis.html
 
     :return: example asset identification submodel
@@ -105,7 +105,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
                                                    value='http://acplt.org/RefersTo/ExampleRefersTo'),),
                                         model.AssetAdministrationShell)],)
 
-    # Property-Element conform to 'Verwaltungssschale in der Praxis' page 41 ManufacturerName:
+    # Property-Element conform to 'Verwaltungsschale in der Praxis' page 41 ManufacturerName:
     # https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/2019-verwaltungsschale-in-der-praxis.html
     identification_submodel_element_manufacturer_name = model.Property(
         id_short='ManufacturerName',
@@ -133,7 +133,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         embedded_data_specifications=()
     )
 
-    # Property-Element conform to 'Verwaltungssschale in der Praxis' page 44 InstanceId:
+    # Property-Element conform to 'Verwaltungsschale in der Praxis' page 44 InstanceId:
     # https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/2019-verwaltungsschale-in-der-praxis.html
     identification_submodel_element_instance_id = model.Property(
         id_short='InstanceId',
@@ -309,7 +309,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         category=None,
         description=model.MultiLanguageTextType({
             'en-US': 'An example bill of material submodel for the test application',
-            'de': 'Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung'
+            'de': 'Ein Beispiel-BillOfMaterial-Submodel für eine Test-Anwendung'
         }),
         parent=None,
         administration=model.AdministrativeInformation(version='9',
@@ -384,7 +384,7 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_multi_language_property = model.MultiLanguageProperty(
         id_short='ExampleMultiLanguageProperty',
         value=model.MultiLanguageTextType({'en-US': 'Example value of a MultiLanguageProperty element',
-                                           'de': 'Beispielswert für ein MulitLanguageProperty-Element'}),
+                                           'de': 'Beispielwert für ein MultitLanguageProperty-Element'}),
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                     value='http://acplt.org/ValueId/ExampleMultiLanguageValueId'),)),
         category='CONSTANT',
@@ -864,7 +864,7 @@ def create_example_asset_administration_shell() -> \
 
 
 ##############################################################################
-# check functions for checking if an given object is the same as the example #
+# check functions for checking if a given object is the same as the example #
 ##############################################################################
 def check_example_asset_identification_submodel(checker: AASDataChecker, submodel: model.Submodel) -> None:
     expected_submodel = create_example_asset_identification_submodel()

--- a/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
@@ -206,7 +206,7 @@ def create_example_empty_asset_administration_shell() -> model.AssetAdministrati
 
 
 ##############################################################################
-# check functions for checking if an given object is the same as the example #
+# check functions for checking if a given object is the same as the example #
 ##############################################################################
 def check_example_concept_description(checker: AASDataChecker, concept_description: model.ConceptDescription) -> None:
     expected_concept_description = create_example_concept_description()

--- a/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -59,11 +59,11 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_multi_language_property = model.MultiLanguageProperty(
         id_short='ExampleMultiLanguageProperty',
         value=model.MultiLanguageTextType({'en-US': 'Example value of a MultiLanguageProperty element',
-                                           'de': 'Beispielswert für ein MulitLanguageProperty-Element'}),
+                                           'de': 'Beispielwert für ein MultiLanguageProperty-Element'}),
         value_id=None,  # TODO
         category='CONSTANT',
         description=model.MultiLanguageTextType({'en-US': 'Example MultiLanguageProperty object',
-                                                 'de': 'Beispiel MulitLanguageProperty Element'}),
+                                                 'de': 'Beispiel MultiLanguageProperty Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                        value='http://acplt.org/MultiLanguageProperties/'
@@ -396,7 +396,7 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
 
 
 ##############################################################################
-# check functions for checking if an given object is the same as the example #
+# check functions for checking if a given object is the same as the example #
 ##############################################################################
 def check_example_concept_description(checker: AASDataChecker, concept_description: model.ConceptDescription) -> None:
     expected_concept_description = create_example_concept_description()

--- a/sdk/basyx/aas/examples/data/example_submodel_template.py
+++ b/sdk/basyx/aas/examples/data/example_submodel_template.py
@@ -45,7 +45,7 @@ def create_example_submodel_template() -> model.Submodel:
         value_id=None,  # TODO
         category='CONSTANT',
         description=model.MultiLanguageTextType({'en-US': 'Example MultiLanguageProperty object',
-                                                 'de': 'Beispiel MulitLanguageProperty Element'}),
+                                                 'de': 'Beispiel MultiLanguageProperty Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
                                                        value='http://acplt.org/MultiLanguageProperties/'
@@ -332,7 +332,7 @@ def create_example_submodel_template() -> model.Submodel:
 
 
 ##############################################################################
-# check functions for checking if an given object is the same as the example #
+# check functions for checking if a given object is the same as the example #
 ##############################################################################
 def check_example_submodel(checker: AASDataChecker, submodel: model.Submodel) -> None:
     expected_submodel = create_example_submodel_template()

--- a/sdk/basyx/aas/examples/tutorial_aasx.py
+++ b/sdk/basyx/aas/examples/tutorial_aasx.py
@@ -95,7 +95,7 @@ with aasx.AASXWriter("MyAASXPackage.aasx") as writer:
     # Write the AAS and everything belonging to it to the AASX package
     # The `write_aas()` method will automatically fetch the AAS object with the given id
     # and all referenced Submodel objects from the ObjectStore. It will also scan every object for
-    # semanticIds referencing ConceptDescription, fetch them from the ObjectStore, and scan all sbmodels for `File`
+    # semanticIds referencing ConceptDescription, fetch them from the ObjectStore, and scan all submodels for `File`
     # objects and fetch the referenced auxiliary files from the SupplementaryFileContainer.
     # In order to add more than one AAS to the package, we can simply add more Identifiers to the `aas_ids` list.
     #

--- a/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -133,6 +133,6 @@ xml_file_data = basyx.aas.adapter.xml.read_aas_xml_file('data.xml')
 # Again, we can use `failsafe=False` for switching on stricter error reporting in the parser.
 
 # step 5.3: Retrieving the objects from the ObjectStore
-# For more information on the availiable techniques, see `tutorial_storage.py`.
+# For more information on the available techniques, see `tutorial_storage.py`.
 submodel_from_xml = xml_file_data.get_identifiable('https://acplt.org/Simple_Submodel')
 assert isinstance(submodel_from_xml, model.Submodel)

--- a/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -9,7 +9,6 @@ and XML files.
 import json
 
 from basyx.aas import model
-import basyx.aas.adapter.json
 import basyx.aas.adapter.xml
 
 # 'Details of the Asset Administration Shell' specifies multiple official serialization formats for AAS data. In this
@@ -58,7 +57,6 @@ aashell = model.AssetAdministrationShell(
 
 # Before serializing the data, we should make sure, it's up-to-date. This is irrelevant for the static AAS objects in
 # this tutorial, but may be important when dealing with dynamic data.
-# See `tutorial_dynamic_model.py` for more information on that topic.
 aashell.update()
 
 # `AASToJsonEncoder` from the `aas.adapter.json` module is a custom JSONEncoder class for serializing

--- a/sdk/basyx/aas/model/__init__.py
+++ b/sdk/basyx/aas/model/__init__.py
@@ -1,5 +1,5 @@
 """
-This package contains a python implementation of the meta-model of the AssetAdministrationShell.
+This package contains a python implementation of the metamodel of the AssetAdministrationShell.
 The model is divided into 5 modules, splitting it in sensible parts. However, all classes (except for the
 specialized Concept Descriptions) are imported into this top-level package, for simple imports like
 

--- a/sdk/basyx/aas/model/aas.py
+++ b/sdk/basyx/aas/model/aas.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 """
-The main module of the AAS meta-model. It is used to define the class structures of high level elements such as
+The main module of the AAS metamodel. It is used to define the class structures of high level elements such as
 AssetAdministrationShell.
 """
 
@@ -18,7 +18,7 @@ from .submodel import Submodel
 @_string_constraints.constrain_identifier("asset_type")
 class AssetInformation:
     """
-    In AssetInformation identifying meta data of the asset that is represented by an AAS is defined.
+    In AssetInformation identifying metadata of the asset that is represented by an AAS is defined.
 
     The asset may either represent an asset type or an asset instance.
     The asset has a globally unique identifier plus – if needed – additional domain specific (proprietary)
@@ -36,7 +36,7 @@ class AssetInformation:
                            global id but already an internal identifier. The internal identifier would be modelled via
                            :attr:`~.specific_asset_id`.
     :ivar specific_asset_id: Additional domain specific, typically proprietary Identifier (Set of
-                             :class:`SpecificAssetIds <basyx.aas.model.base.SpecificAssetId>` for the asset like
+                             :class:`SpecificAssetIds <basyx.aas.model.base.SpecificAssetId>`) for the asset like
                              e.g. serial number etc.
     :ivar asset_type: In case AssetInformation/assetKind is applicable the AssetInformation/assetType is the asset ID
                       of the type asset of the asset under consideration as identified by
@@ -139,7 +139,8 @@ class AssetAdministrationShell(base.Identifiable, base.UniqueIdShortNamespace, b
                           :class:`~basyx.aas.model.base.Identifiable`)
     :ivar submodel: Unordered list of :class:`~basyx.aas.model.base.ModelReference` to
                     :class:`~basyx.aas.model.submodel.Submodel` to describe typically the asset of an AAS.
-    :ivar derived_from: The :class:`reference <basyx.aas.model.base.ModelReference>` to the AAS the AAs was derived from
+    :ivar derived_from: The :class:`reference <basyx.aas.model.base.ModelReference>` to the AAS
+                        from which it was derived.
     :ivar embedded_data_specifications: List of Embedded data specification.
     :ivar extension: An extension of the element.
                      (from :class:`~basyx.aas.model.base.HasExtension`)

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 """
-This module implements the basic structures of the AAS meta-model, including the abstract classes and enums needed for
+This module implements the basic structures of the AAS metamodel, including the abstract classes and enums needed for
 the higher level classes to inherit from.
 """
 
@@ -29,7 +29,7 @@ ValueList = Set["ValueReferencePair"]
 BlobType = bytes
 
 # The following string aliases are constrained by the decorator functions defined in the string_constraints module,
-# wherever they are used for a instance attributes.
+# wherever they are used for an instance attributes.
 ContentType = str  # any mimetype as in RFC2046
 Identifier = str
 LabelType = str
@@ -58,7 +58,7 @@ class KeyTypes(Enum):
     **ReferableElements starting from 1000**
 
     .. note::
-        DataElement is abstract, i. e. if a key uses :attr:`~.KeyTypes.DATA_ELEMENT` the reference may be
+        DataElement is abstract, i.e. if a key uses :attr:`~.KeyTypes.DATA_ELEMENT` the reference may be
         :class:`~basyx.aas.model.submodel.Property`, :class:`~basyx.aas.model.submodel.File` etc.
 
     .. note::
@@ -230,7 +230,7 @@ class AssetKind(Enum):
         specific property values.
 
     .. note::
-        In an object oriented view, an instance denotes an object of a class (of a type)
+        In an object-oriented view, an instance denotes an object of a class (of a type)
 
     :cvar TYPE: Type asset
     :cvar INSTANCE: Instance asset
@@ -283,9 +283,9 @@ class LangStringSet(MutableMapping[str, str]):
     A mapping of language code to string. Must be non-empty.
 
     langString is an RDF data type. A langString is a value tagged with a language code. RDF requires
-    IETF BCP 4723 language tags, i.e. simple two-letter language tags for Locales like “de” conformant to ISO 639-1
-    are allowed as well as language tags plus extension like “de-DE” for country code, dialect etc. like in “en-US” or
-    “en-GB” for English (United Kingdom) and English (United States). IETF language tags are referencing ISO 639,
+    IETF BCP 4723 language tags, i.e. simple two-letter language tags for Locales like "de" conformant to ISO 639-1
+    are allowed as well as language tags plus extension like "de-DE" for country code, dialect etc. like in "en-US" or
+    "en-GB" for English (United Kingdom) and English (United States). IETF language tags are referencing ISO 639,
     ISO 3166 and ISO 15924.
     """
     def __init__(self, dict_: Dict[str, str]):
@@ -592,7 +592,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     **Constraint AASd-002:** idShort shall only feature letters, digits, underscore (``_``); starting
     mandatory with a letter.
 
-    **Constraint AASd-004:** Add parent in case of non identifiable elements.
+    **Constraint AASd-004:** Add parent in case of non-identifiable elements.
 
     **Constraint AASd-022:** idShort of non-identifiable referables shall be unique in its namespace (case-sensitive)
 
@@ -603,7 +603,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     :ivar parent: Reference (in form of a :class:`~.UniqueIdShortNamespace`) to the next referable parent element
         of the element.
 
-    :ivar source: Source of the object, an URI, that defines where this object's data originates from.
+    :ivar source: Source of the object, a URI, that defines where this object's data originates from.
                   This is used to specify where the Referable should be updated from and committed to.
                   Default is an empty string, making it use the source of its ancestor, if possible.
     """
@@ -730,7 +730,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
             self._id_short = id_short
             for set_ in set_add_list:
                 set_.add(self)
-        # Redundant to the line above. However this way, we make sure that we really update the _id_short
+        # Redundant to the line above. However, this way, we make sure that we really update the _id_short
         self._id_short = id_short
 
     def update(self,
@@ -781,7 +781,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
 
     def find_source(self) -> Tuple[Optional["Referable"], Optional[List[str]]]:  # type: ignore
         """
-        Finds the closest source in this objects ancestors. If there is no source, returns None
+        Finds the closest source in these objects ancestors. If there is no source, returns None
 
         :return: Tuple with the closest ancestor with a defined source and the relative path of id_shorts to that
                  ancestor
@@ -1012,7 +1012,7 @@ class ModelReference(Reference, Generic[_RT]):
                                                       f"but the last key of the chain is not: {key[-1]!r}")
         for pk, k in zip(key, key[1:]):
             if k.type == KeyTypes.FRAGMENT_REFERENCE and pk.type not in (KeyTypes.BLOB, KeyTypes.FILE):
-                raise AASConstraintViolation(127, f"{k!r} is not preceeded by a key of type File or Blob, but {pk!r}")
+                raise AASConstraintViolation(127, f"{k!r} is not preceded by a key of type File or Blob, but {pk!r}")
             if pk.type == KeyTypes.SUBMODEL_ELEMENT_LIST and not k.value.isnumeric():
                 raise AASConstraintViolation(128, f"Key {pk!r} references a SubmodelElementList, "
                                                   f"but the value of the succeeding key ({k!r}) is not a non-negative "
@@ -1119,7 +1119,7 @@ class ModelReference(Reference, Generic[_RT]):
 @_string_constraints.constrain_path_type("path")
 class Resource:
     """
-    Resource represents an address to a file (a locator). The value is an URI that can represent an absolute or relative
+    Resource represents an address to a file (a locator). The value is a URI that can represent an absolute or relative
     path.
 
     :ivar path: Path and name of the resource (with file extension). The path can be absolute or relative.
@@ -1446,7 +1446,7 @@ class HasSemantics(metaclass=abc.ABCMeta):
             self._semantic_id = semantic_id
             for set_ in set_add_list:
                 set_.add(self)
-        # Redundant to the line above. However this way, we make sure that we really update the _semantic_id
+        # Redundant to the line above. However, this way, we make sure that we really update the _semantic_id
         self._semantic_id = semantic_id
 
     @property
@@ -1526,7 +1526,7 @@ class Extension(HasSemantics):
             self._name = name
             for set_ in set_add_list:
                 set_.add(self)
-        # Redundant to the line above. However this way, we make sure that we really update the _name
+        # Redundant to the line above. However, this way, we make sure that we really update the _name
         self._name = name
 
 
@@ -1673,7 +1673,7 @@ class Qualifier(HasSemantics):
             self._type = type_
             for set_ in set_add_list:
                 set_.add(self)
-        # Redundant to the line above. However this way, we make sure that we really update the _type
+        # Redundant to the line above. However, this way, we make sure that we really update the _type
         self._type = type_
 
 
@@ -1792,10 +1792,10 @@ class UniqueIdShortNamespace(Namespace, metaclass=abc.ABCMeta):
 
 class UniqueSemanticIdNamespace(Namespace, metaclass=abc.ABCMeta):
     """
-    Abstract baseclass for all objects which form a Namespace to hold HasSemantics objects and resolve them by their
+    Abstract baseclass for all objects which form a Namespace to hold HasSemantics objects and resolve them by
     their semantic_id.
 
-    A Namespace can contain multiple NamespaceSets, which contain HasSemantics objects of different types. However, the
+    A Namespace can contain multiple NamespaceSets, which contain HasSemantics objects of different types. However,
     the semantic_id of each object must be unique across all NamespaceSets of one Namespace.
 
     :ivar namespace_element_sets: A list of all NamespaceSets of this Namespace
@@ -1807,7 +1807,7 @@ class UniqueSemanticIdNamespace(Namespace, metaclass=abc.ABCMeta):
 
     def get_object_by_semantic_id(self, semantic_id: Reference) -> HasSemantics:
         """
-        Find an HasSemantics in this Namespaces by its semantic_id
+        Find a HasSemantics in these Namespaces by its semantic_id
 
         :raises KeyError: If no such HasSemantics can be found
         """
@@ -1881,7 +1881,7 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
                                  SubmodelElementList to unset id_shorts on removal. Should not be used for
                                  constraint checking, as the hook is called after removal.
         :raises AASConstraintViolation: When ``items`` contains multiple objects with same unique attribute or when an
-                                        item doesn't has an identifying attribute
+                                        item doesn't have an identifying attribute
         """
         self.parent = parent
         parent.namespace_element_sets.append(self)
@@ -2042,7 +2042,7 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
         :param attribute_name: name of the attribute to search for
         :param attribute_value: value of the attribute to search for
         :param default: An object to be returned, if no object with the given attribute is found
-        :return: The AAS object with the given attribute in the set. Otherwise the ``default`` object or None, if
+        :return: The AAS object with the given attribute in the set. Otherwise, the ``default`` object or None, if
                  none is given.
         """
         backend, case_sensitive = self._backend[attribute_name]
@@ -2068,11 +2068,11 @@ class NamespaceSet(MutableSet[_NSO], Generic[_NSO]):
                 elif isinstance(other_object, Qualifier):
                     backend, case_sensitive = self._backend["type"]
                     qualifier = backend[other_object.type if case_sensitive else other_object.type.upper()]
-                    # qualifier.update_from(other_object, update_source=True) # TODO: What should happend here?
+                    # qualifier.update_from(other_object, update_source=True) # TODO: What should happen here?
                 elif isinstance(other_object, Extension):
                     backend, case_sensitive = self._backend["name"]
                     extension = backend[other_object.name if case_sensitive else other_object.name.upper()]
-                    # extension.update_from(other_object, update_source=True) # TODO: What should happend here?
+                    # extension.update_from(other_object, update_source=True) # TODO: What should happen here?
                 else:
                     raise TypeError("Type not implemented")
             except KeyError:
@@ -2097,7 +2097,7 @@ class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NS
     A specialized version of :class:`~.NamespaceSet`, that keeps track of the order of the stored
     :class:`~.Referable` objects.
 
-    Additionally to the MutableSet interface of :class:`~.NamespaceSet`, this class provides a set-like interface
+    Additionally, to the MutableSet interface of :class:`~.NamespaceSet`, this class provides a set-like interface
     (actually it is derived from MutableSequence). However, we don't permit duplicate entries in the ordered list of
     objects.
     """
@@ -2125,7 +2125,7 @@ class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NS
                                  SubmodelElementList to unset id_shorts on removal. Should not be used for
                                  constraint checking, as the hook is called after removal.
         :raises AASConstraintViolation: When ``items`` contains multiple objects with same unique attribute or when an
-                                        item doesn't has an identifying attribute
+                                        item doesn't have an identifying attribute
         """
         self._order: List[_NSO] = []
         super().__init__(parent, attribute_names, items, item_add_hook, item_id_set_hook, item_id_del_hook)

--- a/sdk/basyx/aas/model/concept.py
+++ b/sdk/basyx/aas/model/concept.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 """
-This module contains the class :class:`~.ConceptDescription` from the AAS meta model.
+This module contains the class :class:`~.ConceptDescription` from the AAS metamodel.
 """
 from typing import Optional, Set, Iterable, List
 

--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -89,7 +89,7 @@ class Date(datetime.date):
         memo[id(self)] = result
         return result
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add into_datetime function
     # TODO add includes(:DateTime) -> bool function
 
@@ -118,7 +118,7 @@ class GYearMonth:
             return NotImplemented
         return self.year == other.year and self.month == other.month and self.tzinfo == other.tzinfo
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add includes(:Union[DateTime, Date]) -> bool function
 
 
@@ -143,7 +143,7 @@ class GYear:
             return NotImplemented
         return self.year == other.year and self.tzinfo == other.tzinfo
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add includes(:Union[DateTime, Date]) -> bool function
 
 
@@ -173,7 +173,7 @@ class GMonthDay:
             return NotImplemented
         return self.month == other.month and self.day == other.day and self.tzinfo == other.tzinfo
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add includes(:Union[DateTime, Date]) -> bool function
 
 
@@ -200,7 +200,7 @@ class GDay:
             return NotImplemented
         return self.day == other.day and self.tzinfo == other.tzinfo
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add includes(:Union[DateTime, Date]) -> bool function
 
 
@@ -227,7 +227,7 @@ class GMonth:
             return NotImplemented
         return self.month == other.month and self.tzinfo == other.tzinfo
 
-    # TODO override comparsion operators
+    # TODO override comparison operators
     # TODO add includes(:Union[DateTime, Date]) -> bool function
 
 
@@ -527,7 +527,7 @@ def from_xsd(value: str, type_: Type[AnyXSDType]) -> AnyXSDType:  # workaround. 
     Parse an XSD type value from its lexical representation
 
     :param value: Lexical representation
-    :param type_: The expected XSD type (from this module). It is required to chose the correct conversion.
+    :param type_: The expected XSD type (from this module). It is required to choose the correct conversion.
     """
     if type_ is Boolean:
         return _parse_xsd_bool(value)

--- a/sdk/basyx/aas/model/provider.py
+++ b/sdk/basyx/aas/model/provider.py
@@ -47,7 +47,7 @@ class AbstractObjectProvider(metaclass=abc.ABCMeta):
         :param default: An object to be returned, if no object with the given
                         :class:`id <basyx.aas.model.base.Identifier>` is found
         :return: The :class:`~basyx.aas.model.base.Identifiable` object with the given
-                 :class:`id <basyx.aas.model.base.Identifier>` in the provider. Otherwise the ``default`` object
+                 :class:`id <basyx.aas.model.base.Identifier>` in the provider. Otherwise, the ``default`` object
                  or None, if none is given.
         """
         try:

--- a/sdk/basyx/aas/model/provider.py
+++ b/sdk/basyx/aas/model/provider.py
@@ -125,7 +125,7 @@ class ObjectProviderMultiplexer(AbstractObjectProvider):
     to allow retrieving :class:`~basyx.aas.model.base.Identifiable` objects from different sources.
     It implements the :class:`~.AbstractObjectProvider` interface to be used as registry itself.
 
-    :ivar registries: A list of :class:`AbstractObjectProviders <.AbstractObjectProvider>` to query when looking up an
+    :param registries: A list of :class:`AbstractObjectProviders <.AbstractObjectProvider>` to query when looking up an
                       object
     """
     def __init__(self, registries: Optional[List[AbstractObjectProvider]] = None):

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -87,7 +87,7 @@ class Submodel(base.Identifiable, base.HasSemantics, base.HasKind, base.Qualifia
     A Submodel defines a specific aspect of the asset represented by the AAS.
 
     A submodel is used to structure the virtual representation and technical functionality of an Administration Shell
-    into distinguishable parts. Each submodel refers to a well-defined domain or subject matter. Submodels can become
+    into distinguishable parts. Each submodel refers to a well-defined domain or subject. Submodels can become
     standardized and thus become submodel types. Submodels can have different life-cycles.
 
     :ivar id: The globally unique id of the element. (inherited from :class:`~basyx.aas.model.base.Identifiable`)
@@ -440,7 +440,7 @@ class Blob(DataElement):
     :ivar id_short: Identifying string of the element within its name space. (inherited from
                     :class:`~basyx.aas.model.base.Referable`)
     :ivar content_type: Mime type of the content of the BLOB. The mime type states which file extension the file has.
-                     Valid values are e.g. “application/json”, “application/xls”, ”image/jpg”. The allowed values
+                     Valid values are e.g. "application/json", "application/xls", "image/jpg". The allowed values
                      are defined as in RFC2046.
     :ivar value: The value of the BLOB instance of a blob data element.
     :ivar display_name: Can be provided in several languages. (inherited from :class:`~basyx.aas.model.base.Referable`)
@@ -723,7 +723,7 @@ class SubmodelElementList(SubmodelElement, base.UniqueIdShortNamespace, Generic[
             raise base.AASConstraintViolation(109, f"type_value_list_element={self.type_value_list_element.__name__}, "
                                                    "but value_type_list_element is not set!")
 
-        # Items must be added after the above contraint has been checked. Otherwise, it can lead to errors, since the
+        # Items must be added after the above constraint has been checked. Otherwise, it can lead to errors, since the
         # constraints in _check_constraints() assume that this constraint has been checked.
         self._value: base.OrderedNamespaceSet[_SE] = base.OrderedNamespaceSet(self, [("id_short", True)], (),
                                                                               item_add_hook=self._check_constraints,

--- a/sdk/basyx/aas/util/identification.py
+++ b/sdk/basyx/aas/util/identification.py
@@ -109,7 +109,7 @@ class NamespaceIRIGenerator(AbstractIdentifierGenerator):
 
 # Reserved IRI characters according to https://tools.ietf.org/html/rfc3987#section-2.2
 # minus '/', '?', '=', '&', '#', which can be used in a path, querystring and fragment
-# plus unallowed characters (see) https://stackoverflow.com/a/36667242/10315508
+# plus not allowed characters (see) https://stackoverflow.com/a/36667242/10315508
 _iri_segment_quote_table_tmpl: Dict[Union[str, int], Optional[str]] = {
     c: '%{:02X}'.format(c.encode()[0])
     for c in [

--- a/sdk/docs/source/model/submodel.rst
+++ b/sdk/docs/source/model/submodel.rst
@@ -1,4 +1,4 @@
-submodel - Meta-model of the submodels and events
+submodel - metamodel of the submodels and events
 =================================================
 
 .. automodule:: basyx.aas.model.submodel

--- a/sdk/test/_helper/setup_testdb.py
+++ b/sdk/test/_helper/setup_testdb.py
@@ -49,7 +49,7 @@ if args.admin_user is not None:
         ('%s:%s' % (args.admin_user, args.admin_password)).encode('ascii')).decode("ascii")
 
 
-# Check if CouchDB server is avaliable
+# Check if CouchDB server is available
 request = urllib.request.Request(
     TEST_CONFIG['couchdb']['url'],
     headers=default_headers,

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -19,13 +19,6 @@ from basyx.aas.examples.data import example_aas, example_aas_mandatory_attribute
 
 
 class TestAASXUtils(unittest.TestCase):
-    def test_name_friendlyfier(self) -> None:
-        friendlyfier = aasx.NameFriendlyfier()
-        name1 = friendlyfier.get_friendly_name("http://example.com/AAS-a")
-        self.assertEqual("http___example_com_AAS_a", name1)
-        name2 = friendlyfier.get_friendly_name("http://example.com/AAS+a")
-        self.assertEqual("http___example_com_AAS_a_1", name2)
-
     def test_supplementary_file_container(self) -> None:
         container = aasx.DictSupplementaryFileContainer()
         with open(os.path.join(os.path.dirname(__file__), 'TestFile.pdf'), 'rb') as f:

--- a/sdk/test/adapter/xml/test_xml_deserialization.py
+++ b/sdk/test/adapter/xml/test_xml_deserialization.py
@@ -200,8 +200,6 @@ class XmlDeserializationTest(unittest.TestCase):
         self._assertInExceptionAndLog(xml, ["aas:qualifier", "has no child aas:type"], KeyError, logging.ERROR)
 
     def test_operation_variable_no_submodel_element(self) -> None:
-        # TODO: simplify this should our suggestion regarding the XML schema get accepted
-        # https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/57
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
@@ -222,8 +220,6 @@ class XmlDeserializationTest(unittest.TestCase):
         self._assertInExceptionAndLog(xml, ["aas:value", "has no submodel element"], KeyError, logging.ERROR)
 
     def test_operation_variable_too_many_submodel_elements(self) -> None:
-        # TODO: simplify this should our suggestion regarding the XML schema get accepted
-        # https://git.rwth-aachen.de/acplt/pyi40aas/-/issues/57
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -835,7 +835,7 @@ class ModelReferenceTest(unittest.TestCase):
                 model.Key(model.KeyTypes.FRAGMENT_REFERENCE, "urn:x-test:x"))
         with self.assertRaises(model.AASConstraintViolation) as cm:
             model.ModelReference(keys, model.Property)
-        self.assertEqual(f"{keys[-1]!r} is not preceeded by a key of type File or Blob, but {keys[1]!r}"
+        self.assertEqual(f"{keys[-1]!r} is not preceded by a key of type File or Blob, but {keys[1]!r}"
                          f" (Constraint AASd-127)", str(cm.exception))
         keys = (keys[0], model.Key(model.KeyTypes.BLOB, "urn:x-test:x"), keys[2])
         model.ModelReference(keys, model.Blob)


### PR DESCRIPTION
- Fixed grammar and typos
- Removed outdated reference to removed tutorial (Fixes  #282)
- Replaced mutable mutable default argument in `do_request() with None (Fixes #342)
- Fixed wrong tag (Fixes #341)
- Add a note about max line length exception (Fixes #285)
- Log warning if no AAS files read within AASX package (Fixes #247)