### PR TITLE
adapter.rdf: Add trailing slash to AAS namespace

### DIFF
--- a/basyx/aas/adapter/rdf/rdf_serialization.py
+++ b/basyx/aas/adapter/rdf/rdf_serialization.py
@@ -29,7 +29,7 @@ from rdflib.namespace import OWL, RDF, Namespace, XSD
 from basyx.aas import model
 from .. import _generic
 
-NS_AAS = _generic.XML_NS_MAP["aas"]
+NS_AAS = _generic.XML_NS_MAP["aas"]+"/"
 
 
 class AASToRDFEncoder():


### PR DESCRIPTION
Previously, there was a trailing slash (`/`) missing in the AAS namespace resulting in invalid URIs, e.g.:

```
https://admin-shell.io/aas/3/0Identifiable/
```
instead of: 
```
https://admin-shell.io/aas/3/0/Identifiable/
```

This adds the trailing slash to the namespace in`the RDF serializer.

Fixes #365