### PR TITLE
sdk.deps: Move test depencies to extra dev section

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -44,17 +44,17 @@ The BaSyx Python SDK requires the following Python packages to be installed for 
 * `pyecma376-2` (Apache License v2.0)
 * `urllib3` (MIT License)
 * `Werkzeug` (BSD 3-clause License)
-* `jsonschema` (MIT License, Apache License, PSF License)
-* `types-python-dateutil` (Apache License v2.0)
-* `schemathesis` (MIT License)
-* `hypothesis` (MPL v2.0)
-* `lxml-stubs` (Apache License)
 
 Development/testing/documentation/example dependencies:
 * `mypy` (MIT License)
 * `pycodestyle` (MIT License)
 * `codeblocks` (Apache License v2.0)
 * `coverage` (Apache License v2.0)
+* `jsonschema` (MIT License, Apache License, PSF License)
+* `schemathesis` (MIT License)
+* `hypothesis` (MPL v2.0)
+* `lxml-stubs` (Apache License)
+* `types-python-dateutil` (Apache License v2.0)
 
 Dependencies for building the documentation (see `docs/add-requirements.txt`):
 * `Sphinx` and its dependencies (BSD 2-clause License, MIT License, Apache License)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -36,16 +36,11 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "jsonschema~=4.7",
     "lxml>=4.2,<5",
     "python-dateutil>=2.8,<3",
-    "types-python-dateutil",
     "pyecma376-2>=0.2.4",
     "urllib3>=1.26,<3",
     "Werkzeug>=3.0.3,<4",
-    "schemathesis~=3.7",
-    "hypothesis~=6.13",
-    "lxml-stubs~=0.5.1",
 ]
 
 [project.optional-dependencies]
@@ -54,6 +49,11 @@ dev = [
     "pycodestyle",
     "codeblocks",
     "coverage",
+    "schemathesis~=3.7",
+    "jsonschema~=4.7",
+    "hypothesis~=6.13",
+    "types-python-dateutil",
+    "lxml-stubs~=0.5.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Move test depencies to extra dev section

Some `sdk` dependencies, that are only necessary for testing, are included in the mandatory dependencies.

The development dependencies can be moved to the existing optional-dependencies  `dev` section, to make the library footprint smaller, when it is used without modifications.

I assume following deps can be moved:
* schemathesis: imported in `test_http.py`
* jsonschema: imported in `test_http.py` and `test_json_serialization.py`
  - [x] used in `compliance_tool` --> added to `pyproject.toml`in #361
* hypothesis: imported in `test_http.py`
* types-python-dateutil: used for typechecking
* lxml-stubs: used for typechecking
