### PR TITLE
etc/scripts/set_copyright_year.sh: Fix exit bug and check LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 the Eclipse BaSyx Authors
+Copyright (c) 2019-2026 the Eclipse BaSyx Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/compliance_tool/aas_compliance_tool/compliance_check_xml.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_xml.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/etc/scripts/set_copyright_year.sh
+++ b/etc/scripts/set_copyright_year.sh
@@ -2,13 +2,17 @@
 # Usage: ./set_copyright_year.sh [PATHS]
 #
 # This is a small script for setting the correct copyright year
-# for each given file (i.e. the year the file was last changed).
-# Instead of file paths you can also specify directories, in which
-# case the script will attempt to set the copyright year for all
-# files in the given directories. Globbing is also possible.
+# for each given source file (i.e. the year the file was last
+# changed) and LICENSE file (i.e. the latest modification year
+# across all files). Instead of file paths you can also specify
+# directories, in which case the script will attempt to set the
+# copyright year for all files in the given directories.
+# Globbing is also possible.
 #
-# The script will check the first two lines for a copyright
-# notice (in case the first line is a shebang).
+# In source files, the script checks the first two lines for a
+# copyright notice (in case the first line is a shebang).
+# In the LICENSE file, it checks the first three lines for a
+# copyright notice containing a year range.
 #
 # Run this script with --check to have it raise an error if it
 # would change anything.
@@ -17,32 +21,56 @@
 EXIT_CODE=0
 
 # Set CHECK_MODE based on whether --check is passed
-    CHECK_MODE=false
-    if [[ "$1" == "--check" ]]; then
-        CHECK_MODE=true
-        shift # Remove --check from the arguments
-    fi
+CHECK_MODE=false
+if [[ "$1" == "--check" ]]; then
+    CHECK_MODE=true
+    shift # Remove --check from the arguments
+fi
 
+# Initialise a variable to track the latest modification year across all files
+max_year=""
+
+# Validate the copyright year of each source file
 while read -rd $'\0' year file; do
+
+    # Extract the current modification year and update variable
+    if [[ -z "$max_year" || "$year" -gt "$max_year" ]]; then
+        max_year="$year"
+    fi
 
     # Extract the first year from the copyright notice
     current_year=$(sed -n '1,2s/^\(# Copyright (c) \)\([[:digit:]]\{4,\}\).*/\2/p' "$file")
 
-    # Skip the file if no year is found
+    # Skip the source file if no year is found
     if [[ -z "$current_year" ]]; then
         continue
     fi
 
+    # If in check mode, report the incorrect copyright year
     if $CHECK_MODE && [[ "$current_year" != "$year" ]]; then
         echo "Error: Copyright year mismatch in file $file. Expected $year, found $current_year."
-        # Set ERROR_CODE to 1 to indicate mismatch
-	ERROR_CODE=1
+        # Set EXIT_CODE to 1 to indicate mismatch
+        EXIT_CODE=1
     fi
 
+    # Otherwise rewrite the incorrect copyright year
     if ! $CHECK_MODE && [[ "$current_year" != "$year" ]]; then
         sed -i "1,2s/^\(# Copyright (c) \)[[:digit:]]\{4,\}/\1$year/" "$file"
         echo "Updated copyright year in $file"
     fi
 done < <(git ls-files -z "$@" | xargs -0I{} git log -1 -z --format="%cd {}" --date="format:%Y" -- "{}")
+
+# Validate the copyright year of the LICENSE file
+license_current_year=$(sed -n '1,3{s/^Copyright (c) [[:digit:]]\{4\}-\([[:digit:]]\{4\}\).*/\1/p}' LICENSE)
+
+if $CHECK_MODE && [[ -n "$license_current_year" && "$license_current_year" != "$max_year" ]]; then
+    echo "Error: Copyright year mismatch in file LICENSE. Expected $max_year, found $license_current_year."
+    EXIT_CODE=1
+fi
+
+if ! $CHECK_MODE && [[ -n "$license_current_year" && "$license_current_year" != "$max_year" ]]; then
+    sed -i "1,3s/^\(Copyright (c) [[:digit:]]\{4\}-\)[[:digit:]]\{4\}/\1$max_year/" LICENSE
+    echo "Updated copyright year in LICENSE"
+fi
 
 exit $EXIT_CODE

--- a/sdk/basyx/aas/util/identification.py
+++ b/sdk/basyx/aas/util/identification.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/adapter/json/test_json_serialization.py
+++ b/sdk/test/adapter/json/test_json_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/adapter/xml/test_xml_serialization.py
+++ b/sdk/test/adapter/xml/test_xml_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/examples/test_tutorials.py
+++ b/sdk/test/examples/test_tutorials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_provider.py
+++ b/sdk/test/model/test_provider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/util/test_identification.py
+++ b/sdk/test/util/test_identification.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.


### PR DESCRIPTION
Previously, the `EXIT_CODE` of the copyright year check was hardcoded to the value 0, causing the CI to pass unconditionally.

This fixes the bug by coupling the `EXIT_CODE` to the result of the copyright year check. Moreover, the check has been extended to additionally verify the copyright year of the `LICENSE` file.

Fixes #458