### PR TITLE
Incorporate aas-test-engines for server testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: aas-test-results
-          path: result.html
+          path: ./server/result.html
       - name: Stop and remove the container
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,7 @@ jobs:
               sleep 2
             done
           '
+          sleep 5
       - name: Check if container is running
         run: |
           docker inspect --format='{{.State.Running}}' basyx-python-server | grep true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
           docker build -t basyx-python-server -f Dockerfile ..
       - name: Run container
         run: |
-          docker run -d -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
+          docker run -d -p 8080:80 -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
       - name: Wait for container and server initialization
         run: |
           timeout 30s bash -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,11 @@ jobs:
           docker inspect --format='{{.State.Running}}' basyx-python-server | grep true
       - name: Run AAS Test Engines compliance check
         run: |
+          FILTER=$(tr -d '\n' < ../etc/scripts/aas_test_engines_filter.txt)
           aas_test_engines check_server \
             http://localhost:8081/api/v3.0 \
             https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRepositoryServiceSpecification/SSP-002 \
+            --filter "$FILTER" \
             --output html > result.html
       - name: Upload test results as artifact
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,8 +357,8 @@ jobs:
       - name: Prepare test data
         run: |
            mkdir -p input
-           wget -O input/TestDataWithThumbnail.aasx \
-           https://raw.githubusercontent.com/admin-shell-io/aas-test-engines/main/bin/check_servers/test_data/TestDataWithThumbnail.aasx
+           curl -L -o input/TestDataWithThumbnail.aasx \
+           https://media.githubusercontent.com/media/admin-shell-io/aas-test-engines/main/bin/check_servers/test_data/TestDataWithThumbnail.aasx
       - name: Build the Docker image
         run: |
           docker build -t basyx-python-server -f Dockerfile ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,10 +381,12 @@ jobs:
             http://localhost:8081/api/v3.0 \
             https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRepositoryServiceSpecification/SSP-002 \
             --output html > result.html
-      - name: Show test results
+      - name: Upload test results as artifact
         if: always()
-        run: |
-          cat result.html
+        uses: actions/upload-artifact@v4
+        with:
+          name: aas-test-results
+          path: result.html
       - name: Stop and remove the container
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,9 +359,18 @@ jobs:
            mkdir -p input
            curl -L -o input/TestDataWithThumbnail.aasx \
            https://media.githubusercontent.com/media/admin-shell-io/aas-test-engines/main/bin/check_servers/test_data/TestDataWithThumbnail.aasx
-      - name: Build the Docker image
-        run: |
-          docker build -t basyx-python-server -f Dockerfile ..
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image with cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile
+          push: false
+          tags: basyx-python-server
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
       - name: Run container
         run: |
           docker run -d -p 8081:80 -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
           docker build -t basyx-python-server -f Dockerfile ..
       - name: Run container
         run: |
-          docker run -d -p 8080:80 -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
+          docker run -d -p 8081:80 -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
       - name: Wait for container and server initialization
         run: |
           timeout 30s bash -c '
@@ -372,14 +372,13 @@ jobs:
               sleep 2
             done
           '
-          sleep 8
       - name: Check if container is running
         run: |
           docker inspect --format='{{.State.Running}}' basyx-python-server | grep true
       - name: Run AAS Test Engines compliance check
         run: |
           aas_test_engines check_server \
-            http://localhost:8080/api/v3.0 \
+            http://localhost:8081/api/v3.0 \
             https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRepositoryServiceSpecification/SSP-002 \
             --output html > result.html
       - name: Show test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,9 +356,9 @@ jobs:
           pip install aas-test-engines
       - name: Prepare test data
         run: |
-          mkdir -p input
-          PKG_DIR=$(python -c "import os, aas_test_engines; print(os.path.dirname(aas_test_engines.__file__))")
-          cp "$PKG_DIR/bin/check_servers/test_data/TestDataWithThumbnail.aasx" input/
+           mkdir -p input
+           wget -O input/TestDataWithThumbnail.aasx \
+           https://raw.githubusercontent.com/admin-shell-io/aas-test-engines/main/bin/check_servers/test_data/TestDataWithThumbnail.aasx
       - name: Build the Docker image
         run: |
           docker build -t basyx-python-server -f Dockerfile ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
               sleep 2
             done
           '
-          sleep 5
+          sleep 8
       - name: Check if container is running
         run: |
           docker inspect --format='{{.State.Running}}' basyx-python-server | grep true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
           docker build -t basyx-python-server -f Dockerfile ..
       - name: Run container
         run: |
-           docker run -d --name basyx-python-server basyx-python-server
+           docker run -d -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
       - name: Wait for container and server initialization
         run: |
           timeout 30s bash -c '
@@ -338,3 +338,54 @@ jobs:
         run: |
           docker stop basyx-python-server && docker rm basyx-python-server
 
+  server-aas-test-engines:
+    # This job checks if our server is compliant
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./server
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ env.X_PYTHON_MIN_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.X_PYTHON_MIN_VERSION }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install aas-test-engines
+      - name: Prepare test data
+        run: |
+          mkdir -p input
+          PKG_DIR=$(python -c "import os, aas_test_engines; print(os.path.dirname(aas_test_engines.__file__))")
+          cp "$PKG_DIR/bin/check_servers/test_data/TestDataWithThumbnail.aasx" input/
+      - name: Build the Docker image
+        run: |
+          docker build -t basyx-python-server -f Dockerfile ..
+      - name: Run container
+        run: |
+          docker run -d -v ./input:/input -v ./storage:/storage --name basyx-python-server basyx-python-server
+      - name: Wait for container and server initialization
+        run: |
+          timeout 30s bash -c '
+            until docker logs basyx-python-server 2>&1 | grep -q "INFO success: quit_on_failure entered RUNNING state"; do
+              sleep 2
+            done
+          '
+      - name: Check if container is running
+        run: |
+          docker inspect --format='{{.State.Running}}' basyx-python-server | grep true
+      - name: Run AAS Test Engines compliance check
+        run: |
+          aas_test_engines check_server \
+            http://localhost:8080/api/v3.0 \
+            https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRepositoryServiceSpecification/SSP-002 \
+            --output html > result.html
+      - name: Show test results
+        if: always()
+        run: |
+          cat result.html
+      - name: Stop and remove the container
+        if: always()
+        run: |
+          docker stop basyx-python-server && docker rm basyx-python-server

--- a/etc/scripts/aas_test_engines_filter.txt
+++ b/etc/scripts/aas_test_engines_filter.txt
@@ -1,0 +1,10 @@
+*~GetSubmodelById:
+GetSubmodelById-ValueOnly:
+GetSubmodelById-Path:
+GetAllSubmodelElements:
+GetAllSubmodelElements-ValueOnly:
+GetAllSubmodelElements-Path:
+GetSubmodelElementByPath:
+GetSubmodelElementByPath-ValueOnly:
+GetSubmodelElementByPath-Path:
+GenerateSerializationByIds


### PR DESCRIPTION
Previously, we lacked a way to test our server for compliance to the specification.

This PR incorporates the aas-test-engines project into our ci pipeline. Using only operations we have implemented (where we do not return a 501) we can check our server for compliance.
Fixes #302