### PR TITLE
Add CI job to release compliance-tool to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [published]
 
 jobs:
-  publish:
-    # This job publishes the package to PyPI
+  sdk-publish:
+    # This job publishes the SDK package to PyPI
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,3 +31,30 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_ORG_TOKEN }}
+
+  compliance-tool-publish:
+    # This job publishes the compliance_tool package to PyPI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./compliance_tool
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Create source and wheel dist
+        # (2024-12-11, s-heppner)
+        # The PyPI Action expects the dist files in a toplevel `/dist` directory,
+        # so we have to specify this as output directory here.
+        run: |
+          python -m build --outdir ../dist
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_ORG_TOKEN }}


### PR DESCRIPTION
This adds a job `compliance-tool-publish` to the `release.yml` that automatically publishes the compliance-tool package to PyPI upon release. It is simply copied from the SDK job, with adapted paths.