### PR TITLE
server/README.md: move documentation of unimplemented routes

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -126,6 +126,34 @@ The server can also be run directly on the host system without Docker, NGINX and
 
 The server can be accessed at http://localhost:8080/api/v3.0/ from your host system. 
 
+## Currently Unimplemented
+Several features and routes are currently not supported:
+
+1. Correlation ID: Not implemented because it was deemed unnecessary for this server.
+
+2. Extent Parameter (`withBlobValue/withoutBlobValue`):
+   Not implemented due to the lack of support in JSON/XML serialization.
+
+3. Route `/shells/{aasIdentifier}/asset-information/thumbnail`: Not implemented because the specification lacks clarity.
+
+4. Serialization and Description Routes:
+   - `/serialization`
+   - `/description`
+   These routes are not implemented at this time.
+
+5. Value, Path, and PATCH Routes:
+   - All `/…/value$`, `/…/path$`, and `PATCH` routes are currently not implemented.
+
+6. Operation Invocation Routes: The following routes are not implemented because operation invocation
+   is not yet supported by the `basyx-python-sdk`:
+   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke`
+   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value`
+   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async`
+   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value`
+   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}`
+   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}`
+   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value`
+
 ## Acknowledgments
 
 This Dockerfile is inspired by the [tiangolo/uwsgi-nginx-docker][10] repository.

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -6,32 +6,6 @@
 # SPDX-License-Identifier: MIT
 """
 This module implements the "Specification of the Asset Administration Shell Part 2 Application Programming Interfaces".
-However, several features and routes are currently not supported:
-
-1. Correlation ID: Not implemented because it was deemed unnecessary for this server.
-
-2. Extent Parameter (`withBlobValue/withoutBlobValue`):
-   Not implemented due to the lack of support in JSON/XML serialization.
-
-3. Route `/shells/{aasIdentifier}/asset-information/thumbnail`: Not implemented because the specification lacks clarity.
-
-4. Serialization and Description Routes:
-   - `/serialization`
-   - `/description`
-   These routes are not implemented at this time.
-
-5. Value, Path, and PATCH Routes:
-   - All `/…/value$`, `/…/path$`, and `PATCH` routes are currently not implemented.
-
-6. Operation Invocation Routes: The following routes are not implemented because operation invocation
-   is not yet supported by the `basyx-python-sdk`:
-   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke`
-   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value`
-   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async`
-   - `POST /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value`
-   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}`
-   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}`
-   - `GET /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value`
 """
 
 import io


### PR DESCRIPTION
We will have to pay attention to update the list of undocumented routes when merging with the [API V3.1 branch](https://github.com/eclipse-basyx/basyx-python-sdk/pull/421).
Fixes #380 