### PR TITLE
sdk/docs: Move documentation dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
-        pip install -r docs/add-requirements.txt
+        pip install .[docs]
     - name: Check documentation for errors
       run: |
         SPHINXOPTS="-a -E -n -W --keep-going" make -C docs html

--- a/sdk/.readthedocs.yaml
+++ b/sdk/.readthedocs.yaml
@@ -15,4 +15,5 @@ python:
   install:
     - method: pip
       path: .
-    - requirements: docs/add-requirements.txt
+      extra_requirements:
+        - docs

--- a/sdk/docs/add-requirements.txt
+++ b/sdk/docs/add-requirements.txt
@@ -1,4 +1,0 @@
-# Additional requirements for building the docs
-sphinx~=8.2
-sphinx-rtd-theme~=3.0
-sphinx-argparse~=0.5.0

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -55,6 +55,11 @@ dev = [
     "types-python-dateutil",
     "lxml-stubs~=0.5.1",
 ]
+docs= [
+    "sphinx~=8.2",
+    "sphinx-rtd-theme~=3.0",
+    "sphinx-argparse~=0.5.0"
+]
 
 [project.urls]
 "Homepage" = "https://github.com/eclipse-basyx/basyx-python-sdk"


### PR DESCRIPTION
Previously, the build-dependencies for the sphinx autodocumentation were listed in `sdk/docs/add-requirements.txt`. This is outdated and the new state of the art is managing all dependencies via `pyproject.toml`.

This refactors the dependencies from `sdk/docs/add-requirements.txt` into a new optional `[docs]` section in the `pyproject.toml` dependency definitions.

Furthermore, we adapt the `.github/workflows/ci.yml` to use the new definitions accordingly.

Fixes #384