### PR TITLE
sdk/docs: Bump versions for sphinx dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,10 @@ jobs:
         working-directory: ./sdk
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
+    - name: Set up Python ${{ env.X_PYTHON_MAX_VERSION }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ env.X_PYTHON_MIN_VERSION }}
+        python-version: ${{ env.X_PYTHON_MAX_VERSION }}
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/sdk/docs/add-requirements.txt
+++ b/sdk/docs/add-requirements.txt
@@ -1,4 +1,4 @@
 # Additional requirements for building the docs
-sphinx~=7.2
-sphinx-rtd-theme~=2.0
-sphinx-argparse~=0.4.0
+sphinx~=8.2
+sphinx-rtd-theme~=3.0
+sphinx-argparse~=0.5.0


### PR DESCRIPTION
Currently, the sphinx dependencies in `docs/add_requirements.txt` are outdated, causing our CI pipeline to fail.

This bumps the versions for the additional requirements for the compilation of the documentation to their newest working state. Since that version needs `Python >= 3.11`, we also need to bump the version of Python used in the CI.

Fixes #385