### PR TITLE
sdk: Disallow invalid types in MultiLanguage objects

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -291,7 +291,6 @@ class LangStringSet(MutableMapping[str, str]):
     """
     def __init__(self, dict_: Dict[str, str]):
         self._dict: Dict[str, str] = {}
-        
         if not isinstance(dict_, dict):
             raise TypeError(f"A {self.__class__.__name__} must be initialized with a dict!, got {type(dict_)}")
         if len(dict_) < 1:
@@ -830,23 +829,23 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         self._id_short = id_short
 
     @property
-    def display_name(self) -> MultiLanguageNameType | None:
+    def display_name(self) -> Optional[MultiLanguageNameType]:
         """Display name of the element (MultiLanguageNameType)."""
         return self._display_name
 
     @display_name.setter
-    def display_name(self, value: MultiLanguageNameType | dict| None) -> None:
+    def display_name(self, value: Union[MultiLanguageNameType, dict, None]) -> None:
         if value is not None and not isinstance(value, MultiLanguageNameType):
             value = MultiLanguageNameType(value)
         self._display_name = value
 
     @property
-    def description(self) -> MultiLanguageTextType | None:
+    def description(self) -> Optional[MultiLanguageTextType]:
         """Description of the element (MultiLanguageTextType)."""
         return self._description
 
     @description.setter
-    def description(self, value: MultiLanguageTextType | dict | None) -> None:
+    def description(self, value: Union[MultiLanguageTextType, dict, None]) -> None:
         if value is not None and not isinstance(value, MultiLanguageTextType):
             value = MultiLanguageTextType(value)
         self._description = value

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2025 the Eclipse BaSyx Authors
-#
+# 
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
 #
@@ -621,6 +621,10 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         # simpler and faster navigation/checks and it has no effect in the serialized data formats anyway.
         self.parent: Optional[UniqueIdShortNamespace] = None
 
+        # Initialize with empty objects to avoid ValueError
+        self.display_name = MultiLanguageNameType({})
+        self.description = MultiLanguageTextType({})
+
     def __repr__(self) -> str:
         root = self.get_identifiable_root()
         try:
@@ -825,64 +829,43 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
             for set_ in set_add_list:
                 set_.add(self)
         # Redundant to the line above. However, this way, we make sure that we really update the _id_short
-        self._id_short = id_short
+        self._id_short = id_short 
 
-    def _check_multiLanguageNameType(self, value): 
-        """ 
-        Check that the given type is either None or of type MultiLanguageNameType 
 
-        :param value: The display name to check
-        :raises TypeError: If the type is not :datatype:`MultiLanguageNameType` or `None`
-        """ 
-
+    def _check_multiLanguageNameType(self, value: Optional[MultiLanguageNameType]) -> None:
+        """Ensure value is None or a MultiLanguageNameType."""
         if value is not None and not isinstance(value, MultiLanguageNameType):
             raise TypeError(
                 f"display_name must be of type MultiLanguageNameType, but got {type(value)}"
-            ) 
-    
-    def _get_display_name(self) -> Optional[MultiLanguageNameType]:
-        return self._display_name 
-    
-    def _set_display_name(self, display_name: Optional[MultiLanguageNameType]):
-        """
-        Check the input type and then set the display_name
-
-        :param display_name: MultiLanguageNameType for the display name of the element
-        :raises TypeError: if the type is not correct
-        """ 
-        self._check_multiLanguageNameType(display_name)
-        self._display_name = display_name
-
-    display_name = property(_get_display_name, _set_display_name) 
-
-        
-    def _check_MultiLanguageTextType(self, value):
-        """
-        Check that the given type is either None or of type MultiLanguageTextType 
-
-        :param value: The description to check
-        :raises TypeError: if the type is not :datatype:`MultiLanguageTextType` or `None`
-        """ 
-
-        if value is not None and not isinstance(value, MultiLanguageTextType): 
-            raise TypeError(
-                f"description must be of type MultiLanguageTextType, but got {type(value)}" 
             )
+
+    @property
+    def display_name(self) -> Optional[MultiLanguageNameType]:
+        """Display name of the element (MultiLanguageNameType)."""
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, value: Optional[MultiLanguageNameType]) -> None:
+        self._check_multiLanguageNameType(value)
+        self._display_name = value  
+
         
-    def _get_description(self) -> Optional[MultiLanguageTextType]:
+    def _check_MultiLanguageTextType(self, value: Optional[MultiLanguageTextType]) -> None:
+        """Ensure value is None or a MultiLanguageTextType."""
+        if value is not None and not isinstance(value, MultiLanguageTextType):
+            raise TypeError(
+                f"description must be of type MultiLanguageTextType, but got {type(value)}"
+            )
+
+    @property
+    def description(self) -> Optional[MultiLanguageTextType]:
+        """Description of the element (MultiLanguageTextType)."""
         return self._description
-    
-    def _set_description(self, description: Optional[MultiLanguageTextType]):
-        """
-        Check the input type and then set the description
 
-        :param description: MultiLanguageTextType for the description of the element
-        :raises TypeError: if the type is not correct
-        """ 
-        self._check_MultiLanguageTextType(description)
-        self._description = description 
-
-    description = property(_get_description, _set_description)
+    @description.setter
+    def description(self, value: Optional[MultiLanguageTextType]) -> None:
+        self._check_MultiLanguageTextType(value)
+        self._description = value
 
     def update_from(self, other: "Referable"):
         """
@@ -895,7 +878,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         for name in dir(other):
             # Skip private and protected attributes
-            if name.startswith('_'):
+            if name.startswith('_'): 
                 continue
 
             # Do not update 'parent', 'namespace_element_sets'

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -835,7 +835,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         return self._display_name
 
     @display_name.setter
-    def display_name(self, value: MultiLanguageNameType | None) -> None:
+    def display_name(self, value: MultiLanguageNameType | dict| None) -> None:
         if value is not None and not isinstance(value, MultiLanguageNameType):
             value = MultiLanguageNameType(value)
         self._display_name = value
@@ -846,7 +846,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         return self._description
 
     @description.setter
-    def description(self, value: MultiLanguageTextType | None) -> None:
+    def description(self, value: MultiLanguageTextType | dict | None) -> None:
         if value is not None and not isinstance(value, MultiLanguageTextType):
             value = MultiLanguageTextType(value)
         self._description = value

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -613,10 +613,10 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self):
         super().__init__()
-        self._id_short: Optional[NameType] = None
-        self.display_name: Optional[MultiLanguageNameType] = dict()
+        self._id_short: Optional[NameType] = None 
+        self.display_name: Optional[MultiLanguageNameType] = None
         self._category: Optional[NameType] = None
-        self.description: Optional[MultiLanguageTextType] = dict()
+        self.description: Optional[MultiLanguageTextType] = None
         # We use a Python reference to the parent Namespace instead of a Reference Object, as specified. This allows
         # simpler and faster navigation/checks and it has no effect in the serialized data formats anyway.
         self.parent: Optional[UniqueIdShortNamespace] = None
@@ -826,6 +826,63 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
                 set_.add(self)
         # Redundant to the line above. However, this way, we make sure that we really update the _id_short
         self._id_short = id_short
+
+    def _check_multiLanguageNameType(self, value): 
+        """ 
+        Check that the given type is either None or of type MultiLanguageNameType 
+
+        :param value: The display name to check
+        :raises TypeError: If the type is not :datatype:`MultiLanguageNameType` or `None`
+        """ 
+
+        if value is not None and not isinstance(value, MultiLanguageNameType):
+            raise TypeError(
+                f"display_name must be of type MultiLanguageNameType, but got {type(value)}"
+            ) 
+    
+    def _get_display_name(self) -> Optional[MultiLanguageNameType]:
+        return self._display_name 
+    
+    def _set_display_name(self, display_name: Optional[MultiLanguageNameType]):
+        """
+        Check the input type and then set the display_name
+
+        :param display_name: MultiLanguageNameType for the display name of the element
+        :raises TypeError: if the type is not correct
+        """ 
+        self._check_multiLanguageNameType(display_name)
+        self._display_name = display_name
+
+    display_name = property(_get_display_name, _set_display_name) 
+
+        
+    def _check_MultiLanguageTextType(self, value):
+        """
+        Check that the given type is either None or of type MultiLanguageTextType 
+
+        :param value: The description to check
+        :raises TypeError: if the type is not :datatype:`MultiLanguageTextType` or `None`
+        """ 
+
+        if value is not None and not isinstance(value, MultiLanguageTextType): 
+            raise TypeError(
+                f"description must be of type MultiLanguageTextType, but got {type(value)}" 
+            )
+        
+    def _get_description(self) -> Optional[MultiLanguageTextType]:
+        return self._description
+    
+    def _set_description(self, description: Optional[MultiLanguageTextType]):
+        """
+        Check the input type and then set the description
+
+        :param description: MultiLanguageTextType for the description of the element
+        :raises TypeError: if the type is not correct
+        """ 
+        self._check_MultiLanguageTextType(description)
+        self._description = description 
+
+    description = property(_get_description, _set_description)
 
     def update_from(self, other: "Referable"):
         """

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2025 the Eclipse BaSyx Authors
-# 
+#
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
 #
@@ -613,7 +613,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self):
         super().__init__()
-        self._id_short: Optional[NameType] = None 
+        self._id_short: Optional[NameType] = None
         self._display_name: Optional[MultiLanguageNameType] = None
         self._category: Optional[NameType] = None
         self._description: Optional[MultiLanguageTextType] = None
@@ -829,8 +829,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
             for set_ in set_add_list:
                 set_.add(self)
         # Redundant to the line above. However, this way, we make sure that we really update the _id_short
-        self._id_short = id_short 
-
+        self._id_short = id_short
 
     def _check_multiLanguageNameType(self, value: Optional[MultiLanguageNameType]) -> None:
         """Ensure value is None or a MultiLanguageNameType."""
@@ -848,7 +847,6 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     def display_name(self, value: Optional[MultiLanguageNameType]) -> None:
         self._check_multiLanguageNameType(value)
         self._display_name = value  
-
         
     def _check_MultiLanguageTextType(self, value: Optional[MultiLanguageTextType]) -> None:
         """Ensure value is None or a MultiLanguageTextType."""
@@ -878,7 +876,7 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         """
         for name in dir(other):
             # Skip private and protected attributes
-            if name.startswith('_'): 
+            if name.startswith('_'):
                 continue
 
             # Do not update 'parent', 'namespace_element_sets'

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -291,7 +291,9 @@ class LangStringSet(MutableMapping[str, str]):
     """
     def __init__(self, dict_: Dict[str, str]):
         self._dict: Dict[str, str] = {}
-
+        
+        if not isinstance(dict_, dict):
+            raise TypeError(f"A {self.__class__.__name__} must be initialized with a dict!, got {type(dict_)}")
         if len(dict_) < 1:
             raise ValueError(f"A {self.__class__.__name__} must not be empty!")
         for ltag in dict_:
@@ -827,38 +829,26 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         # Redundant to the line above. However, this way, we make sure that we really update the _id_short
         self._id_short = id_short
 
-    def _check_multiLanguageNameType(self, value: Optional[MultiLanguageNameType]) -> None:
-        """Ensure value is None or a MultiLanguageNameType."""
-        if value is not None and not isinstance(value, MultiLanguageNameType):
-            raise TypeError(
-                f"display_name must be of type MultiLanguageNameType, but got {type(value)}"
-            )
-
     @property
-    def display_name(self) -> Optional[MultiLanguageNameType]:
+    def display_name(self) -> MultiLanguageNameType | None:
         """Display name of the element (MultiLanguageNameType)."""
         return self._display_name
 
     @display_name.setter
-    def display_name(self, value: Optional[MultiLanguageNameType]) -> None:
-        self._check_multiLanguageNameType(value)
+    def display_name(self, value: MultiLanguageNameType | None) -> None:
+        if value is not None and not isinstance(value, MultiLanguageNameType):
+            value = MultiLanguageNameType(value)
         self._display_name = value
 
-    def _check_MultiLanguageTextType(self, value: Optional[MultiLanguageTextType]) -> None:
-        """Ensure value is None or a MultiLanguageTextType."""
-        if value is not None and not isinstance(value, MultiLanguageTextType):
-            raise TypeError(
-                f"description must be of type MultiLanguageTextType, but got {type(value)}"
-            )
-
     @property
-    def description(self) -> Optional[MultiLanguageTextType]:
+    def description(self) -> MultiLanguageTextType | None:
         """Description of the element (MultiLanguageTextType)."""
         return self._description
 
     @description.setter
-    def description(self, value: Optional[MultiLanguageTextType]) -> None:
-        self._check_MultiLanguageTextType(value)
+    def description(self, value: MultiLanguageTextType | None) -> None:
+        if value is not None and not isinstance(value, MultiLanguageTextType):
+            value = MultiLanguageTextType(value)
         self._description = value
 
     def update_from(self, other: "Referable"):

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -614,9 +614,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     def __init__(self):
         super().__init__()
         self._id_short: Optional[NameType] = None 
-        self.display_name: Optional[MultiLanguageNameType] = None
+        self._display_name: Optional[MultiLanguageNameType] = None
         self._category: Optional[NameType] = None
-        self.description: Optional[MultiLanguageTextType] = None
+        self._description: Optional[MultiLanguageTextType] = None
         # We use a Python reference to the parent Namespace instead of a Reference Object, as specified. This allows
         # simpler and faster navigation/checks and it has no effect in the serialized data formats anyway.
         self.parent: Optional[UniqueIdShortNamespace] = None

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -621,10 +621,6 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         # simpler and faster navigation/checks and it has no effect in the serialized data formats anyway.
         self.parent: Optional[UniqueIdShortNamespace] = None
 
-        # Initialize with empty objects to avoid ValueError
-        self.display_name = MultiLanguageNameType({})
-        self.description = MultiLanguageTextType({})
-
     def __repr__(self) -> str:
         root = self.get_identifiable_root()
         try:
@@ -846,8 +842,8 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
     @display_name.setter
     def display_name(self, value: Optional[MultiLanguageNameType]) -> None:
         self._check_multiLanguageNameType(value)
-        self._display_name = value  
-        
+        self._display_name = value
+
     def _check_MultiLanguageTextType(self, value: Optional[MultiLanguageTextType]) -> None:
         """Ensure value is None or a MultiLanguageTextType."""
         if value is not None and not isinstance(value, MultiLanguageTextType):

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -342,8 +342,17 @@ class MultiLanguageProperty(DataElement):
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
         self.value: Optional[base.MultiLanguageTextType] = value
-        self.value_id: Optional[base.Reference] = value_id
+        self.value_id: Optional[base.Reference] = value_id 
 
+    @property
+    def value(self) -> base.MultiLanguageTextType | None:
+        return self._value
+    
+    @value.setter
+    def value(self, value: base.MultiLanguageTextType | dict | None) -> None:
+        if value is not None and not isinstance(value, base.MultiLanguageTextType):
+            value = base.MultiLanguageTextType(value)
+        self._value = value
 
 class Range(DataElement):
     """

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -342,17 +342,18 @@ class MultiLanguageProperty(DataElement):
         super().__init__(id_short, display_name, category, description, parent, semantic_id, qualifier, extension,
                          supplemental_semantic_id, embedded_data_specifications)
         self.value: Optional[base.MultiLanguageTextType] = value
-        self.value_id: Optional[base.Reference] = value_id 
+        self.value_id: Optional[base.Reference] = value_id
 
     @property
-    def value(self) -> base.MultiLanguageTextType | None:
+    def value(self) -> Optional[base.MultiLanguageTextType]:
         return self._value
-    
+
     @value.setter
-    def value(self, value: base.MultiLanguageTextType | dict | None) -> None:
+    def value(self, value: Union[base.MultiLanguageTextType, dict, None]) -> None:
         if value is not None and not isinstance(value, base.MultiLanguageTextType):
             value = base.MultiLanguageTextType(value)
         self._value = value
+
 
 class Range(DataElement):
     """


### PR DESCRIPTION
Previously, multilingual fields (`display_name`, `description`,
`MultiLanguageProperty.value`) could be assigned invalid types, leading to inconsistent
and sometimes invalid JSON/XML serialization.
As a result, this behavior could cause interoperability issues. 
 
The AAS specification requires these fields to be of type
`LangStringSet / MultiLanguageTextType`. This requirement is now
enforced to ensure spec-compliant serialization.

Fixes #416  