### PR TITLE
sdk/.readthedocs.yaml: install dependencies from pyproject.toml

### DIFF
--- a/sdk/.readthedocs.yaml
+++ b/sdk/.readthedocs.yaml
@@ -12,6 +12,7 @@ sphinx:
    configuration: docs/source/conf.py
 
 python:
-   install:
-   - requirements: requirements.txt
-   - requirements: docs/add-requirements.txt
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/add-requirements.txt


### PR DESCRIPTION
We were still trying to install dependencies from the already deleted requirements.txt, now they are being installed from the pyproject.toml.