### PR TITLE
Add Reference to RDF serializer to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The `compliance_tool` is to be determined.
   * Modelling of AASs as Python objects
   * Reading and writing of AASX package files
   * (De-)serialization of AAS objects into/from JSON and XML
+  * Experimental serialization to RDF (see branch [Experimental/Adapter/RDF](https://github.com/eclipse-basyx/basyx-python-sdk/tree/Experimental/Adapter/RDF/basyx/aas/adapter/rdf)).
+    Please refer to discussion of PR [#308](https://github.com/eclipse-basyx/basyx-python-sdk/pull/308) for the reasoning behind keeping this feature experimental. 
   * Storing of AAS objects in CouchDB, Backend infrastructure for easy expansion 
   * Compliance checking of AAS XML and JSON files
 * [Server](./server/README.md): Docker Image of a specification compliant HTTP Server implementing the interfaces:


### PR DESCRIPTION
Previously, we did not advertise the existence of the RDF serializer in our `README.md`. 
This adds a reference to this experimental feature and where to find it.