### PR TITLE
sdk: Update version of pyecma dependency in pyproject.toml

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "lxml>=4.2,<5",
     "python-dateutil>=2.8,<3",
     "types-python-dateutil",
-    "pyecma376-2>=0.2.4",
+    "pyecma376-2>=1.0.1",
     "urllib3>=1.26,<3",
     "Werkzeug>=3.0.3,<4",
     "schemathesis~=3.7",


### PR DESCRIPTION
This updates the minimum version of the dependency `pyecma376` in the `pyproject.toml`, ensuring that our AASX files allow for spaces in file names. 

Fixes #236