### PR TITLE
server/README.md: Clarify Docker build context

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,8 @@ The container image can be built via:
 $ docker build -t basyx-python-server -f Dockerfile ..
 ```
 
+Note that when cloning this repository on Windows, Git may convert the line separators to CRLF. This breaks `entrypoint.sh` and `stop-supervisor.sh`. Ensure both files use LF line separators before building. 
+
 ## Running
 
 ### Storage
@@ -77,11 +79,12 @@ services:
     - "8080:80"
     volumes:
       - ./storage:/storage
-
 ````
 
 Here files are read from `/storage` and the server can be accessed at http://localhost:8080/api/v3.0/ from your host system. 
 To get a different setup this compose.yaml file can be adapted and expanded.
+
+Note that the `Dockerfile` has to be specified explicitly, as the build context must be set to the parent directory of `/server` to allow access to the local `/sdk`.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Previously, #386 proposed narrowing the scope of the build context for `server/Dockerfile` to `/server`. As a consequence, `/sdk`, which is required to build the server, would no longer be accessible. Locally, this would necessitate explicitly referencing `/sdk` as a second build context. When using the GitHub URL of this repository as build context instead of a local repository, this would additionally lead to inefficient data handling. Since Docker Compose does not yet support sparse checkouts, specifying subdirectories like `/server` as build context still results in the full repository being cloned. Consequently, although `/sdk` would be downloaded, it would be excluded from the narrowed build context and thus remain unavailable. Any attempt to include `/sdk` separately afterwards would result in the same data being downloaded again. As this is an inefficient solution, #386 is rejected.

This documents the decision of keeping the repository root as the build context of `server/Dockerfile`. A corresponding note was added in `server/README.md`.

Additionally, a mention of faulty line endings being a common error when building the Docker container has been added in `server/README.md`.

Fixes #386