### PR TITLE
compliance-tool: Fix compliance tool imports and unitests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.12"]
+        python-version: ["3.9", "3.12"]
     defaults:
       run:
         working-directory: ./compliance_tool
@@ -224,10 +224,10 @@ jobs:
         working-directory: ./compliance_tool
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
+    - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ env.X_PYTHON_VERSION }}
+        python-version: ${{ env.X_PYTHON_MIN_VERSION }}
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -249,10 +249,10 @@ jobs:
         working-directory: ./compliance_tool
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
+    - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ env.X_PYTHON_VERSION }}
+        python-version: ${{ env.X_PYTHON_MIN_VERSION }}
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -277,10 +277,10 @@ jobs:
         working-directory: ./compliance_tool
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ env.X_PYTHON_VERSION }}
+    - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ env.X_PYTHON_VERSION }}
+        python-version: ${{ env.X_PYTHON_MIN_VERSION }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.9", "3.10", "3.12"]
     defaults:
       run:
         working-directory: ./compliance_tool

--- a/compliance_tool/aas_compliance_tool/cli.py
+++ b/compliance_tool/aas_compliance_tool/cli.py
@@ -19,12 +19,12 @@ import pyecma376_2
 
 from basyx.aas.adapter import aasx
 from basyx.aas.adapter.xml import write_aas_xml_file
-from . import compliance_check_xml as compliance_tool_xml, \
+from aas_compliance_tool import compliance_check_xml as compliance_tool_xml, \
     compliance_check_json as compliance_tool_json, \
     compliance_check_aasx as compliance_tool_aasx
 from basyx.aas.adapter.json import write_aas_json_file
 from basyx.aas.examples.data import create_example, create_example_aas_binding, TEST_PDF_FILE
-from .state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 def parse_cli_arguments() -> argparse.ArgumentParser:

--- a/compliance_tool/aas_compliance_tool/cli.py
+++ b/compliance_tool/aas_compliance_tool/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -19,11 +19,12 @@ import pyecma376_2
 
 from basyx.aas.adapter import aasx
 from basyx.aas.adapter.xml import write_aas_xml_file
-from basyx.aas.compliance_tool import compliance_check_xml as compliance_tool_xml, \
-    compliance_check_json as compliance_tool_json, compliance_check_aasx as compliance_tool_aasx
+from . import compliance_check_xml as compliance_tool_xml, \
+    compliance_check_json as compliance_tool_json, \
+    compliance_check_aasx as compliance_tool_aasx
 from basyx.aas.adapter.json import write_aas_json_file
 from basyx.aas.examples.data import create_example, create_example_aas_binding, TEST_PDF_FILE
-from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
+from .state_manager import ComplianceToolStateManager, Status
 
 
 def parse_cli_arguments() -> argparse.ArgumentParser:

--- a/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
@@ -19,14 +19,14 @@ from lxml import etree  # type: ignore
 
 import pyecma376_2
 
-from . import compliance_check_json, compliance_check_xml
+from aas_compliance_tool import compliance_check_json, compliance_check_xml
 from basyx.aas import model
 from basyx.aas.adapter import aasx
 from basyx.aas.adapter.xml import xml_deserialization
 from basyx.aas.adapter.json import json_deserialization
 from basyx.aas.examples.data import example_aas, create_example_aas_binding
 from basyx.aas.examples.data._helper import AASDataChecker, DataChecker
-from .state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 def check_deserialization(file_path: str, state_manager: ComplianceToolStateManager,

--- a/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/aas_compliance_tool/compliance_check_json.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_json.py
@@ -20,7 +20,7 @@ from basyx.aas import (model)
 from basyx.aas.adapter.json import json_deserialization
 from basyx.aas.examples.data import example_aas, create_example
 from basyx.aas.examples.data._helper import AASDataChecker
-from .state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 JSON_SCHEMA_FILE = os.path.join(os.path.dirname(__file__), 'schemas/aasJSONSchema.json')

--- a/compliance_tool/aas_compliance_tool/compliance_check_json.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/aas_compliance_tool/compliance_check_xml.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_xml.py
@@ -20,7 +20,7 @@ from basyx.aas import model
 from basyx.aas.adapter.xml import xml_deserialization
 from basyx.aas.examples.data import example_aas, create_example
 from basyx.aas.examples.data._helper import AASDataChecker
-from .state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 XML_SCHEMA_FILE = os.path.join(os.path.dirname(__file__), 'schemas/aasXMLSchema.xsd')

--- a/compliance_tool/aas_compliance_tool/compliance_check_xml.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_xml.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/aas_compliance_tool/state_manager.py
+++ b/compliance_tool/aas_compliance_tool/state_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/setup.py
+++ b/compliance_tool/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019-2021 the Eclipse BaSyx Authors
+# Copyright (c) 2024-2021 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/test/files/test_demo_full_example.json
+++ b/compliance_tool/test/files/test_demo_full_example.json
@@ -499,7 +499,7 @@
                 },
                 {
                     "language": "de",
-                    "text": "Ein Beispiel-BillofMaterial-Submodel f\u00fcr eine Test-Anwendung"
+                    "text": "Ein Beispiel-BillOfMaterial-Submodel f\u00fcr eine Test-Anwendung"
                 }
             ],
             "modelType": "Submodel",
@@ -1309,7 +1309,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ],
                             "valueId": {
@@ -2281,7 +2281,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",
@@ -2301,7 +2301,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ]
                         },
@@ -2825,7 +2825,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",

--- a/compliance_tool/test/files/test_demo_full_example.xml
+++ b/compliance_tool/test/files/test_demo_full_example.xml
@@ -486,7 +486,7 @@
         </aas:langStringTextType>
         <aas:langStringTextType>
           <aas:language>de</aas:language>
-          <aas:text>Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung</aas:text>
+          <aas:text>Ein Beispiel-BillOfMaterial-Submodel für eine Test-Anwendung</aas:text>
         </aas:langStringTextType>
       </aas:description>
       <aas:administration>
@@ -1424,7 +1424,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
               <aas:valueId>
@@ -2109,7 +2109,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                  <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
               <aas:semanticId>
@@ -2128,7 +2128,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
             </aas:multiLanguageProperty>
@@ -2632,7 +2632,7 @@
                     </aas:langStringTextType>
                     <aas:langStringTextType>
                       <aas:language>de</aas:language>
-                      <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                      <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
                   <aas:semanticId>

--- a/compliance_tool/test/files/test_demo_full_example_json_aasx/aasx/data.json
+++ b/compliance_tool/test/files/test_demo_full_example_json_aasx/aasx/data.json
@@ -507,7 +507,7 @@
                 },
                 {
                     "language": "de",
-                    "text": "Ein Beispiel-BillofMaterial-Submodel f\u00fcr eine Test-Anwendung"
+                    "text": "Ein Beispiel-BillOfMaterial-Submodel f\u00fcr eine Test-Anwendung"
                 }
             ],
             "modelType": "Submodel",
@@ -1317,7 +1317,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ],
                             "valueId": {
@@ -2289,7 +2289,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",
@@ -2309,7 +2309,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ]
                         },
@@ -2833,7 +2833,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",

--- a/compliance_tool/test/files/test_demo_full_example_wrong_attribute.json
+++ b/compliance_tool/test/files/test_demo_full_example_wrong_attribute.json
@@ -499,7 +499,7 @@
                 },
                 {
                     "language": "de",
-                    "text": "Ein Beispiel-BillofMaterial-Submodel f\u00fcr eine Test-Anwendung"
+                    "text": "Ein Beispiel-BillOfMaterial-Submodel f\u00fcr eine Test-Anwendung"
                 }
             ],
             "modelType": "Submodel",
@@ -1309,7 +1309,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ],
                             "valueId": {
@@ -2281,7 +2281,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",
@@ -2301,7 +2301,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispielswert f\u00fcr ein MulitLanguageProperty-Element"
+                                    "text": "Beispielwert f\u00fcr ein MultiLanguageProperty-Element"
                                 }
                             ]
                         },
@@ -2825,7 +2825,7 @@
                                 },
                                 {
                                     "language": "de",
-                                    "text": "Beispiel MulitLanguageProperty Element"
+                                    "text": "Beispiel MultiLanguageProperty Element"
                                 }
                             ],
                             "modelType": "MultiLanguageProperty",

--- a/compliance_tool/test/files/test_demo_full_example_wrong_attribute.xml
+++ b/compliance_tool/test/files/test_demo_full_example_wrong_attribute.xml
@@ -486,7 +486,7 @@
         </aas:langStringTextType>
         <aas:langStringTextType>
           <aas:language>de</aas:language>
-          <aas:text>Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung</aas:text>
+          <aas:text>Ein Beispiel-BillOfMaterial-Submodel für eine Test-Anwendung</aas:text>
         </aas:langStringTextType>
       </aas:description>
       <aas:administration>
@@ -1424,7 +1424,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
               <aas:valueId>
@@ -2109,7 +2109,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                  <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
               <aas:semanticId>
@@ -2128,7 +2128,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
             </aas:multiLanguageProperty>
@@ -2632,7 +2632,7 @@
                     </aas:langStringTextType>
                     <aas:langStringTextType>
                       <aas:language>de</aas:language>
-                      <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                      <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
                   <aas:semanticId>

--- a/compliance_tool/test/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/compliance_tool/test/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -494,7 +494,7 @@
         </aas:langStringTextType>
         <aas:langStringTextType>
           <aas:language>de</aas:language>
-          <aas:text>Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung</aas:text>
+          <aas:text>Ein Beispiel-BillOfMaterial-Submodel für eine Test-Anwendung</aas:text>
         </aas:langStringTextType>
       </aas:description>
       <aas:administration>
@@ -1432,7 +1432,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
               <aas:valueId>
@@ -2117,7 +2117,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                  <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
               <aas:semanticId>
@@ -2136,7 +2136,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
             </aas:multiLanguageProperty>
@@ -2640,7 +2640,7 @@
                     </aas:langStringTextType>
                     <aas:langStringTextType>
                       <aas:language>de</aas:language>
-                      <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                      <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
                   <aas:semanticId>

--- a/compliance_tool/test/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/compliance_tool/test/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -494,7 +494,7 @@
         </aas:langStringTextType>
         <aas:langStringTextType>
           <aas:language>de</aas:language>
-          <aas:text>Ein Beispiel-BillofMaterial-Submodel für eine Test-Anwendung</aas:text>
+          <aas:text>Ein Beispiel-BillOfMaterial-Submodel für eine Test-Anwendung</aas:text>
         </aas:langStringTextType>
       </aas:description>
       <aas:administration>
@@ -1432,7 +1432,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
               <aas:valueId>
@@ -2117,7 +2117,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                  <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                 </aas:langStringTextType>
               </aas:description>
               <aas:semanticId>
@@ -2136,7 +2136,7 @@
                 </aas:langStringTextType>
                 <aas:langStringTextType>
                   <aas:language>de</aas:language>
-                  <aas:text>Beispielswert für ein MulitLanguageProperty-Element</aas:text>
+                  <aas:text>Beispielwert für ein MultiLanguageProperty-Element</aas:text>
                 </aas:langStringTextType>
               </aas:value>
             </aas:multiLanguageProperty>
@@ -2640,7 +2640,7 @@
                     </aas:langStringTextType>
                     <aas:langStringTextType>
                       <aas:language>de</aas:language>
-                      <aas:text>Beispiel MulitLanguageProperty Element</aas:text>
+                      <aas:text>Beispiel MultiLanguageProperty Element</aas:text>
                     </aas:langStringTextType>
                   </aas:description>
                   <aas:semanticId>

--- a/compliance_tool/test/test_aas_compliance_tool.py
+++ b/compliance_tool/test/test_aas_compliance_tool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -13,8 +13,6 @@ import unittest
 import io
 
 import tempfile
-
-import basyx.aas.compliance_tool
 from basyx.aas import model
 from basyx.aas.adapter import aasx
 from basyx.aas.adapter.json import read_aas_json_file
@@ -25,14 +23,16 @@ from basyx.aas.examples.data._helper import AASDataChecker
 
 def _run_compliance_tool(*compliance_tool_args, **kwargs) -> subprocess.CompletedProcess:
     """
-    This function runs the compliance tool using subprocess.run() while adjusting the PYTHONPATH environment variable
-    and setting the stdout and stderr parameters of subprocess.run() to PIPE.
+    This function runs the compliance tool using subprocess.run()
+    and sets the stdout and stderr parameters of subprocess.run() to PIPE.
     Positional arguments are passed to the compliance tool, while keyword arguments are passed to subprocess.run().
     """
     env = os.environ.copy()
-    env['PYTHONPATH'] = "{}:{}".format(os.environ.get('PYTHONPATH', ''),
-                                       os.path.join(os.path.dirname(basyx.__file__), os.pardir))
-    compliance_tool_path = os.path.join(os.path.dirname(basyx.aas.compliance_tool.__file__), 'cli.py')
+    compliance_tool_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        'aas_compliance_tool',
+        'cli.py'
+    )
     return subprocess.run([sys.executable, compliance_tool_path] + list(compliance_tool_args), stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE, env=env, **kwargs)
 

--- a/compliance_tool/test/test_aas_compliance_tool.py
+++ b/compliance_tool/test/test_aas_compliance_tool.py
@@ -28,6 +28,11 @@ def _run_compliance_tool(*compliance_tool_args, **kwargs) -> subprocess.Complete
     Positional arguments are passed to the compliance tool, while keyword arguments are passed to subprocess.run().
     """
     env = os.environ.copy()
+    parent_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        'aas_compliance_tool'
+    )
+    env["PYTHONPATH"] = parent_dir + os.pathsep + env.get("PYTHONPATH", "")
     compliance_tool_path = os.path.join(
         os.path.dirname(os.path.dirname(__file__)),
         'aas_compliance_tool',

--- a/compliance_tool/test/test_compliance_check_aasx.py
+++ b/compliance_tool/test/test_compliance_check_aasx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -7,8 +7,8 @@
 import os
 import unittest
 
-from basyx.aas.compliance_tool import compliance_check_aasx as compliance_tool
-from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool import compliance_check_aasx as compliance_tool
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 class ComplianceToolAASXTest(unittest.TestCase):

--- a/compliance_tool/test/test_compliance_check_aasx.py
+++ b/compliance_tool/test/test_compliance_check_aasx.py
@@ -20,7 +20,9 @@ class ComplianceToolAASXTest(unittest.TestCase):
         compliance_tool.check_deserialization(file_path_1, manager)
         self.assertEqual(2, len(manager.steps))
         self.assertEqual(Status.FAILED, manager.steps[0].status)
-        self.assertIn("is not a valid ECMA376-2 (OPC) file", manager.format_step(0, verbose_level=1))
+        # we should expect a FileNotFound error here since the file does not exist and that is the first error
+        # aasx.py will throw if you try to open a file that does not exist.
+        self.assertIn("No such file or directory:", manager.format_step(0, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[1].status)
 
         # Todo add more tests for checking wrong aasx files

--- a/compliance_tool/test/test_compliance_check_json.py
+++ b/compliance_tool/test/test_compliance_check_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -7,8 +7,8 @@
 import os
 import unittest
 
-import basyx.aas.compliance_tool.compliance_check_json as compliance_tool
-from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool import compliance_check_json as compliance_tool
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 class ComplianceToolJsonTest(unittest.TestCase):

--- a/compliance_tool/test/test_compliance_check_xml.py
+++ b/compliance_tool/test/test_compliance_check_xml.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -7,8 +7,8 @@
 import os
 import unittest
 
-import basyx.aas.compliance_tool.compliance_check_xml as compliance_tool
-from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool import compliance_check_xml as compliance_tool
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 
 
 class ComplianceToolXmlTest(unittest.TestCase):

--- a/compliance_tool/test/test_state_manager.py
+++ b/compliance_tool/test/test_state_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 the Eclipse BaSyx Authors
+# Copyright (c) 2024 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -7,7 +7,7 @@
 import logging
 import unittest
 
-from basyx.aas.compliance_tool.state_manager import ComplianceToolStateManager, Status
+from aas_compliance_tool.state_manager import ComplianceToolStateManager, Status
 from basyx.aas.examples.data._helper import DataChecker
 
 


### PR DESCRIPTION
Currently there are quite some wrong imports in the compliance-tool directory. Even when those are fixed many Unitests still fail.
Here these imports are fixed.
Fixes https://github.com/eclipse-basyx/basyx-python-sdk/issues/354