### PR TITLE
Update `develop` with state of `main`

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "mypy",
+    "mypy==1.15.0",
     "pycodestyle",
     "codeblocks",
     "coverage",


### PR DESCRIPTION
It seems that our `develop` branch diverged a bit from the state of `main`, probably due to some small patches that went directly to `main` instead of going through `develop`. 

This brings `develop` back up to date with `main`. 

This is the execution of #393 which can now be closed.