### PR TITLE
Refactor server start-up options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ htmlcov/
 docs/build/
 .hypothesis/
 
-# customized config files
+# Customized config files
 sdk/test/test_config.ini
 # Schema files needed for testing
 sdk/test/adapter/schemas
@@ -31,5 +31,6 @@ sdk/basyx/version.py
 compliance_tool/aas_compliance_tool/version.py
 server/app/version.py
 
-# ignore the content of the server storage
+# Ignore the content of the server storage
+server/input/
 server/storage/

--- a/sdk/basyx/aas/adapter/__init__.py
+++ b/sdk/basyx/aas/adapter/__init__.py
@@ -7,3 +7,44 @@ This package contains different kinds of adapters.
   Python SDK objects to/from XML.
 * :ref:`aasx <adapter.aasx>`: This package offers functions for reading and writing AASX-files.
 """
+
+from basyx.aas.adapter.aasx import AASXReader, DictSupplementaryFileContainer
+from basyx.aas.adapter.json import read_aas_json_file_into
+from basyx.aas.adapter.xml import read_aas_xml_file_into
+from basyx.aas.model.provider import DictObjectStore
+from pathlib import Path
+
+
+def load_directory(directory: Path | str) -> tuple[DictObjectStore, DictSupplementaryFileContainer]:
+    """
+    Create a new :class:`~basyx.aas.model.provider.DictObjectStore` and use it to load Asset Administration Shell and
+    Submodel files in ``AASX``, ``JSON`` and ``XML`` format from a given directory into memory. Additionally, load all
+    embedded supplementary files into a new :class:`~basyx.aas.adapter.aasx.DictSupplementaryFileContainer`.
+
+    :param directory: :class:`~pathlib.Path` or ``str`` pointing to the directory containing all Asset Administration
+        Shell and Submodel files to load
+    :return: Tuple consisting of a :class:`~basyx.aas.model.provider.DictObjectStore` and a
+        :class:`~basyx.aas.adapter.aasx.DictSupplementaryFileContainer` containing all loaded data
+    """
+
+    dict_object_store: DictObjectStore = DictObjectStore()
+    file_container: DictSupplementaryFileContainer = DictSupplementaryFileContainer()
+
+    directory = Path(directory)
+
+    for file in directory.iterdir():
+        if not file.is_file():
+            continue
+
+        suffix = file.suffix.lower()
+        if suffix == ".json":
+            with open(file) as f:
+                read_aas_json_file_into(dict_object_store, f)
+        elif suffix == ".xml":
+            with open(file) as f:
+                read_aas_xml_file_into(dict_object_store, f)
+        elif suffix == ".aasx":
+            with AASXReader(file) as reader:
+                reader.read_into(object_store=dict_object_store, file_store=file_container)
+
+    return dict_object_store, file_container

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -871,3 +871,6 @@ class DictSupplementaryFileContainer(AbstractSupplementaryFileContainer):
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._name_map)
+
+    def __len__(self) -> int:
+        return len(self._name_map)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod +x /etc/supervisor/stop-supervisor.sh
 
 # Makes it possible to use a different configuration
 ENV UWSGI_INI=/etc/uwsgi/uwsgi.ini
-# object stores aren't thread-safe yet
+# Object stores aren't thread-safe yet
 # https://github.com/eclipse-basyx/basyx-python-sdk/issues/205
 ENV UWSGI_CHEAPER=0
 ENV UWSGI_PROCESSES=1
@@ -31,6 +31,14 @@ ENV NGINX_MAX_UPLOAD=1M
 ENV NGINX_WORKER_PROCESSES=1
 ENV LISTEN_PORT=80
 ENV CLIENT_BODY_BUFFER_SIZE=1M
+ENV API_BASE_PATH=/api/v3.0/
+
+# Default values for the storage envs
+ENV INPUT=/input
+ENV STORAGE=/storage
+ENV STORAGE_PERSISTENCY=False
+ENV STORAGE_OVERWRITE=False
+VOLUME ["/input", "/storage"]
 
 # Copy the entrypoint that will generate Nginx additional configs
 COPY server/entrypoint.sh /entrypoint.sh

--- a/server/README.md
+++ b/server/README.md
@@ -6,10 +6,10 @@ The server currently implements the following interfaces:
 - [Asset Administration Shell Repository Service][4]
 - [Submodel Repository Service][5]
 
-It uses the [HTTP API][1] and the [AASX][7], [JSON][8], and [XML][9] Adapters of the [BaSyx Python SDK][3], to serve regarding files from a given directory.
+It uses the [HTTP API][1] and the [*AASX*][7], [*JSON*][8], and [*XML*][9] Adapters of the [BaSyx Python SDK][3], to serve regarding files from a given directory.
 The files are only read, changes won't persist.
 
-Alternatively, the container can also be told to use the [Local-File Backend][2] instead, which stores AAS and Submodels as individual JSON files and allows for persistent changes (except supplementary files, i.e. files referenced by `File` submodel elements).
+Alternatively, the container can also be told to use the [Local-File Backend][2] instead, which stores Asset Administration Shells (AAS) and Submodels as individual *JSON* files and allows for persistent changes (except supplementary files, i.e. files referenced by `File` SubmodelElements).
 See [below](#options) on how to configure this.
 
 ## Building
@@ -19,17 +19,20 @@ The container image can be built via:
 $ docker build -t basyx-python-server -f Dockerfile ..
 ```
 
-Note that when cloning this repository on Windows, Git may convert the line separators to CRLF. This breaks `entrypoint.sh` and `stop-supervisor.sh`. Ensure both files use LF line separators before building. 
+Note that when cloning this repository on Windows, Git may convert the line separators to CRLF. This breaks [`entrypoint.sh`](entrypoint.sh) and [`stop-supervisor.sh`](stop-supervisor.sh). Ensure both files use LF line separators (`\n`) before building. 
 
 ## Running
 
 ### Storage
 
-The container needs to be provided with the directory `/storage` to store AAS and Submodel files: AASX, JSON, XML or JSON files of Local-File Backend.
+The server makes use of two directories:
 
-This directory can be mapped via the `-v` option from another image or a local directory.
-To map the directory `storage` inside the container, `-v ./storage:/storage` can be used.
-The directory `storage` will be created in the current working directory, if it doesn't already exist.
+- **`/input`** - *start-up data*: Directory from which the server loads AAS and Submodel files in *AASX*, *JSON* or *XML* format during start-up. The server will not modify these files.
+- **`/storage`** - *persistent store*: Directory where all AAS and Submodels are stored as individual *JSON* files if the server is [configured](#options) for persistence. The server will modify these files.
+
+The directories can be mapped via the `-v` option from another image or a local directory.
+To mount the host directories into the container, `-v ./input:/input -v ./storage:/storage` can be used.
+Both local directories `./input` and `./storage` will be created in the current working directory, if they don't already exist.
 
 ### Port
 
@@ -38,31 +41,40 @@ To expose it on the host on port 8080, use the option `-p 8080:80` when running 
 
 ### Options
 
-The container can be configured via environment variables:
-- `API_BASE_PATH` determines the base path under which all other API paths are made available.
-  Default: `/api/v3.0`
-- `STORAGE_TYPE` can be one of `LOCAL_FILE_READ_ONLY` or `LOCAL_FILE_BACKEND`:
-  - When set to `LOCAL_FILE_READ_ONLY` (the default), the server will read and serve AASX, JSON, XML files from the storage directory.
-    The files are not modified, all changes done via the API are only stored in memory.
-  - When instead set to `LOCAL_FILE`, the server makes use of the [LocalFileBackend][2], where AAS and Submodels are persistently stored as JSON files.
-    Supplementary files, i.e. files referenced by `File` submodel elements, are not stored in this case.
-- `STORAGE_PATH` sets the directory to read the files from *within the container*. If you bind your files to a directory different from the default `/storage`, you can use this variable to adjust the server accordingly.
+The container can be configured via environment variables. The most important ones are summarised below:
+
+| Variable              | Description                                                                                                                                                                                                                                                                                                  | Default      |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| `API_BASE_PATH`       | Base path under which the API is served.                                                                                                                                                                                                                                                                     | `/api/v3.0/` |
+| `INPUT`               | Path inside the container pointing to the directory from which the server takes its start-up data (*AASX*, *JSON*, *XML*).                                                                                                                                                                                   | `/input`     |
+| `STORAGE`             | Path inside the container pointing to the directory used by the server to persistently store data (*JSON*).                                                                                                                                                                                                  | `/storage`   |
+| `STORAGE_PERSISTENCY` | Flag to enable data persistence via the [LocalFileBackend][2]. AAS/Submodels are stored as *JSON* files in the directory specified by `STORAGE`. Supplementary files, i.e. files referenced by `File` SubmodelElements, are not stored. If disabled, any changes made via the API are only stored in memory. | `False`      |
+| `STORAGE_OVERWRITE`   | Flag to enable storage overwrite if `STORAGE_PERSISTENCY` is enabled. Any AAS/Submodel from the `INPUT` directory already present in the LocalFileBackend replaces its existing version. If disabled, the existing version is kept.                                                                          | `False`      |
+
+
+This implies the following start-up behaviour:
+
+- Any AAS/Submodel found in `INPUT` is loaded during start-up.
+- If `STORAGE_PERSISTENCY = True`:
+  - Any AAS/Submodel *not* present in the LocalFileBackend is added to it.
+  - Any AAS/Submodel *already present* is skipped, unless `STORAGE_OVERWRITE = True`, in which case it is replaced.
+- Supplementary files (e.g., `File` SubmodelElements) are never persisted by the LocalFileBackend.
 
 ### Running Examples
 
 Putting it all together, the container can be started via the following command:
 ```
-$ docker run -p 8080:80 -v ./storage:/storage basyx-python-server
+$ docker run -p 8080:80 -v ./input:/input -v ./storage:/storage basyx-python-server
 ```
 
 Since Windows uses backslashes instead of forward slashes in paths, you'll have to adjust the path to the storage directory there:
 ```
-> docker run -p 8080:80 -v .\storage:/storage basyx-python-server
+> docker run -p 8080:80 -v .\input:/input -v .\storage:/storage basyx-python-server
 ```
 
-Per default, the server will use the `LOCAL_FILE_READ_ONLY` storage type and serve the API under `/api/v3.0` and read files from `/storage`. If you want to change this, you can do so like this:
+By default, the server will use the standard settings described [above](#options). Those settings can be adapted in the following way:
 ```
-$ docker run -p 8080:80 -v ./storage2:/storage2 -e API_BASE_PATH=/api/v3.1 -e STORAGE_TYPE=LOCAL_FILE_BACKEND -e STORAGE_PATH=/storage2 basyx-python-server
+$ docker run -p 8080:80 -v ./input:/input2 -v ./storage:/storage2 -e API_BASE_PATH=/api/v3.1/ -e INPUT=/input2 -e STORAGE=/storage2 -e STORAGE_PERSISTENCY=True -e STORAGE_OVERWRITE=True basyx-python-server
 ```
 
 ## Building and Running the Image with Docker Compose
@@ -72,8 +84,9 @@ The container image can also be built and run via:
 $ docker compose up
 ```
 
-This is the exemplary `compose.yml` file for the server:
+An exemplary [`compose.yml`](compose.yml) file for the server is given [here](compose.yml):
 ```yaml
+name: basyx-python-server
 services:
   app:
     build:
@@ -82,13 +95,16 @@ services:
     ports:
     - "8080:80"
     volumes:
+      - ./input:/input
       - ./storage:/storage
+    environment:
+      STORAGE_PERSISTENCY: True
 ```
 
-Here files are read from `/storage` and the server can be accessed at http://localhost:8080/api/v3.0/ from your host system. 
-To get a different setup this compose.yaml file can be adapted and expanded.
+Input files are read from `./input` and stored persistently under `./storage` on your host system. The server can be accessed at http://localhost:8080/api/v3.0/ from your host system. 
+To get a different setup, the [`compose.yml`](compose.yml) file can be adapted using the options described [above](#options), similar to the third [running example](#running-examples).
 
-Note that the `Dockerfile` has to be specified explicitly, as the build context must be set to the parent directory of `/server` to allow access to the local `/sdk`.
+Note that the `Dockerfile` has to be specified explicitly via `dockerfile: server/Dockerfile`, as the build context must be set to the parent directory of `/server` to allow access to the local `/sdk`.
 
 ## Running without Docker (Debugging Only)
 
@@ -103,7 +119,7 @@ The server can also be run directly on the host system without Docker, NGINX and
    $ pip install ./app
    ```
 
-2. Run the server by executing the main function in [`./app/interfaces/repository.py`](./app/interfaces/repository.py) from within the current folder.
+2. Run the server by executing the main function in [`./app/interfaces/repository.py`](./app/interfaces/repository.py).
    ```bash
    $ python -m app.interfaces.repository
    ```
@@ -119,7 +135,7 @@ This Dockerfile is inspired by the [tiangolo/uwsgi-nginx-docker][10] repository.
 [3]: https://github.com/eclipse-basyx/basyx-python-sdk
 [4]: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.0.1_SSP-001
 [5]: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.0.1_SSP-001
-[6]: https://industrialdigitaltwin.org/content-hub/aasspecifications/idta_01002-3-0_application_programming_interfaces
+[6]: https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1.1/index.html
 [7]: https://basyx-python-sdk.readthedocs.io/en/latest/adapter/aasx.html#adapter-aasx
 [8]: https://basyx-python-sdk.readthedocs.io/en/latest/adapter/json.html
 [9]: https://basyx-python-sdk.readthedocs.io/en/latest/adapter/xml.html

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -54,7 +54,7 @@ from .base import ObjectStoreWSGIApp, APIResponse, is_stripped_request, HTTPApiD
 
 class WSGIApp(ObjectStoreWSGIApp):
     def __init__(self, object_store: model.AbstractObjectStore, file_store: aasx.AbstractSupplementaryFileContainer,
-                 base_path: str = "/api/v3.0"):
+                 base_path: str = "/api/v3.0/"):
         self.object_store: model.AbstractObjectStore = object_store
         self.file_store: aasx.AbstractSupplementaryFileContainer = file_store
         self.url_map = werkzeug.routing.Map([

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,48 +1,160 @@
+# Copyright (c) 2025 the Eclipse BaSyx Authors
+#
+# This program and the accompanying materials are made available under the terms of the MIT License, available in
+# the LICENSE file of this project.
+#
+# SPDX-License-Identifier: MIT
+"""
+This module provides the WSGI entry point for the Asset Administration Shell Repository Server.
+"""
+
+import logging
 import os
-import pathlib
-import sys
-
-from basyx.aas import model
-from basyx.aas.adapter.aasx import AASXReader, DictSupplementaryFileContainer
-from basyx.aas.adapter.json import read_aas_json_file_into
-from basyx.aas.adapter.xml import read_aas_xml_file_into
-
+from basyx.aas.adapter import load_directory
+from basyx.aas.adapter.aasx import DictSupplementaryFileContainer
 from basyx.aas.backend.local_file import LocalFileObjectStore
+from basyx.aas.model.provider import DictObjectStore
 from interfaces.repository import WSGIApp
+from typing import Tuple
 
-storage_path = os.getenv("STORAGE_PATH", "/storage")
-storage_type = os.getenv("STORAGE_TYPE", "LOCAL_FILE_READ_ONLY")
-base_path = os.getenv("API_BASE_PATH")
 
-wsgi_optparams = {}
+# -------- Helper methods --------
 
-if base_path is not None:
-    wsgi_optparams["base_path"] = base_path
+def setup_logger() -> logging.Logger:
+    """
+    Configure a custom :class:`~logging.Logger` for the start-up sequence of the server.
 
-if storage_type == "LOCAL_FILE_BACKEND":
-    application = WSGIApp(LocalFileObjectStore(storage_path), DictSupplementaryFileContainer(), **wsgi_optparams)
+    :return: Configured :class:`~logging.Logger`
+    """
 
-elif storage_type == "LOCAL_FILE_READ_ONLY":
-    object_store: model.DictObjectStore = model.DictObjectStore()
-    file_store: DictSupplementaryFileContainer = DictSupplementaryFileContainer()
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter("%(levelname)s [Server Start-up] %(message)s"))
+        logger.addHandler(handler)
+        logger.propagate = False
+    return logger
 
-    for file in pathlib.Path(storage_path).iterdir():
-        if not file.is_file():
-            continue
-        print(f"Loading {file}")
 
-        if file.suffix.lower() == ".json":
-            with open(file) as f:
-                read_aas_json_file_into(object_store, f)
-        elif file.suffix.lower() == ".xml":
-            with open(file) as f:
-                read_aas_xml_file_into(object_store, f)
-        elif file.suffix.lower() == ".aasx":
-            with AASXReader(file) as reader:
-                reader.read_into(object_store=object_store, file_store=file_store)
+def sync_input_to_storage(
+        input_files: DictObjectStore,
+        storage_files: LocalFileObjectStore,
+        overwrite: bool
+) -> Tuple[int, int, int]:
+    """
+    Merge :class:`Identifiables <basyx.aas.model.base.Identifiable>` from an in-memory
+    :class:`~basyx.aas.model.provider.DictObjectStore` into a persistent
+    :class:`~basyx.aas.backend.local_file.LocalFileObjectStore`.
 
-    application = WSGIApp(object_store, file_store, **wsgi_optparams)
+    :param input_files: In-memory :class:`~basyx.aas.model.provider.DictObjectStore`
+    :param storage_files: Persistent :class:`~basyx.aas.backend.local_file.LocalFileObjectStore`
+    :param overwrite: Flag to overwrite existing :class:`Identifiables <basyx.aas.model.base.Identifiable>` in the
+        :class:`~basyx.aas.backend.local_file.LocalFileObjectStore`
+    :return: Counts of processed :class:`Identifiables <basyx.aas.model.base.Identifiable>` as
+        ``(added, overwritten, skipped)``
+    """
 
-else:
-    print(f"STORAGE_TYPE must be either LOCAL_FILE or LOCAL_FILE_READ_ONLY! Current value: {storage_type}",
-          file=sys.stderr)
+    added, overwritten, skipped = 0, 0, 0
+    for identifiable in input_files:
+        if identifiable.id in storage_files:
+            if overwrite:
+                existing = storage_files.get_identifiable(identifiable.id)
+                storage_files.discard(existing)
+                storage_files.add(identifiable)
+                overwritten += 1
+            else:
+                skipped += 1
+        else:
+            storage_files.add(identifiable)
+            added += 1
+    return added, overwritten, skipped
+
+
+def build_storage(
+    env_input: str,
+    env_storage: str,
+    env_storage_persistency: bool,
+    env_storage_overwrite: bool,
+    logger: logging.Logger
+) -> Tuple[DictObjectStore | LocalFileObjectStore, DictSupplementaryFileContainer]:
+    """
+    Configure the server's storage according to the given start-up settings.
+
+    :param env_input: ``str`` pointing to the input directory of the server
+    :param env_storage: ``str`` pointing to the :class:`~basyx.aas.backend.local_file.LocalFileObjectStore` storage
+        directory of the server if persistent storage is enabled
+    :param env_storage_persistency: Flag to enable persistent storage
+    :param env_storage_overwrite: Flag to overwrite existing :class:`Identifiables <basyx.aas.model.base.Identifiable>`
+        in the :class:`~basyx.aas.backend.local_file.LocalFileObjectStore` if persistent storage is enabled
+    :param logger: :class:`~logging.Logger` used for start-up diagnostics
+    :return: Tuple consisting of a :class:`~basyx.aas.model.provider.DictObjectStore` if persistent storage is disabled
+        or a :class:`~basyx.aas.backend.local_file.LocalFileObjectStore` if persistent storage is enabled and a
+        :class:`~basyx.aas.adapter.aasx.DictSupplementaryFileContainer` as storage for
+        :class:`~interfaces.repository.WSGIApp`
+    """
+
+    if env_storage_persistency:
+        storage_files = LocalFileObjectStore(env_storage)
+        storage_files.check_directory(create=True)
+        if os.path.isdir(env_input):
+            input_files, input_supp_files = load_directory(env_input)
+            added, overwritten, skipped = sync_input_to_storage(input_files, storage_files, env_storage_overwrite)
+            logger.info(
+                "Loaded %d identifiable(s) and %d supplementary file(s) from \"%s\"",
+                len(input_files), len(input_supp_files), env_input
+            )
+            logger.info(
+                "Synced INPUT to STORAGE with %d added and %d %s",
+                added,
+                overwritten if env_storage_overwrite else skipped,
+                "overwritten" if env_storage_overwrite else "skipped"
+            )
+            return storage_files, input_supp_files
+        else:
+            logger.warning("INPUT directory \"%s\" not found, starting empty", env_input)
+            return storage_files, DictSupplementaryFileContainer()
+
+    if os.path.isdir(env_input):
+        input_files, input_supp_files = load_directory(env_input)
+        logger.info(
+            "Loaded %d identifiable(s) and %d supplementary file(s) from \"%s\"",
+            len(input_files), len(input_supp_files), env_input
+        )
+        return input_files, input_supp_files
+    else:
+        logger.warning("INPUT directory \"%s\" not found, starting empty", env_input)
+        return DictObjectStore(), DictSupplementaryFileContainer()
+
+
+# -------- WSGI entrypoint --------
+
+logger = setup_logger()
+
+env_input = os.getenv("INPUT", "/input")
+env_storage = os.getenv("STORAGE", "/storage")
+env_storage_persistency = os.getenv("STORAGE_PERSISTENCY", "false").lower() in {"1", "true", "yes"}
+env_storage_overwrite = os.getenv("STORAGE_OVERWRITE", "false").lower() in {"1", "true", "yes"}
+env_api_base_path = os.getenv("API_BASE_PATH")
+
+wsgi_optparams = {"base_path": env_api_base_path} if env_api_base_path else {}
+
+logger.info(
+    "Loaded settings API_BASE_PATH=\"%s\", INPUT=\"%s\", STORAGE=\"%s\", PERSISTENCY=%s, OVERWRITE=%s",
+    env_api_base_path or "", env_input, env_storage, env_storage_persistency, env_storage_overwrite
+)
+
+storage_files, supp_files = build_storage(
+    env_input,
+    env_storage,
+    env_storage_persistency,
+    env_storage_overwrite,
+    logger
+)
+
+application = WSGIApp(storage_files, supp_files, **wsgi_optparams)
+
+
+if __name__ == "__main__":
+    logger.info("WSGI entrypoint created. Serve this module with uWSGI/Gunicorn/etc.")

--- a/server/compose.yml
+++ b/server/compose.yml
@@ -1,3 +1,4 @@
+name: basyx-python-server
 services:
   app:
     build:
@@ -6,4 +7,7 @@ services:
     ports:
     - "8080:80"
     volumes:
+      - ./input:/input
       - ./storage:/storage
+    environment:
+      STORAGE_PERSISTENCY: True


### PR DESCRIPTION
Previously, the repository server used one and the same folder for loading data during start-up and storing it persistently. This resulted in a mixture of input AAS/Submodel files (AASX, JSON and XML) and persistently stored AAS/Submodel files from the `LocalFileObjectStore` (JSON).

This separates the server's input and storage into two different directories to prevent their files being mixed. Moreover, the option to overwrite existing AAS/Submodels in the storage got added and the option to persistently store data got adapted. In accordance with the new changes, the `README` and `Dockerfile` were adapted to present the changes to the end users.

Fixes #404