### PR TITLE
sdk/basyx/aas: Fix type issues under mypy 1.16

### DIFF
--- a/sdk/basyx/aas/adapter/xml/xml_serialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_serialization.py
@@ -875,82 +875,78 @@ def object_to_xml_element(obj: object) -> etree._Element:
 
     :param obj: The object to serialize
     """
-    serialization_func: Callable[..., etree._Element]
-
     if isinstance(obj, model.Key):
-        serialization_func = key_to_xml
+        return key_to_xml(obj)
     elif isinstance(obj, model.Reference):
-        serialization_func = reference_to_xml
-    elif isinstance(obj, model.Reference):
-        serialization_func = reference_to_xml
+        return reference_to_xml(obj)
     elif isinstance(obj, model.AdministrativeInformation):
-        serialization_func = administrative_information_to_xml
+        return administrative_information_to_xml(obj)
     elif isinstance(obj, model.Qualifier):
-        serialization_func = qualifier_to_xml
+        return qualifier_to_xml(obj)
     elif isinstance(obj, model.AnnotatedRelationshipElement):
-        serialization_func = annotated_relationship_element_to_xml
+        return annotated_relationship_element_to_xml(obj)
     elif isinstance(obj, model.BasicEventElement):
-        serialization_func = basic_event_element_to_xml
+        return basic_event_element_to_xml(obj)
     elif isinstance(obj, model.Blob):
-        serialization_func = blob_to_xml
+        return blob_to_xml(obj)
     elif isinstance(obj, model.Capability):
-        serialization_func = capability_to_xml
+        return capability_to_xml(obj)
     elif isinstance(obj, model.Entity):
-        serialization_func = entity_to_xml
+        return entity_to_xml(obj)
     elif isinstance(obj, model.Extension):
-        serialization_func = extension_to_xml
+        return extension_to_xml(obj)
     elif isinstance(obj, model.File):
-        serialization_func = file_to_xml
+        return file_to_xml(obj)
     elif isinstance(obj, model.Resource):
-        serialization_func = resource_to_xml
+        return resource_to_xml(obj)
     elif isinstance(obj, model.MultiLanguageProperty):
-        serialization_func = multi_language_property_to_xml
+        return multi_language_property_to_xml(obj)
     elif isinstance(obj, model.Operation):
-        serialization_func = operation_to_xml
+        return operation_to_xml(obj)
     elif isinstance(obj, model.Property):
-        serialization_func = property_to_xml
+        return property_to_xml(obj)
     elif isinstance(obj, model.Range):
-        serialization_func = range_to_xml
+        return range_to_xml(obj)
     elif isinstance(obj, model.ReferenceElement):
-        serialization_func = reference_element_to_xml
+        return reference_element_to_xml(obj)
     elif isinstance(obj, model.RelationshipElement):
-        serialization_func = relationship_element_to_xml
+        return relationship_element_to_xml(obj)
     elif isinstance(obj, model.SubmodelElementCollection):
-        serialization_func = submodel_element_collection_to_xml
+        return submodel_element_collection_to_xml(obj)
     elif isinstance(obj, model.SubmodelElementList):
-        serialization_func = submodel_element_list_to_xml
+        return submodel_element_list_to_xml(obj)
     elif isinstance(obj, model.AssetAdministrationShell):
-        serialization_func = asset_administration_shell_to_xml
+        return asset_administration_shell_to_xml(obj)
     elif isinstance(obj, model.AssetInformation):
-        serialization_func = asset_information_to_xml
+        return asset_information_to_xml(obj)
     elif isinstance(obj, model.SpecificAssetId):
-        serialization_func = specific_asset_id_to_xml
+        return specific_asset_id_to_xml(obj)
     elif isinstance(obj, model.Submodel):
-        serialization_func = submodel_to_xml
+        return submodel_to_xml(obj)
     elif isinstance(obj, model.ValueReferencePair):
-        serialization_func = value_reference_pair_to_xml
+        return value_reference_pair_to_xml(obj)
     elif isinstance(obj, model.ConceptDescription):
-        serialization_func = concept_description_to_xml
+        return concept_description_to_xml(obj)
     elif isinstance(obj, model.LangStringSet):
-        serialization_func = lang_string_set_to_xml
+        # FIXME: `lang_string_set_to_xml` expects `tag` parameter, `tag` doesn't have default value
+        # Issue: https://github.com/eclipse-basyx/basyx-python-sdk/issues/397
+        return lang_string_set_to_xml(obj) # type: ignore[call-arg]
     elif isinstance(obj, model.EmbeddedDataSpecification):
-        serialization_func = embedded_data_specification_to_xml
+        return embedded_data_specification_to_xml(obj)
     elif isinstance(obj, model.DataSpecificationIEC61360):
-        serialization_func = data_specification_iec61360_to_xml
+        return data_specification_iec61360_to_xml(obj)
     # generic serialization using the functions for abstract classes
     elif isinstance(obj, model.DataElement):
-        serialization_func = data_element_to_xml
+        return data_element_to_xml(obj)
     elif isinstance(obj, model.SubmodelElement):
-        serialization_func = submodel_to_xml
+        return submodel_element_to_xml(obj)
     elif isinstance(obj, model.DataSpecificationContent):
-        serialization_func = data_specification_content_to_xml
+        return data_specification_content_to_xml(obj)
     # type aliases
     elif isinstance(obj, model.ValueList):
-        serialization_func = value_list_to_xml
+        return value_list_to_xml(obj)
     else:
         raise ValueError(f"{obj!r} cannot be serialized!")
-
-    return serialization_func(obj)
 
 
 def write_aas_xml_element(file: _generic.PathOrBinaryIO, obj: object, **kwargs) -> None:

--- a/sdk/basyx/aas/adapter/xml/xml_serialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_serialization.py
@@ -930,7 +930,7 @@ def object_to_xml_element(obj: object) -> etree._Element:
     elif isinstance(obj, model.LangStringSet):
         # FIXME: `lang_string_set_to_xml` expects `tag` parameter, `tag` doesn't have default value
         # Issue: https://github.com/eclipse-basyx/basyx-python-sdk/issues/397
-        return lang_string_set_to_xml(obj) # type: ignore[call-arg]
+        return lang_string_set_to_xml(obj)  # type: ignore[call-arg]
     elif isinstance(obj, model.EmbeddedDataSpecification):
         return embedded_data_specification_to_xml(obj)
     elif isinstance(obj, model.DataSpecificationIEC61360):

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1504,7 +1504,7 @@ class Extension(HasSemantics):
         self.value = value
         self.refers_to: Set[ModelReference] = set(refers_to)
         self.semantic_id: Optional[Reference] = semantic_id
-        self.supplemental_semantic_id: ConstrainedList[Reference] = ConstrainedList(supplemental_semantic_id)
+        self.supplemental_semantic_id = ConstrainedList(supplemental_semantic_id)
 
     def __repr__(self) -> str:
         return "Extension(name={})".format(self.name)
@@ -1653,7 +1653,7 @@ class Qualifier(HasSemantics):
         self.value_id: Optional[Reference] = value_id
         self.kind: QualifierKind = kind
         self.semantic_id: Optional[Reference] = semantic_id
-        self.supplemental_semantic_id: ConstrainedList[Reference] = ConstrainedList(supplemental_semantic_id)
+        self.supplemental_semantic_id = ConstrainedList(supplemental_semantic_id)
 
     def __repr__(self) -> str:
         return "Qualifier(type={})".format(self.type)

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 the Eclipse BaSyx Authors
+# Copyright (c) 2025 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -76,8 +76,7 @@ class SubmodelElement(base.Referable, base.Qualifiable, base.HasSemantics,
         self.semantic_id: Optional[base.Reference] = semantic_id
         self.qualifier = base.NamespaceSet(self, [("type", True)], qualifier)
         self.extension = base.NamespaceSet(self, [("name", True)], extension)
-        self.supplemental_semantic_id: base.ConstrainedList[base.Reference] = \
-            base.ConstrainedList(supplemental_semantic_id)
+        self.supplemental_semantic_id = base.ConstrainedList(supplemental_semantic_id)
         self.embedded_data_specifications: List[base.EmbeddedDataSpecification] = list(embedded_data_specifications)
 
 
@@ -147,8 +146,7 @@ class Submodel(base.Identifiable, base.HasSemantics, base.HasKind, base.Qualifia
         self.qualifier = base.NamespaceSet(self, [("type", True)], qualifier)
         self._kind: base.ModellingKind = kind
         self.extension = base.NamespaceSet(self, [("name", True)], extension)
-        self.supplemental_semantic_id: base.ConstrainedList[base.Reference] = \
-            base.ConstrainedList(supplemental_semantic_id)
+        self.supplemental_semantic_id = base.ConstrainedList(supplemental_semantic_id)
         self.embedded_data_specifications: List[base.EmbeddedDataSpecification] = list(embedded_data_specifications)
 
 


### PR DESCRIPTION
Previously, the release of `mypy 1.16` added new features for the type check, resulting in our pipeline to fail.

This refactors the codebase to comply with `mypy 1.16`. Instances where `# type: ignore` was necessary are documented with context.

Fixes #390