### PR TITLE
Small fixes in `server\app\main.py`

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -2,8 +2,10 @@ import os
 import pathlib
 import sys
 
-from basyx.aas import model, adapter
-from basyx.aas.adapter import aasx
+from basyx.aas import model
+from basyx.aas.adapter.aasx import AASXReader, DictSupplementaryFileContainer
+from basyx.aas.adapter.json import read_aas_json_file_into
+from basyx.aas.adapter.xml import read_aas_xml_file_into
 
 from basyx.aas.backend.local_file import LocalFileObjectStore
 from interfaces.repository import WSGIApp
@@ -18,11 +20,11 @@ if base_path is not None:
     wsgi_optparams["base_path"] = base_path
 
 if storage_type == "LOCAL_FILE_BACKEND":
-    application = WSGIApp(LocalFileObjectStore(storage_path), aasx.DictSupplementaryFileContainer(), **wsgi_optparams)
+    application = WSGIApp(LocalFileObjectStore(storage_path), DictSupplementaryFileContainer(), **wsgi_optparams)
 
-elif storage_type in "LOCAL_FILE_READ_ONLY":
+elif storage_type == "LOCAL_FILE_READ_ONLY":
     object_store: model.DictObjectStore = model.DictObjectStore()
-    file_store: aasx.DictSupplementaryFileContainer = aasx.DictSupplementaryFileContainer()
+    file_store: DictSupplementaryFileContainer = DictSupplementaryFileContainer()
 
     for file in pathlib.Path(storage_path).iterdir():
         if not file.is_file():
@@ -31,12 +33,12 @@ elif storage_type in "LOCAL_FILE_READ_ONLY":
 
         if file.suffix.lower() == ".json":
             with open(file) as f:
-                adapter.json.read_aas_json_file_into(object_store, f)
+                read_aas_json_file_into(object_store, f)
         elif file.suffix.lower() == ".xml":
             with open(file) as f:
-                adapter.xml.read_aas_xml_file_into(object_store, file)
+                read_aas_xml_file_into(object_store, f)
         elif file.suffix.lower() == ".aasx":
-            with aasx.AASXReader(file) as reader:
+            with AASXReader(file) as reader:
                 reader.read_into(object_store=object_store, file_store=file_store)
 
     application = WSGIApp(object_store, file_store, **wsgi_optparams)


### PR DESCRIPTION
- Refactor imports
- Fix the reading of json and xml files
We use now FileIO as input for `read_aas_xml_file_into` as we do in `read_aas_json_file_into`. 
I have checked it and it worked