### PR TITLE
adapter.aasx: Allow reading AASX with wrong relationship

### DIFF
--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -39,7 +39,9 @@ from ..util import traversal
 
 logger = logging.getLogger(__name__)
 
-RELATIONSHIP_TYPE_AASX_ORIGIN = "http://admin-shell.io/aasx/relationships/aasx-origin"
+RELATIONSHIP_TYPE_AASX_ORIGIN = ("http://admin-shell.io/aasx/relationships/aasx-origin",
+                                 "http://www.admin-shell.io/aasx/relationships/aasx-origin")  # Fallback
+
 RELATIONSHIP_TYPE_AAS_SPEC = "http://admin-shell.io/aasx/relationships/aas-spec"
 RELATIONSHIP_TYPE_AAS_SPEC_SPLIT = "http://admin-shell.io/aasx/relationships/aas-spec-split"
 RELATIONSHIP_TYPE_AAS_SUPL = "http://admin-shell.io/aasx/relationships/aas-suppl"
@@ -140,10 +142,14 @@ class AASXReader:
         """
         # Find AASX-Origin part
         core_rels = self.reader.get_related_parts_by_type()
-        try:
-            aasx_origin_part = core_rels[RELATIONSHIP_TYPE_AASX_ORIGIN][0]
-        except IndexError as e:
-            raise ValueError("Not a valid AASX file: aasx-origin Relationship is missing.") from e
+        for rel_type in RELATIONSHIP_TYPE_AASX_ORIGIN:
+            if rel_type in core_rels:
+                print(rel_type[0])
+                aasx_origin_part = core_rels[rel_type][0]
+                break
+        else:
+            raise ValueError("Not a valid AASX file: aasx-origin Relationship is missing.")
+        
 
         read_identifiables: Set[model.Identifier] = set()
 

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -144,13 +144,12 @@ class AASXReader:
         core_rels = self.reader.get_related_parts_by_type()
         for rel_type in RELATIONSHIP_TYPE_AASX_ORIGIN:
             if rel_type in core_rels:
-                print(rel_type[0])
                 aasx_origin_part = core_rels[rel_type][0]
+                logger.warning("SPECIFICATION VIOLATED: The Relationship-URL in your AASX file is not valid as per IDTA specification. Please adhere to the specification.")
                 break
         else:
             raise ValueError("Not a valid AASX file: aasx-origin Relationship is missing.")
         
-
         read_identifiables: Set[model.Identifier] = set()
 
         no_aas_files_found = True

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -142,13 +142,14 @@ class AASXReader:
         """
         # Find AASX-Origin part
         core_rels = self.reader.get_related_parts_by_type()
-        for rel_type in RELATIONSHIP_TYPE_AASX_ORIGIN:
-            if rel_type in core_rels:
-                aasx_origin_part = core_rels[rel_type][0]
-                logger.warning("SPECIFICATION VIOLATED: The Relationship-URL in your AASX file is not valid as per IDTA specification. Please adhere to the specification.")
-                break
-        else:
+        found_rel_type = next((rel for rel in RELATIONSHIP_TYPE_AASX_ORIGIN if rel in core_rels), None)
+        if found_rel_type is None:
             raise ValueError("Not a valid AASX file: aasx-origin Relationship is missing.")
+        aasx_origin_part = core_rels[found_rel_type][0]
+        if found_rel_type == "http://www.admin-shell.io/aasx/relationships/aasx-origin":
+            logger.warning(
+                "SPECIFICATION VIOLATED: The Relationship-URL in your AASX file is not valid as per IDTA specification. Please adhere to the specification."
+            )
         
         read_identifiables: Set[model.Identifier] = set()
 


### PR DESCRIPTION
There are many AASX in the wild where there is an additional `www` in the relationship definition that does not belong there:
```
http://www.admin-shell.io/aasx/relationships/aasx-origin
```
whereas it should be according to the [specification](https://industrialdigitaltwin.org/wp-content/uploads/2024/06/IDTA-01005-3-0-1_SpecificationAssetAdministrationShell_Part5_AASXPackageFileFormat.pdf#Page=18):
```
http://admin-shell.io/aasx/relationships/aasx-origin
```

Previously, our SDK did not allow for reading these AASX files with wrong relationship URL. 
However, since there are so many of them, this change enables them to be read, while notifying the user with a big warning message that their AASX file is actually not standard compliant and needs to be changed (see discussion in #381).

Fixes #379 
Fixes #383 