### PR TITLE
AASXReader additional Unittests

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -250,8 +250,8 @@ class AASXReaderTest(unittest.TestCase):
             )
         finally:
             os.unlink(filename)
-            
-            
+
+
 class AASXWriterReferencedSubmodelsTest(unittest.TestCase):
 
     def test_only_referenced_submodels(self):

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -130,7 +130,6 @@ class AASXWriterTest(unittest.TestCase):
 
 class AASXReaderTest(unittest.TestCase):
     def _create_test_aasx(self) -> str:
-        """create a temporary AASX file using the AASXWriter (tested before) and return its filename"""
         data = example_aas.create_full_example()
         files = aasx.DictSupplementaryFileContainer()
 
@@ -188,7 +187,7 @@ class AASXReaderTest(unittest.TestCase):
         filename = self._create_test_aasx()
 
         try:
-            objects = model.DictObjectStore()
+            objects: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
             files = aasx.DictSupplementaryFileContainer()
 
             with warnings.catch_warnings(record=True) as w:
@@ -196,13 +195,10 @@ class AASXReaderTest(unittest.TestCase):
                     ids = reader.read_into(objects, files)
 
             assert isinstance(w, list)
-            self.assertEqual(0, len(w))     #Ensure no warnings were raised
+            self.assertEqual(0, len(w))     # Ensure no warnings were raised
 
-            # Objects populated
-            self.assertGreater(len(ids), 0)     #Ensure at least one AAS was read
-            self.assertGreater(len(objects), 0)     #Ensure objects were populated
-
-            # Files populated
+            self.assertGreater(len(ids), 0)     # Ensure at least one AAS was read
+            self.assertGreater(len(objects), 0)     # Ensure objects were populated
             self.assertGreater(len(files), 0)
             self.assertEqual(
                 files.get_content_type("/TestFile.pdf"),
@@ -215,7 +211,7 @@ class AASXReaderTest(unittest.TestCase):
         filename = self._create_test_aasx()
 
         try:
-            objects = model.DictObjectStore()
+            objects: model.DictObjectStore[model.Identifiable] = model.DictObjectStore()
             files = aasx.DictSupplementaryFileContainer()
 
             with aasx.AASXReader(filename) as reader:

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -126,3 +126,107 @@ class AASXWriterTest(unittest.TestCase):
                                  "78450a66f59d74c073bf6858db340090ea72a8b1")
 
                 os.unlink(filename)
+
+
+class AASXReaderTest(unittest.TestCase):
+    def _create_test_aasx(self) -> str:
+        """create a temporary AASX file using the AASXWriter (tested before) and return its filename"""
+        data = example_aas.create_full_example()
+        files = aasx.DictSupplementaryFileContainer()
+
+        with open(os.path.join(os.path.dirname(__file__), 'TestFile.pdf'), 'rb') as f:
+            files.add_file("/TestFile.pdf", f, "application/pdf")
+            f.seek(0)
+
+        # Core properties
+        cp = pyecma376_2.OPCCoreProperties()
+        cp.created = datetime.datetime.now()
+        cp.creator = "Eclipse BaSyx Python Testing Framework"
+
+        fd, filename = tempfile.mkstemp(suffix=".aasx")
+        os.close(fd)
+
+        with aasx.AASXWriter(filename) as writer:
+            writer.write_aas(
+                'https://acplt.org/Test_AssetAdministrationShell',
+                data, files, write_json=False
+            )
+            writer.write_core_properties(cp)
+
+        return filename
+
+    def test_init_file_handling(self) -> None:
+        # Missing file assertion test
+        with self.assertRaises(FileNotFoundError):
+            aasx.AASXReader("does_not_exist.aasx")
+
+        # Invalid file assertion test
+        fd, invalid_path = tempfile.mkstemp()
+        os.write(fd, b"not a file")
+        os.close(fd)
+
+        try:
+            with self.assertRaises(ValueError):
+                aasx.AASXReader(invalid_path)
+        finally:
+            os.unlink(invalid_path)
+
+    def test_reading_core_properties(self) -> None:
+        filename = self._create_test_aasx()
+
+        try:
+            with aasx.AASXReader(filename) as reader:
+                cp = reader.get_core_properties()
+
+            self.assertIsInstance(cp.created, datetime.datetime)
+            self.assertEqual(cp.creator, "Eclipse BaSyx Python Testing Framework")
+            self.assertIsNone(cp.lastModifiedBy)
+        finally:
+            os.unlink(filename)
+
+    def test_read_into(self) -> None:
+        filename = self._create_test_aasx()
+
+        try:
+            objects = model.DictObjectStore()
+            files = aasx.DictSupplementaryFileContainer()
+
+            with warnings.catch_warnings(record=True) as w:
+                with aasx.AASXReader(filename) as reader:
+                    ids = reader.read_into(objects, files)
+
+            assert isinstance(w, list)
+            self.assertEqual(0, len(w))     #Ensure no warnings were raised
+
+            # Objects populated
+            self.assertGreater(len(ids), 0)     #Ensure at least one AAS was read
+            self.assertGreater(len(objects), 0)     #Ensure objects were populated
+
+            # Files populated
+            self.assertGreater(len(files), 0)
+            self.assertEqual(
+                files.get_content_type("/TestFile.pdf"),
+                "application/pdf"
+            )
+        finally:
+            os.unlink(filename)
+
+    def test_supplementary_file_integrity(self) -> None:
+        filename = self._create_test_aasx()
+
+        try:
+            objects = model.DictObjectStore()
+            files = aasx.DictSupplementaryFileContainer()
+
+            with aasx.AASXReader(filename) as reader:
+                reader.read_into(objects, files)
+
+            buf = io.BytesIO()
+            files.write_file("/TestFile.pdf", buf)
+
+            self.assertEqual(
+                hashlib.sha1(buf.getvalue()).hexdigest(),
+                "78450a66f59d74c073bf6858db340090ea72a8b1"
+            )
+        finally:
+            os.unlink(filename)


### PR DESCRIPTION
This adds an additional unittest for the `adatper.aasx.AASXReader` 
class. While the reading of AASX was previously implicitly tested by 
first reading and then writing AASX when testing the `AASXWriter`, this
adds dedicated test cases for the reading. 

Furthermore, we fix some years in the copyright notices of some files.

Fixes #441