### PR TITLE
sdk: Update lxml and mypy dependency in pyproject.toml

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "mypy",
+    "mypy==1.15.0",
     "pycodestyle",
     "codeblocks",
     "coverage",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "lxml>=4.2,<5",
+    "lxml>=5.3",
     "python-dateutil>=2.8,<3",
     "pyecma376-2>=1.0.1",
     "urllib3>=1.26,<3",


### PR DESCRIPTION
Previously, the `lxml` dependency in the `pyproject.toml` was pinned to versions `>=4.2,<5`. This caused a faulty installation via `pip` on Windows due to missing binary wheels. Moreover, the `mypy` dependency was unpinned, leading to the installation of the latest version. The recent release of `mypy 1.16.0` introduced changes not yet supported by our codebase, resulting in CI pipeline failures.

This updates the `lxml` dependency to versions `>=5.3` to resolve the installation issue. Additionally, this restricts the `mypy` dependency to version `1.15.0` until we have proper support for `1.16.0` and its new features.

Fixes #391