### PR TITLE
aasx.py: Add failsafe for writing and reading AASX files

### DIFF
--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -238,12 +238,12 @@ class AASXReader:
         if content_type.split(";")[0] in ("text/xml", "application/xml") or content_type == "" and extension == "xml":
             logger.debug("Parsing AAS objects from XML stream in OPC part {} ...".format(part_name))
             with self.reader.open_part(part_name) as p:
-                return read_aas_xml_file(p, failsafe, **kwargs)
+                return read_aas_xml_file(p, failsafe=failsafe, **kwargs)
         elif content_type.split(";")[0] in ("text/json", "application/json") \
                 or content_type == "" and extension == "json":
             logger.debug("Parsing AAS objects from JSON stream in OPC part {} ...".format(part_name))
             with self.reader.open_part(part_name) as p:
-                return read_aas_json_file(io.TextIOWrapper(p, encoding='utf-8-sig'), failsafe, **kwargs)
+                return read_aas_json_file(io.TextIOWrapper(p, encoding='utf-8-sig'), failsafe=failsafe, **kwargs)
         else:
             error_message = ("Could not determine part format of AASX part {} (Content Type: {}, extension: {}"
                              .format(part_name, content_type, extension))

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -45,39 +45,7 @@ RELATIONSHIP_TYPE_AAS_SPEC_SPLIT = "http://admin-shell.io/aasx/relationships/aas
 RELATIONSHIP_TYPE_AAS_SUPL = "http://admin-shell.io/aasx/relationships/aas-suppl"
 
 
-class FailsafeConfigurable:
-    """
-    A base class for enabling or disabling failsafe behavior in readers, writers,
-    or other components that perform parsing or serialization.
-
-    This class provides a standard mechanism to configure and access a `failsafe` flag
-    that can be used to control whether errors should raise exceptions or be handled
-    more leniently (e.g., logged and skipped).
-
-    Subclasses can use the `failsafe` attribute directly or call `set_failsafe()` to update it.
-
-    :param failsafe: If ``True``, operate in failsafe mode by suppressing exceptions and logging errors instead.
-                     If ``False``, raise exceptions on critical issues.
-    """
-
-    def __init__(self, failsafe: bool = True):
-        """
-        Initialize the failsafe configuration.
-
-        :param failsafe: Initial value for the failsafe behavior.
-        """
-        self.failsafe = failsafe
-
-    def set_failsafe(self, enabled: bool):
-        """
-        Enable or disable failsafe behavior.
-
-        :param enabled: If ``True``, enables failsafe mode. If ``False``, disables it.
-        """
-        self.failsafe = enabled
-
-
-class AASXReader(FailsafeConfigurable):
+class AASXReader():
     """
     An AASXReader wraps an existing AASX package file to allow reading its contents and metadata.
 
@@ -106,7 +74,7 @@ class AASXReader(FailsafeConfigurable):
         :raises FileNotFoundError: If the file does not exist
         :raises ValueError: If the file is not a valid OPC zip package
         """
-        super().__init__(failsafe)
+        self.failsafe = failsafe
         try:
             logger.debug("Opening {} as AASX pacakge for reading ...".format(file))
             self.reader = pyecma376_2.ZipPackageReader(file)
@@ -310,7 +278,7 @@ class AASXReader(FailsafeConfigurable):
                 element.value = final_name
 
 
-class AASXWriter(FailsafeConfigurable):
+class AASXWriter():
     """
     An AASXWriter wraps a new AASX package file to write its contents to it piece by piece.
 
@@ -352,7 +320,7 @@ class AASXWriter(FailsafeConfigurable):
             logged instead of causing exceptions. Defect objects are skipped.
         :param file: filename, path, or binary file handle opened for writing
         """
-        super().__init__(failsafe)
+        self.failsafe = failsafe
         # names of aas-spec parts, used by `_write_aasx_origin_relationships()`
         self._aas_part_names: List[str] = []
         # name of the thumbnail part (if any)
@@ -431,7 +399,7 @@ class AASXWriter(FailsafeConfigurable):
                                     f"{aas!r}")
             except (KeyError, TypeError) as e:
                 if self.failsafe:
-                    logger.warning(f"Skipping AAS {aas_id}: {e}")
+                    logger.error(f"Skipping AAS {aas_id}: {e}")
                     continue
                 else:
                     raise

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -885,13 +885,15 @@ def read_aas_json_file_into(object_store: model.AbstractObjectStore, file: PathO
     return ret
 
 
-def read_aas_json_file(file: PathOrIO, **kwargs) -> model.DictObjectStore[model.Identifiable]:
+def read_aas_json_file(file: PathOrIO, failsafe: bool = True, **kwargs) -> model.DictObjectStore[model.Identifiable]:
     """
     A wrapper of :meth:`~basyx.aas.adapter.json.json_deserialization.read_aas_json_file_into`, that reads all objects
     in an empty :class:`~basyx.aas.model.provider.DictObjectStore`. This function supports the same keyword arguments as
     :meth:`~basyx.aas.adapter.json.json_deserialization.read_aas_json_file_into`.
 
     :param file: A filename or file-like object to read the JSON-serialized data from
+    :param failsafe: If ``True``, the document is parsed in a failsafe way: Missing attributes and elements are logged
+        instead of causing exceptions. Defect objects are skipped.
     :param kwargs: Keyword arguments passed to :meth:`read_aas_json_file_into`
     :raises KeyError: **Non-failsafe**: Encountered a duplicate identifier
     :raises (~basyx.aas.model.base.AASConstraintViolation, KeyError, ValueError, TypeError): **Non-failsafe**:
@@ -901,5 +903,5 @@ def read_aas_json_file(file: PathOrIO, **kwargs) -> model.DictObjectStore[model.
     :return: A :class:`~basyx.aas.model.provider.DictObjectStore` containing all AAS objects from the JSON file
     """
     object_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
-    read_aas_json_file_into(object_store, file, **kwargs)
+    read_aas_json_file_into(object_store, file, failsafe=failsafe, **kwargs)
     return object_store

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1502,13 +1502,16 @@ def read_aas_xml_file_into(object_store: model.AbstractObjectStore[model.Identif
     return ret
 
 
-def read_aas_xml_file(file: PathOrIO, **kwargs: Any) -> model.DictObjectStore[model.Identifiable]:
+def read_aas_xml_file(file: PathOrIO, failsafe: bool = True, **kwargs: Any)\
+        -> model.DictObjectStore[model.Identifiable]:
     """
     A wrapper of :meth:`~basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into`, that reads all objects in an
     empty :class:`~basyx.aas.model.provider.DictObjectStore`. This function supports
     the same keyword arguments as :meth:`~basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into`.
 
     :param file: A filename or file-like object to read the XML-serialized data from
+    :param failsafe: If ``True``, the document is parsed in a failsafe way: Missing attributes and elements are logged
+        instead of causing exceptions. Defect objects are skipped.
     :param kwargs: Keyword arguments passed to :meth:`~basyx.aas.adapter.xml.xml_deserialization.read_aas_xml_file_into`
     :raises ~lxml.etree.XMLSyntaxError: **Non-failsafe**: If the given file(-handle) has invalid XML
     :raises KeyError: **Non-failsafe**: If a required namespace has not been declared on the XML document
@@ -1519,5 +1522,5 @@ def read_aas_xml_file(file: PathOrIO, **kwargs: Any) -> model.DictObjectStore[mo
     :return: A :class:`~basyx.aas.model.provider.DictObjectStore` containing all AAS objects from the XML file
     """
     object_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
-    read_aas_xml_file_into(object_store, file, **kwargs)
+    read_aas_xml_file_into(object_store, file, failsafe=failsafe, **kwargs)
     return object_store


### PR DESCRIPTION
Previously, the `failsafe` parameter, allowing to skip errors and only log them as warnings instead, only existed for JSON and XML (de-)serialization. 

This PR extends the feature to also be included when reading and writing AASX files. 
For this, we add the `failsafe` boolean attribute to the `AASXReader` and `AASXWriter` classes in `adapter.aasx`. 
If `failsafe` is `True`, the document is parsed in a failsafe way: Missing attributes and elements are logged instead of causing exceptions. Defect objects are skipped. The default value is `False`, keeping the existing behavior.

Furthermore, we do a little code-style clean up on string-formatting in the `adapter.aasx` module, updating all occurrences from (historically) different syntaxes to the more modern f-string syntax.

Fixes #228
