### PR TITLE
fix: Replace acplt.org with example.org in example data (#460)

### DIFF
--- a/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
+++ b/compliance_tool/aas_compliance_tool/compliance_check_aasx.py
@@ -238,10 +238,10 @@ def check_aas_example(file_path: str, state_manager: ComplianceToolStateManager,
 
     # Check if file in file object is the same
     list_of_id_shorts = ["ExampleSubmodelCollection", "ExampleFile"]
-    identifiable = example_data.get_item("https://acplt.org/Test_Submodel")
+    identifiable = example_data.get_item("https://example.org/Test_Submodel")
     for id_short in list_of_id_shorts:
         identifiable = identifiable.get_referable(id_short)
-    obj2 = identifiable_store.get_item("https://acplt.org/Test_Submodel")
+    obj2 = identifiable_store.get_item("https://example.org/Test_Submodel")
     for id_short in list_of_id_shorts:
         obj2 = obj2.get_referable(id_short)
     try:

--- a/compliance_tool/test/files/test_demo_full_example.json
+++ b/compliance_tool/test/files/test_demo_full_example.json
@@ -13,7 +13,7 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell",
+            "id": "https://example.org/Test_AssetAdministrationShell",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -22,24 +22,24 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell"
+                            "value": "http://example.org/AdministrativeInformation/Test_AssetAdministrationShell"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
             },
             "derivedFrom": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "AssetAdministrationShell",
-                        "value": "https://acplt.org/TestAssetAdministrationShell2"
+                        "value": "https://example.org/TestAssetAdministrationShell2"
                     }
                 ]
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset/",
+                "globalAssetId": "http://example.org/TestAsset/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -49,7 +49,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         },
@@ -58,13 +58,13 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
                     }
                 ],
-                "assetType": "http://acplt.org/TestAssetType/",
+                "assetType": "http://example.org/TestAssetType/",
                 "defaultThumbnail": {
                     "path": "file:///path/to/thumbnail.png",
                     "contentType": "image/png"
@@ -76,7 +76,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel"
+                            "value": "https://example.org/Test_Submodel"
                         }
                     ],
                     "referredSemanticId": {
@@ -84,7 +84,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                                "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                             }
                         ]
                     }
@@ -94,7 +94,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial"
                         }
                     ]
                 },
@@ -103,7 +103,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/Identification"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/Identification"
                         }
                     ],
                     "referredSemanticId": {
@@ -111,7 +111,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                                "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                             }
                         ]
                     }
@@ -167,11 +167,11 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                    "value": "http://example.org/Units/SpaceUnit"
                                 }
                             ]
                         },
-                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                         "symbol": "SU",
                         "valueFormat": "M",
                         "valueList": {
@@ -183,7 +183,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     }
@@ -195,7 +195,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                             }
                                         ]
                                     }
@@ -208,7 +208,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Values/TestValueId"
+                                    "value": "http://example.org/Values/TestValueId"
                                 }
                             ]
                         },
@@ -224,10 +224,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Mandatory/"
+                "globalAssetId": "http://example.org/Test_Asset_Mandatory/"
             },
             "submodels": [
                 {
@@ -235,7 +235,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel2_Mandatory"
+                            "value": "https://example.org/Test_Submodel2_Mandatory"
                         }
                     ]
                 },
@@ -244,7 +244,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Mandatory"
+                            "value": "https://example.org/Test_Submodel_Mandatory"
                         }
                     ]
                 }
@@ -252,10 +252,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
+                "globalAssetId": "http://example.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -271,14 +271,14 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Missing",
+            "id": "https://example.org/Test_AssetAdministrationShell_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Missing/",
+                "globalAssetId": "http://example.org/Test_Asset_Missing/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -288,7 +288,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
@@ -305,7 +305,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Missing"
+                            "value": "https://example.org/Test_Submodel_Missing"
                         }
                     ]
                 }
@@ -326,7 +326,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/Identification",
+            "id": "http://example.org/Submodels/Assets/TestAsset/Identification",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -335,18 +335,18 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/TestAsset/Identification"
+                            "value": "http://example.org/AdministrativeInformation/TestAsset/Identification"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/Identification"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                        "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                     }
                 ]
             },
@@ -361,7 +361,7 @@
                                     "keys": [
                                         {
                                             "type": "AssetAdministrationShell",
-                                            "value": "http://acplt.org/RefersTo/ExampleRefersTo"
+                                            "value": "http://example.org/RefersTo/ExampleRefersTo"
                                         }
                                     ]
                                 }
@@ -400,12 +400,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier2",
+                            "type": "http://example.org/Qualifier/ExampleQualifier2",
                             "kind": "TemplateQualifier"
                         },
                         {
@@ -415,12 +415,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier",
+                            "type": "http://example.org/Qualifier/ExampleQualifier",
                             "kind": "ConceptQualifier"
                         }
                     ],
@@ -430,7 +430,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -467,12 +467,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:dateTime",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier3",
+                            "type": "http://example.org/Qualifier/ExampleQualifier3",
                             "kind": "ValueQualifier"
                         }
                     ],
@@ -482,7 +482,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -503,17 +503,17 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial",
+            "id": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial",
             "administration": {
                 "version": "9",
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/BillOfMaterial"
+                        "value": "http://example.org/SubmodelTemplates/BillOfMaterial"
                     }
                 ]
             },
@@ -561,7 +561,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -571,7 +571,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -596,7 +596,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -606,7 +606,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -661,11 +661,11 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                                    "value": "http://example.org/Units/SpaceUnit"
                                                 }
                                             ]
                                         },
-                                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                         "symbol": "SU",
                                         "valueFormat": "M",
                                         "valueList": {
@@ -677,7 +677,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                "value": "http://example.org/ValueId/ExampleValueId"
                                                             }
                                                         ]
                                                     },
@@ -690,7 +690,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                                             }
                                                         ]
                                                     },
@@ -704,7 +704,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Values/TestValueId"
+                                                    "value": "http://example.org/Values/TestValueId"
                                                 }
                                             ]
                                         },
@@ -720,7 +720,7 @@
                         }
                     ],
                     "entityType": "SelfManagedEntity",
-                    "globalAssetId": "http://acplt.org/TestAsset/",
+                    "globalAssetId": "http://example.org/TestAsset/",
                     "specificAssetIds": [
                         {
                             "name": "TestKey",
@@ -730,7 +730,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SpecificAssetId/"
+                                        "value": "http://example.org/SpecificAssetId/"
                                     }
                                 ]
                             }
@@ -777,7 +777,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel",
+            "id": "https://example.org/Test_Submodel",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -786,7 +786,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_Submodel"
+                            "value": "http://example.org/AdministrativeInformation/Test_Submodel"
                         }
                     ]
                 }
@@ -796,7 +796,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -820,7 +820,7 @@
                         "keys": [
                             {
                                 "type": "ConceptDescription",
-                                "value": "https://acplt.org/Test_ConceptDescription"
+                                "value": "https://example.org/Test_ConceptDescription"
                             }
                         ]
                     },
@@ -829,7 +829,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -842,7 +842,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -870,7 +870,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -879,7 +879,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -892,7 +892,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -937,7 +937,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -972,7 +972,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -983,7 +983,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1022,7 +1022,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -1033,7 +1033,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1072,7 +1072,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -1083,7 +1083,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1111,7 +1111,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -1135,7 +1135,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -1144,7 +1144,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1160,7 +1160,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -1187,7 +1187,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -1211,7 +1211,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -1237,7 +1237,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1263,7 +1263,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1289,7 +1289,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ],
                                 "referredSemanticId": {
@@ -1297,7 +1297,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExampleProperty/Referred"
+                                            "value": "http://example.org/Properties/ExampleProperty/Referred"
                                         }
                                     ]
                                 }
@@ -1317,7 +1317,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleMultiLanguageValueId"
+                                        "value": "http://example.org/ValueId/ExampleMultiLanguageValueId"
                                     }
                                 ]
                             }
@@ -1341,7 +1341,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -1368,7 +1368,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -1377,7 +1377,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -1395,7 +1395,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -1417,7 +1417,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                        "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                                     }
                                 ]
                             },
@@ -1450,7 +1450,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1460,7 +1460,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId1"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId1"
                                                 }
                                             ]
                                         },
@@ -1469,7 +1469,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId2"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId2"
                                                 }
                                             ]
                                         }
@@ -1480,7 +1480,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1535,11 +1535,11 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Units/SpaceUnit"
+                                                            "value": "http://example.org/Units/SpaceUnit"
                                                         }
                                                     ]
                                                 },
-                                                "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                                "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                                 "symbol": "SU",
                                                 "valueFormat": "M",
                                                 "valueList": {
@@ -1551,7 +1551,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId"
                                                                     }
                                                                 ]
                                                             }
@@ -1563,7 +1563,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId2"
                                                                     }
                                                                 ]
                                                             }
@@ -1576,7 +1576,7 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Values/TestValueId"
+                                                            "value": "http://example.org/Values/TestValueId"
                                                         }
                                                     ]
                                                 },
@@ -1618,7 +1618,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1628,7 +1628,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty2/SupplementalId"
+                                                    "value": "http://example.org/Properties/ExampleProperty2/SupplementalId"
                                                 }
                                             ]
                                         }
@@ -1639,7 +1639,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1653,7 +1653,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Mandatory",
+            "id": "https://example.org/Test_Submodel_Mandatory",
             "submodelElements": [
                 {
                     "idShort": "ExampleRelationshipElement",
@@ -1663,7 +1663,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1676,7 +1676,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1693,7 +1693,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1706,7 +1706,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1731,7 +1731,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1798,7 +1798,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel2_Mandatory"
+            "id": "https://example.org/Test_Submodel2_Mandatory"
         },
         {
             "idShort": "TestSubmodel",
@@ -1813,7 +1813,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Missing",
+            "id": "https://example.org/Test_Submodel_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -1823,7 +1823,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -1847,7 +1847,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -1856,7 +1856,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1869,7 +1869,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1897,7 +1897,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -1906,7 +1906,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1919,7 +1919,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1964,7 +1964,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -1999,7 +1999,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2010,7 +2010,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2049,7 +2049,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2060,7 +2060,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2099,7 +2099,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2110,7 +2110,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2138,7 +2138,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -2162,7 +2162,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2171,7 +2171,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2187,7 +2187,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2214,7 +2214,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2238,7 +2238,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2264,7 +2264,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2290,7 +2290,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2324,14 +2324,14 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
                             "qualifiers": [
                                 {
                                     "valueType": "xs:string",
-                                    "type": "http://acplt.org/Qualifier/ExampleQualifier"
+                                    "type": "http://example.org/Qualifier/ExampleQualifier"
                                 }
                             ],
                             "value": "exampleValue",
@@ -2356,7 +2356,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2383,7 +2383,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2392,7 +2392,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -2418,7 +2418,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Template",
+            "id": "https://example.org/Test_Submodel_Template",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -2428,7 +2428,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -2453,7 +2453,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -2463,7 +2463,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2476,7 +2476,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2504,7 +2504,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -2514,7 +2514,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2527,7 +2527,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2555,7 +2555,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -2581,7 +2581,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2611,7 +2611,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2641,7 +2641,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2670,7 +2670,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     },
@@ -2695,7 +2695,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2705,7 +2705,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2721,7 +2721,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2737,7 +2737,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2759,7 +2759,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -2783,7 +2783,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2808,7 +2808,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -2834,7 +2834,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2859,7 +2859,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2886,7 +2886,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2913,7 +2913,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2939,7 +2939,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2965,7 +2965,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2991,7 +2991,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3007,7 +3007,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3029,7 +3029,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -3052,7 +3052,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription",
+            "id": "https://example.org/Test_ConceptDescription",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -3061,11 +3061,11 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_ConceptDescription"
+                            "value": "http://example.org/AdministrativeInformation/Test_ConceptDescription"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription",
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription",
                 "embeddedDataSpecifications": [
                     {
                         "dataSpecification": {
@@ -3116,11 +3116,11 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Units/SpaceUnit"
+                                        "value": "http://example.org/Units/SpaceUnit"
                                     }
                                 ]
                             },
-                            "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                            "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                             "symbol": "SU",
                             "valueFormat": "M",
                             "valueList": {
@@ -3132,7 +3132,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                    "value": "http://example.org/ValueId/ExampleValueId"
                                                 }
                                             ]
                                         }
@@ -3144,7 +3144,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                    "value": "http://example.org/ValueId/ExampleValueId2"
                                                 }
                                             ]
                                         }
@@ -3157,7 +3157,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Values/TestValueId"
+                                        "value": "http://example.org/Values/TestValueId"
                                     }
                                 ]
                             },
@@ -3177,7 +3177,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
+                            "value": "http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
                         }
                     ]
                 }
@@ -3185,7 +3185,7 @@
         },
         {
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Mandatory"
+            "id": "https://example.org/Test_ConceptDescription_Mandatory"
         },
         {
             "idShort": "TestConceptDescription",
@@ -3200,7 +3200,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Missing",
+            "id": "https://example.org/Test_ConceptDescription_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"

--- a/compliance_tool/test/files/test_demo_full_example.xml
+++ b/compliance_tool/test/files/test_demo_full_example.xml
@@ -21,13 +21,13 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell</aas:id>
       <aas:embeddedDataSpecifications>
         <aas:embeddedDataSpecification>
           <aas:dataSpecification>
@@ -67,11 +67,11 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                    <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:unitId>
-              <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+              <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
               <aas:symbol>SU</aas:symbol>
               <aas:dataType>REAL_MEASURE</aas:dataType>
               <aas:definition>
@@ -94,7 +94,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -106,7 +106,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -129,13 +129,13 @@
         <aas:keys>
           <aas:key>
             <aas:type>AssetAdministrationShell</aas:type>
-            <aas:value>https://acplt.org/TestAssetAdministrationShell2</aas:value>
+            <aas:value>https://example.org/TestAssetAdministrationShell2</aas:value>
           </aas:key>
         </aas:keys>
       </aas:derivedFrom>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:semanticId>
@@ -143,7 +143,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:semanticId>
@@ -154,13 +154,13 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
           </aas:specificAssetId>
         </aas:specificAssetIds>
-        <aas:assetType>http://acplt.org/TestAssetType/</aas:assetType>
+        <aas:assetType>http://example.org/TestAssetType/</aas:assetType>
         <aas:defaultThumbnail>
           <aas:path>file:///path/to/thumbnail.png</aas:path>
           <aas:contentType>image/png</aas:contentType>
@@ -174,14 +174,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -192,14 +192,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel</aas:value>
+              <aas:value>https://example.org/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -208,17 +208,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
       <aas:submodels>
         <aas:reference>
@@ -226,7 +226,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel2_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel2_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -235,17 +235,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -264,10 +264,10 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Missing</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Missing</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Missing/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Missing/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:name>TestKey</aas:name>
@@ -277,7 +277,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -294,7 +294,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Missing</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Missing</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -322,20 +322,20 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/Identification</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -352,7 +352,7 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>AssetAdministrationShell</aas:type>
-                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                      <aas:value>http://example.org/RefersTo/ExampleRefersTo</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:reference>
@@ -383,7 +383,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ConceptQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>100</aas:value>
               <aas:valueId>
@@ -391,14 +391,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:qualifier>
             <aas:qualifier>
               <aas:kind>TemplateQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier2</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier2</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>50</aas:value>
               <aas:valueId>
@@ -406,7 +406,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -419,7 +419,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -449,7 +449,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ValueQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier3</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier3</aas:type>
               <aas:valueType>xs:dateTime</aas:valueType>
               <aas:value>2023-04-07T16:59:54.870123</aas:value>
               <aas:valueId>
@@ -457,7 +457,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -470,7 +470,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -491,16 +491,16 @@
       </aas:description>
       <aas:administration>
         <aas:version>9</aas:version>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/BillOfMaterial</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/BillOfMaterial</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -546,7 +546,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -557,7 +557,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -580,7 +580,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -591,14 +591,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:property>
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
-          <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+          <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
           <aas:specificAssetIds>
             <aas:specificAssetId>
               <aas:name>TestKey</aas:name>
@@ -608,7 +608,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                    <aas:value>http://example.org/SpecificAssetId/</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:externalSubjectId>
@@ -661,19 +661,19 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_Submodel</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel</aas:id>
+      <aas:id>https://example.org/Test_Submodel</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -696,7 +696,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>ConceptDescription</aas:type>
-                <aas:value>https://acplt.org/Test_ConceptDescription</aas:value>
+                <aas:value>https://example.org/Test_ConceptDescription</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -705,7 +705,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -718,7 +718,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -745,7 +745,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -754,7 +754,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -767,7 +767,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -809,7 +809,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -844,7 +844,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -855,7 +855,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -894,7 +894,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -905,7 +905,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -944,7 +944,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -955,7 +955,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -982,7 +982,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1005,7 +1005,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1014,7 +1014,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1030,7 +1030,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -1056,7 +1056,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1079,7 +1079,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1104,7 +1104,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1129,7 +1129,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1154,7 +1154,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                    <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1164,7 +1164,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticIdListElement>
@@ -1198,7 +1198,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1208,7 +1208,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId1</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId1</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1217,7 +1217,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId2</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1261,11 +1261,11 @@
                             <aas:keys>
                               <aas:key>
                                 <aas:type>GlobalReference</aas:type>
-                                <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                                <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                               </aas:key>
                             </aas:keys>
                           </aas:unitId>
-                          <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                          <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                           <aas:symbol>SU</aas:symbol>
                           <aas:dataType>REAL_MEASURE</aas:dataType>
                           <aas:definition>
@@ -1288,7 +1288,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1300,7 +1300,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1325,7 +1325,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1357,7 +1357,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1367,7 +1367,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty2/SupplementalId</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty2/SupplementalId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1379,7 +1379,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1406,14 +1406,14 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Properties/ExampleProperty/Referred</aas:value>
+                      <aas:value>http://example.org/Properties/ExampleProperty/Referred</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:referredSemanticId>
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1432,7 +1432,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleMultiLanguageValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleMultiLanguageValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -1455,7 +1455,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1481,7 +1481,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1490,7 +1490,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -1504,7 +1504,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:submodelElements>
         <aas:relationshipElement>
@@ -1514,7 +1514,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1527,7 +1527,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1543,7 +1543,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1556,7 +1556,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1578,7 +1578,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1635,7 +1635,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel2_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
     </aas:submodel>
     <aas:submodel>
@@ -1654,14 +1654,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Missing</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Missing</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -1684,7 +1684,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1693,7 +1693,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1706,7 +1706,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1733,7 +1733,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1742,7 +1742,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1755,7 +1755,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1797,7 +1797,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1832,7 +1832,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1843,7 +1843,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1882,7 +1882,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1893,7 +1893,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1932,7 +1932,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1943,7 +1943,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1970,7 +1970,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1993,7 +1993,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2002,7 +2002,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2018,7 +2018,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2044,7 +2044,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2067,7 +2067,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2092,7 +2092,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2117,7 +2117,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2150,13 +2150,13 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
               <aas:qualifiers>
                 <aas:qualifier>
-                  <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+                  <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:qualifier>
               </aas:qualifiers>
@@ -2181,7 +2181,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2207,7 +2207,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2216,7 +2216,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -2245,14 +2245,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Template</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Template</aas:id>
       <aas:kind>Template</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -2275,7 +2275,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2284,7 +2284,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2297,7 +2297,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2324,7 +2324,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2333,7 +2333,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2346,7 +2346,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2373,7 +2373,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2398,7 +2398,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2428,7 +2428,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2458,7 +2458,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2486,7 +2486,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2509,7 +2509,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2518,7 +2518,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2534,7 +2534,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2560,7 +2560,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2570,7 +2570,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2593,7 +2593,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2616,7 +2616,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2640,7 +2640,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                        <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2663,7 +2663,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2688,7 +2688,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2713,7 +2713,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                        <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2738,7 +2738,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                        <aas:value>http://example.org/Files/ExampleFile</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2762,7 +2762,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                        <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2786,7 +2786,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2811,7 +2811,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2821,7 +2821,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2883,11 +2883,11 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                      <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:unitId>
-                <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                 <aas:symbol>SU</aas:symbol>
                 <aas:dataType>REAL_MEASURE</aas:dataType>
                 <aas:definition>
@@ -2910,7 +2910,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2922,7 +2922,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2947,27 +2947,27 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription</aas:id>
       <aas:isCaseOf>
         <aas:reference>
           <aas:type>ExternalReference</aas:type>
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
+              <aas:value>http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:isCaseOf>
     </aas:conceptDescription>
     <aas:conceptDescription>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Mandatory</aas:id>
     </aas:conceptDescription>
     <aas:conceptDescription>
       <aas:idShort>TestConceptDescription</aas:idShort>
@@ -2985,7 +2985,7 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Missing</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Missing</aas:id>
     </aas:conceptDescription>
   </aas:conceptDescriptions>
 </aas:environment>

--- a/compliance_tool/test/files/test_demo_full_example_json_aasx/aasx/data.json
+++ b/compliance_tool/test/files/test_demo_full_example_json_aasx/aasx/data.json
@@ -13,7 +13,7 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell",
+            "id": "https://example.org/Test_AssetAdministrationShell",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -22,24 +22,24 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell"
+                            "value": "http://example.org/AdministrativeInformation/Test_AssetAdministrationShell"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
             },
             "derivedFrom": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "AssetAdministrationShell",
-                        "value": "https://acplt.org/TestAssetAdministrationShell2"
+                        "value": "https://example.org/TestAssetAdministrationShell2"
                     }
                 ]
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset/",
+                "globalAssetId": "http://example.org/TestAsset/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -49,7 +49,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         },
@@ -58,7 +58,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
@@ -75,7 +75,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel"
+                            "value": "https://example.org/Test_Submodel"
                         }
                     ],
                     "referredSemanticId": {
@@ -83,7 +83,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                                "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                             }
                         ]
                     }
@@ -93,7 +93,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial"
                         }
                     ]
                 },
@@ -102,7 +102,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/Identification"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/Identification"
                         }
                     ],
                     "referredSemanticId": {
@@ -110,7 +110,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                                "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                             }
                         ]
                     }
@@ -120,7 +120,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Template"
+                            "value": "https://example.org/Test_Submodel_Template"
                         }
                     ]
                 }
@@ -175,11 +175,11 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                    "value": "http://example.org/Units/SpaceUnit"
                                 }
                             ]
                         },
-                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                         "symbol": "SU",
                         "valueFormat": "M",
                         "valueList": {
@@ -191,7 +191,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     }
@@ -203,7 +203,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                             }
                                         ]
                                     }
@@ -216,7 +216,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Values/TestValueId"
+                                    "value": "http://example.org/Values/TestValueId"
                                 }
                             ]
                         },
@@ -232,10 +232,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Mandatory/"
+                "globalAssetId": "http://example.org/Test_Asset_Mandatory/"
             },
             "submodels": [
                 {
@@ -243,7 +243,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel2_Mandatory"
+                            "value": "https://example.org/Test_Submodel2_Mandatory"
                         }
                     ]
                 },
@@ -252,7 +252,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Mandatory"
+                            "value": "https://example.org/Test_Submodel_Mandatory"
                         }
                     ]
                 }
@@ -260,10 +260,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
+                "globalAssetId": "http://example.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -279,14 +279,14 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Missing",
+            "id": "https://example.org/Test_AssetAdministrationShell_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Missing/",
+                "globalAssetId": "http://example.org/Test_Asset_Missing/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -296,7 +296,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
@@ -313,7 +313,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Missing"
+                            "value": "https://example.org/Test_Submodel_Missing"
                         }
                     ]
                 }
@@ -334,7 +334,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/Identification",
+            "id": "http://example.org/Submodels/Assets/TestAsset/Identification",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -343,18 +343,18 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/TestAsset/Identification"
+                            "value": "http://example.org/AdministrativeInformation/TestAsset/Identification"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/Identification"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                        "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                     }
                 ]
             },
@@ -369,7 +369,7 @@
                                     "keys": [
                                         {
                                             "type": "AssetAdministrationShell",
-                                            "value": "http://acplt.org/RefersTo/ExampleRefersTo"
+                                            "value": "http://example.org/RefersTo/ExampleRefersTo"
                                         }
                                     ]
                                 }
@@ -408,12 +408,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier2",
+                            "type": "http://example.org/Qualifier/ExampleQualifier2",
                             "kind": "TemplateQualifier"
                         },
                         {
@@ -423,12 +423,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier",
+                            "type": "http://example.org/Qualifier/ExampleQualifier",
                             "kind": "ConceptQualifier"
                         }
                     ],
@@ -438,7 +438,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -475,12 +475,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:dateTime",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier3",
+                            "type": "http://example.org/Qualifier/ExampleQualifier3",
                             "kind": "ValueQualifier"
                         }
                     ],
@@ -490,7 +490,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -511,17 +511,17 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial",
+            "id": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial",
             "administration": {
                 "version": "9",
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/BillOfMaterial"
+                        "value": "http://example.org/SubmodelTemplates/BillOfMaterial"
                     }
                 ]
             },
@@ -569,7 +569,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -579,7 +579,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -604,7 +604,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -614,7 +614,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -669,11 +669,11 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                                    "value": "http://example.org/Units/SpaceUnit"
                                                 }
                                             ]
                                         },
-                                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                         "symbol": "SU",
                                         "valueFormat": "M",
                                         "valueList": {
@@ -685,7 +685,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                "value": "http://example.org/ValueId/ExampleValueId"
                                                             }
                                                         ]
                                                     },
@@ -698,7 +698,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                                             }
                                                         ]
                                                     },
@@ -712,7 +712,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Values/TestValueId"
+                                                    "value": "http://example.org/Values/TestValueId"
                                                 }
                                             ]
                                         },
@@ -728,7 +728,7 @@
                         }
                     ],
                     "entityType": "SelfManagedEntity",
-                    "globalAssetId": "http://acplt.org/TestAsset/",
+                    "globalAssetId": "http://example.org/TestAsset/",
                     "specificAssetIds": [
                         {
                             "name": "TestKey",
@@ -738,7 +738,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SpecificAssetId/"
+                                        "value": "http://example.org/SpecificAssetId/"
                                     }
                                 ]
                             }
@@ -785,7 +785,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel",
+            "id": "https://example.org/Test_Submodel",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -794,7 +794,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_Submodel"
+                            "value": "http://example.org/AdministrativeInformation/Test_Submodel"
                         }
                     ]
                 }
@@ -804,7 +804,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -828,7 +828,7 @@
                         "keys": [
                             {
                                 "type": "ConceptDescription",
-                                "value": "https://acplt.org/Test_ConceptDescription"
+                                "value": "https://example.org/Test_ConceptDescription"
                             }
                         ]
                     },
@@ -837,7 +837,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -850,7 +850,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -878,7 +878,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -887,7 +887,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -900,7 +900,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -945,7 +945,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -980,7 +980,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -991,7 +991,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1030,7 +1030,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -1041,7 +1041,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1080,7 +1080,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -1091,7 +1091,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1119,7 +1119,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -1143,7 +1143,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -1152,7 +1152,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1168,7 +1168,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -1195,7 +1195,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -1219,7 +1219,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -1245,7 +1245,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1271,7 +1271,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1297,7 +1297,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ],
                                 "referredSemanticId": {
@@ -1305,7 +1305,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExampleProperty/Referred"
+                                            "value": "http://example.org/Properties/ExampleProperty/Referred"
                                         }
                                     ]
                                 }
@@ -1325,7 +1325,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleMultiLanguageValueId"
+                                        "value": "http://example.org/ValueId/ExampleMultiLanguageValueId"
                                     }
                                 ]
                             }
@@ -1349,7 +1349,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -1376,7 +1376,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -1385,7 +1385,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -1403,7 +1403,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -1425,7 +1425,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                        "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                                     }
                                 ]
                             },
@@ -1458,7 +1458,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1468,7 +1468,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId1"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId1"
                                                 }
                                             ]
                                         },
@@ -1477,7 +1477,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId2"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId2"
                                                 }
                                             ]
                                         }
@@ -1488,7 +1488,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1543,11 +1543,11 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Units/SpaceUnit"
+                                                            "value": "http://example.org/Units/SpaceUnit"
                                                         }
                                                     ]
                                                 },
-                                                "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                                "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                                 "symbol": "SU",
                                                 "valueFormat": "M",
                                                 "valueList": {
@@ -1559,7 +1559,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId"
                                                                     }
                                                                 ]
                                                             }
@@ -1571,7 +1571,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId2"
                                                                     }
                                                                 ]
                                                             }
@@ -1584,7 +1584,7 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Values/TestValueId"
+                                                            "value": "http://example.org/Values/TestValueId"
                                                         }
                                                     ]
                                                 },
@@ -1626,7 +1626,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1636,7 +1636,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty2/SupplementalId"
+                                                    "value": "http://example.org/Properties/ExampleProperty2/SupplementalId"
                                                 }
                                             ]
                                         }
@@ -1647,7 +1647,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1661,7 +1661,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Mandatory",
+            "id": "https://example.org/Test_Submodel_Mandatory",
             "submodelElements": [
                 {
                     "idShort": "ExampleRelationshipElement",
@@ -1671,7 +1671,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1684,7 +1684,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1701,7 +1701,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1714,7 +1714,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1739,7 +1739,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1806,7 +1806,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel2_Mandatory"
+            "id": "https://example.org/Test_Submodel2_Mandatory"
         },
         {
             "idShort": "TestSubmodel",
@@ -1821,7 +1821,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Missing",
+            "id": "https://example.org/Test_Submodel_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -1831,7 +1831,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -1855,7 +1855,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -1864,7 +1864,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1877,7 +1877,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1905,7 +1905,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -1914,7 +1914,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1927,7 +1927,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1972,7 +1972,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -2007,7 +2007,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2018,7 +2018,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2057,7 +2057,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2068,7 +2068,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2107,7 +2107,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2118,7 +2118,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2146,7 +2146,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -2170,7 +2170,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2179,7 +2179,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2195,7 +2195,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2222,7 +2222,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2246,7 +2246,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2272,7 +2272,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2298,7 +2298,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2332,14 +2332,14 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
                             "qualifiers": [
                                 {
                                     "valueType": "xs:string",
-                                    "type": "http://acplt.org/Qualifier/ExampleQualifier"
+                                    "type": "http://example.org/Qualifier/ExampleQualifier"
                                 }
                             ],
                             "value": "exampleValue",
@@ -2364,7 +2364,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2391,7 +2391,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2400,7 +2400,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -2426,7 +2426,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Template",
+            "id": "https://example.org/Test_Submodel_Template",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -2436,7 +2436,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -2461,7 +2461,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -2471,7 +2471,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2484,7 +2484,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2512,7 +2512,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -2522,7 +2522,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2535,7 +2535,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2563,7 +2563,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -2589,7 +2589,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2619,7 +2619,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2649,7 +2649,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2678,7 +2678,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     },
@@ -2703,7 +2703,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2713,7 +2713,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2729,7 +2729,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2745,7 +2745,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2767,7 +2767,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -2791,7 +2791,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2816,7 +2816,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -2842,7 +2842,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2867,7 +2867,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2894,7 +2894,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2921,7 +2921,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2947,7 +2947,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2973,7 +2973,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2999,7 +2999,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3015,7 +3015,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3037,7 +3037,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -3060,7 +3060,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription",
+            "id": "https://example.org/Test_ConceptDescription",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -3069,11 +3069,11 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_ConceptDescription"
+                            "value": "http://example.org/AdministrativeInformation/Test_ConceptDescription"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription",
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription",
                 "embeddedDataSpecifications": [
                     {
                         "dataSpecification": {
@@ -3124,11 +3124,11 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Units/SpaceUnit"
+                                        "value": "http://example.org/Units/SpaceUnit"
                                     }
                                 ]
                             },
-                            "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                            "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                             "symbol": "SU",
                             "valueFormat": "M",
                             "valueList": {
@@ -3140,7 +3140,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                    "value": "http://example.org/ValueId/ExampleValueId"
                                                 }
                                             ]
                                         }
@@ -3152,7 +3152,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                    "value": "http://example.org/ValueId/ExampleValueId2"
                                                 }
                                             ]
                                         }
@@ -3165,7 +3165,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Values/TestValueId"
+                                        "value": "http://example.org/Values/TestValueId"
                                     }
                                 ]
                             },
@@ -3185,7 +3185,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
+                            "value": "http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
                         }
                     ]
                 }
@@ -3193,7 +3193,7 @@
         },
         {
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Mandatory"
+            "id": "https://example.org/Test_ConceptDescription_Mandatory"
         },
         {
             "idShort": "TestConceptDescription",
@@ -3208,7 +3208,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Missing",
+            "id": "https://example.org/Test_ConceptDescription_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"

--- a/compliance_tool/test/files/test_demo_full_example_wrong_attribute.json
+++ b/compliance_tool/test/files/test_demo_full_example_wrong_attribute.json
@@ -13,7 +13,7 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell",
+            "id": "https://example.org/Test_AssetAdministrationShell",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -22,24 +22,24 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell"
+                            "value": "http://example.org/AdministrativeInformation/Test_AssetAdministrationShell"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell"
             },
             "derivedFrom": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "AssetAdministrationShell",
-                        "value": "https://acplt.org/TestAssetAdministrationShell2"
+                        "value": "https://example.org/TestAssetAdministrationShell2"
                     }
                 ]
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset/",
+                "globalAssetId": "http://example.org/TestAsset/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -49,7 +49,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         },
@@ -58,13 +58,13 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
                     }
                 ],
-                "assetType": "http://acplt.org/TestAssetType/",
+                "assetType": "http://example.org/TestAssetType/",
                 "defaultThumbnail": {
                     "path": "file:///path/to/thumbnail.png",
                     "contentType": "image/png"
@@ -76,7 +76,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel"
+                            "value": "https://example.org/Test_Submodel"
                         }
                     ],
                     "referredSemanticId": {
@@ -84,7 +84,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                                "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                             }
                         ]
                     }
@@ -94,7 +94,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial"
                         }
                     ]
                 },
@@ -103,7 +103,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Submodels/Assets/TestAsset/Identification"
+                            "value": "http://example.org/Submodels/Assets/TestAsset/Identification"
                         }
                     ],
                     "referredSemanticId": {
@@ -111,7 +111,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                                "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                             }
                         ]
                     }
@@ -167,11 +167,11 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                    "value": "http://example.org/Units/SpaceUnit"
                                 }
                             ]
                         },
-                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                         "symbol": "SU",
                         "valueFormat": "M",
                         "valueList": {
@@ -183,7 +183,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     }
@@ -195,7 +195,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                             }
                                         ]
                                     }
@@ -208,7 +208,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/Values/TestValueId"
+                                    "value": "http://example.org/Values/TestValueId"
                                 }
                             ]
                         },
@@ -224,10 +224,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Mandatory/"
+                "globalAssetId": "http://example.org/Test_Asset_Mandatory/"
             },
             "submodels": [
                 {
@@ -235,7 +235,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel2_Mandatory"
+                            "value": "https://example.org/Test_Submodel2_Mandatory"
                         }
                     ]
                 },
@@ -244,7 +244,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Mandatory"
+                            "value": "https://example.org/Test_Submodel_Mandatory"
                         }
                     ]
                 }
@@ -252,10 +252,10 @@
         },
         {
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell2_Mandatory",
+            "id": "https://example.org/Test_AssetAdministrationShell2_Mandatory",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/TestAsset2_Mandatory/"
+                "globalAssetId": "http://example.org/TestAsset2_Mandatory/"
             }
         },
         {
@@ -271,14 +271,14 @@
                 }
             ],
             "modelType": "AssetAdministrationShell",
-            "id": "https://acplt.org/Test_AssetAdministrationShell_Missing",
+            "id": "https://example.org/Test_AssetAdministrationShell_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
             },
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset_Missing/",
+                "globalAssetId": "http://example.org/Test_Asset_Missing/",
                 "specificAssetIds": [
                     {
                         "name": "TestKey",
@@ -288,7 +288,7 @@
                             "keys": [
                                 {
                                     "type": "GlobalReference",
-                                    "value": "http://acplt.org/SpecificAssetId/"
+                                    "value": "http://example.org/SpecificAssetId/"
                                 }
                             ]
                         }
@@ -305,7 +305,7 @@
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "https://acplt.org/Test_Submodel_Missing"
+                            "value": "https://example.org/Test_Submodel_Missing"
                         }
                     ]
                 }
@@ -326,7 +326,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/Identification",
+            "id": "http://example.org/Submodels/Assets/TestAsset/Identification",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -335,18 +335,18 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/TestAsset/Identification"
+                            "value": "http://example.org/AdministrativeInformation/TestAsset/Identification"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/Identification"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/AssetIdentification"
+                        "value": "http://example.org/SubmodelTemplates/AssetIdentification"
                     }
                 ]
             },
@@ -361,7 +361,7 @@
                                     "keys": [
                                         {
                                             "type": "AssetAdministrationShell",
-                                            "value": "http://acplt.org/RefersTo/ExampleRefersTo"
+                                            "value": "http://example.org/RefersTo/ExampleRefersTo"
                                         }
                                     ]
                                 }
@@ -400,12 +400,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier2",
+                            "type": "http://example.org/Qualifier/ExampleQualifier2",
                             "kind": "TemplateQualifier"
                         },
                         {
@@ -415,12 +415,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:int",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier",
+                            "type": "http://example.org/Qualifier/ExampleQualifier",
                             "kind": "ConceptQualifier"
                         }
                     ],
@@ -430,7 +430,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -467,12 +467,12 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
                             "valueType": "xs:dateTime",
-                            "type": "http://acplt.org/Qualifier/ExampleQualifier3",
+                            "type": "http://example.org/Qualifier/ExampleQualifier3",
                             "kind": "ValueQualifier"
                         }
                     ],
@@ -482,7 +482,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                "value": "http://example.org/ValueId/ExampleValueId"
                             }
                         ]
                     },
@@ -503,17 +503,17 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial",
+            "id": "http://example.org/Submodels/Assets/TestAsset/BillOfMaterial",
             "administration": {
                 "version": "9",
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
+                "templateId": "http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial"
             },
             "semanticId": {
                 "type": "ModelReference",
                 "keys": [
                     {
                         "type": "Submodel",
-                        "value": "http://acplt.org/SubmodelTemplates/BillOfMaterial"
+                        "value": "http://example.org/SubmodelTemplates/BillOfMaterial"
                     }
                 ]
             },
@@ -561,7 +561,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -571,7 +571,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -596,7 +596,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -606,7 +606,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                        "value": "http://example.org/ValueId/ExampleValueId"
                                     }
                                 ]
                             },
@@ -661,11 +661,11 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Units/SpaceUnit"
+                                                    "value": "http://example.org/Units/SpaceUnit"
                                                 }
                                             ]
                                         },
-                                        "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                        "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                         "symbol": "SU",
                                         "valueFormat": "M",
                                         "valueList": {
@@ -677,7 +677,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                "value": "http://example.org/ValueId/ExampleValueId"
                                                             }
                                                         ]
                                                     },
@@ -690,7 +690,7 @@
                                                         "keys": [
                                                             {
                                                                 "type": "GlobalReference",
-                                                                "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                "value": "http://example.org/ValueId/ExampleValueId2"
                                                             }
                                                         ]
                                                     },
@@ -704,7 +704,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Values/TestValueId"
+                                                    "value": "http://example.org/Values/TestValueId"
                                                 }
                                             ]
                                         },
@@ -720,7 +720,7 @@
                         }
                     ],
                     "entityType": "SelfManagedEntity",
-                    "globalAssetId": "http://acplt.org/TestAsset/",
+                    "globalAssetId": "http://example.org/TestAsset/",
                     "specificAssetIds": [
                         {
                             "name": "TestKey",
@@ -730,7 +730,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SpecificAssetId/"
+                                        "value": "http://example.org/SpecificAssetId/"
                                     }
                                 ]
                             }
@@ -777,7 +777,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel",
+            "id": "https://example.org/Test_Submodel",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -786,7 +786,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_Submodel"
+                            "value": "http://example.org/AdministrativeInformation/Test_Submodel"
                         }
                     ]
                 }
@@ -796,7 +796,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -820,7 +820,7 @@
                         "keys": [
                             {
                                 "type": "ConceptDescription",
-                                "value": "https://acplt.org/Test_ConceptDescription"
+                                "value": "https://example.org/Test_ConceptDescription"
                             }
                         ]
                     },
@@ -829,7 +829,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -842,7 +842,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -870,7 +870,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -879,7 +879,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -892,7 +892,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -937,7 +937,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -972,7 +972,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -983,7 +983,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1022,7 +1022,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -1033,7 +1033,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1072,7 +1072,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -1083,7 +1083,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -1111,7 +1111,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -1135,7 +1135,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -1144,7 +1144,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1160,7 +1160,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -1187,7 +1187,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -1211,7 +1211,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -1237,7 +1237,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1263,7 +1263,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -1289,7 +1289,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ],
                                 "referredSemanticId": {
@@ -1297,7 +1297,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExampleProperty/Referred"
+                                            "value": "http://example.org/Properties/ExampleProperty/Referred"
                                         }
                                     ]
                                 }
@@ -1317,7 +1317,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ValueId/ExampleMultiLanguageValueId"
+                                        "value": "http://example.org/ValueId/ExampleMultiLanguageValueId"
                                     }
                                 ]
                             }
@@ -1341,7 +1341,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -1368,7 +1368,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -1377,7 +1377,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -1395,7 +1395,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -1417,7 +1417,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                        "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                                     }
                                 ]
                             },
@@ -1450,7 +1450,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1460,7 +1460,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId1"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId1"
                                                 }
                                             ]
                                         },
@@ -1469,7 +1469,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty/SupplementalId2"
+                                                    "value": "http://example.org/Properties/ExampleProperty/SupplementalId2"
                                                 }
                                             ]
                                         }
@@ -1480,7 +1480,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1535,11 +1535,11 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Units/SpaceUnit"
+                                                            "value": "http://example.org/Units/SpaceUnit"
                                                         }
                                                     ]
                                                 },
-                                                "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                                                "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                                                 "symbol": "SU",
                                                 "valueFormat": "M",
                                                 "valueList": {
@@ -1551,7 +1551,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId"
                                                                     }
                                                                 ]
                                                             }
@@ -1563,7 +1563,7 @@
                                                                 "keys": [
                                                                     {
                                                                         "type": "GlobalReference",
-                                                                        "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                                        "value": "http://example.org/ValueId/ExampleValueId2"
                                                                     }
                                                                 ]
                                                             }
@@ -1576,7 +1576,7 @@
                                                     "keys": [
                                                         {
                                                             "type": "GlobalReference",
-                                                            "value": "http://acplt.org/Values/TestValueId"
+                                                            "value": "http://example.org/Values/TestValueId"
                                                         }
                                                     ]
                                                 },
@@ -1618,7 +1618,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/Properties/ExampleProperty"
+                                                "value": "http://example.org/Properties/ExampleProperty"
                                             }
                                         ]
                                     },
@@ -1628,7 +1628,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/Properties/ExampleProperty2/SupplementalId"
+                                                    "value": "http://example.org/Properties/ExampleProperty2/SupplementalId"
                                                 }
                                             ]
                                         }
@@ -1639,7 +1639,7 @@
                                         "keys": [
                                             {
                                                 "type": "GlobalReference",
-                                                "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                "value": "http://example.org/ValueId/ExampleValueId"
                                             }
                                         ]
                                     },
@@ -1653,7 +1653,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Mandatory",
+            "id": "https://example.org/Test_Submodel_Mandatory",
             "submodelElements": [
                 {
                     "idShort": "ExampleRelationshipElement",
@@ -1663,7 +1663,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1676,7 +1676,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1693,7 +1693,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1706,7 +1706,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1731,7 +1731,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1798,7 +1798,7 @@
         },
         {
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel2_Mandatory"
+            "id": "https://example.org/Test_Submodel2_Mandatory"
         },
         {
             "idShort": "TestSubmodel",
@@ -1813,7 +1813,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Missing",
+            "id": "https://example.org/Test_Submodel_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -1823,7 +1823,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -1847,7 +1847,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -1856,7 +1856,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1869,7 +1869,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1897,7 +1897,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -1906,7 +1906,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1919,7 +1919,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -1964,7 +1964,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -1999,7 +1999,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2010,7 +2010,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2049,7 +2049,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2060,7 +2060,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2099,7 +2099,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2110,7 +2110,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/ValueId/ExampleValueId"
+                                            "value": "http://example.org/ValueId/ExampleValueId"
                                         }
                                     ]
                                 },
@@ -2138,7 +2138,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     }
@@ -2162,7 +2162,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2171,7 +2171,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2187,7 +2187,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2214,7 +2214,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2238,7 +2238,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2264,7 +2264,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2290,7 +2290,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2324,14 +2324,14 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
                             "qualifiers": [
                                 {
                                     "valueType": "xs:string",
-                                    "type": "http://acplt.org/Qualifier/ExampleQualifier"
+                                    "type": "http://example.org/Qualifier/ExampleQualifier"
                                 }
                             ],
                             "value": "exampleValue",
@@ -2356,7 +2356,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2383,7 +2383,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2392,7 +2392,7 @@
                                 "keys": [
                                     {
                                         "type": "Submodel",
-                                        "value": "http://acplt.org/Test_Submodel"
+                                        "value": "http://example.org/Test_Submodel"
                                     },
                                     {
                                         "type": "Property",
@@ -2418,7 +2418,7 @@
                 }
             ],
             "modelType": "Submodel",
-            "id": "https://acplt.org/Test_Submodel_Template",
+            "id": "https://example.org/Test_Submodel_Template",
             "administration": {
                 "version": "9",
                 "revision": "0"
@@ -2428,7 +2428,7 @@
                 "keys": [
                     {
                         "type": "GlobalReference",
-                        "value": "http://acplt.org/SubmodelTemplates/ExampleSubmodel"
+                        "value": "http://example.org/SubmodelTemplates/ExampleSubmodel"
                     }
                 ]
             },
@@ -2453,7 +2453,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleRelationshipElement"
                             }
                         ]
                     },
@@ -2463,7 +2463,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2476,7 +2476,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2504,7 +2504,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
+                                "value": "http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement"
                             }
                         ]
                     },
@@ -2514,7 +2514,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2527,7 +2527,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2555,7 +2555,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Operations/ExampleOperation"
+                                "value": "http://example.org/Operations/ExampleOperation"
                             }
                         ]
                     },
@@ -2581,7 +2581,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInput"
                                         }
                                     ]
                                 },
@@ -2611,7 +2611,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyOutput"
                                         }
                                     ]
                                 },
@@ -2641,7 +2641,7 @@
                                     "keys": [
                                         {
                                             "type": "GlobalReference",
-                                            "value": "http://acplt.org/Properties/ExamplePropertyInOutput"
+                                            "value": "http://example.org/Properties/ExamplePropertyInOutput"
                                         }
                                     ]
                                 },
@@ -2670,7 +2670,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Capabilities/ExampleCapability"
+                                "value": "http://example.org/Capabilities/ExampleCapability"
                             }
                         ]
                     },
@@ -2695,7 +2695,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/Events/ExampleBasicEventElement"
+                                "value": "http://example.org/Events/ExampleBasicEventElement"
                             }
                         ]
                     },
@@ -2705,7 +2705,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/Test_Submodel"
+                                "value": "http://example.org/Test_Submodel"
                             },
                             {
                                 "type": "Property",
@@ -2721,7 +2721,7 @@
                         "keys": [
                             {
                                 "type": "Submodel",
-                                "value": "http://acplt.org/ExampleMessageBroker"
+                                "value": "http://example.org/ExampleMessageBroker"
                             }
                         ]
                     },
@@ -2737,7 +2737,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2759,7 +2759,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -2783,7 +2783,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -2808,7 +2808,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Properties/ExampleProperty"
+                                        "value": "http://example.org/Properties/ExampleProperty"
                                     }
                                 ]
                             },
@@ -2834,7 +2834,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
+                                        "value": "http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty"
                                     }
                                 ]
                             },
@@ -2859,7 +2859,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2886,7 +2886,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Ranges/ExampleRange"
+                                        "value": "http://example.org/Ranges/ExampleRange"
                                     }
                                 ]
                             },
@@ -2913,7 +2913,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Blobs/ExampleBlob"
+                                        "value": "http://example.org/Blobs/ExampleBlob"
                                     }
                                 ]
                             },
@@ -2939,7 +2939,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Files/ExampleFile"
+                                        "value": "http://example.org/Files/ExampleFile"
                                     }
                                 ]
                             },
@@ -2965,7 +2965,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/ReferenceElements/ExampleReferenceElement"
+                                        "value": "http://example.org/ReferenceElements/ExampleReferenceElement"
                                     }
                                 ]
                             },
@@ -2991,7 +2991,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3007,7 +3007,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
+                                "value": "http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection"
                             }
                         ]
                     },
@@ -3029,7 +3029,7 @@
                         "keys": [
                             {
                                 "type": "GlobalReference",
-                                "value": "http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList"
+                                "value": "http://example.org/SubmodelElementLists/ExampleSubmodelElementList"
                             }
                         ]
                     },
@@ -3052,7 +3052,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription",
+            "id": "https://example.org/Test_ConceptDescription",
             "administration": {
                 "version": "9",
                 "revision": "0",
@@ -3061,11 +3061,11 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/AdministrativeInformation/Test_ConceptDescription"
+                            "value": "http://example.org/AdministrativeInformation/Test_ConceptDescription"
                         }
                     ]
                 },
-                "templateId": "http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription",
+                "templateId": "http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription",
                 "embeddedDataSpecifications": [
                     {
                         "dataSpecification": {
@@ -3116,11 +3116,11 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Units/SpaceUnit"
+                                        "value": "http://example.org/Units/SpaceUnit"
                                     }
                                 ]
                             },
-                            "sourceOfDefinition": "http://acplt.org/DataSpec/ExampleDef",
+                            "sourceOfDefinition": "http://example.org/DataSpec/ExampleDef",
                             "symbol": "SU",
                             "valueFormat": "M",
                             "valueList": {
@@ -3132,7 +3132,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId"
+                                                    "value": "http://example.org/ValueId/ExampleValueId"
                                                 }
                                             ]
                                         }
@@ -3144,7 +3144,7 @@
                                             "keys": [
                                                 {
                                                     "type": "GlobalReference",
-                                                    "value": "http://acplt.org/ValueId/ExampleValueId2"
+                                                    "value": "http://example.org/ValueId/ExampleValueId2"
                                                 }
                                             ]
                                         }
@@ -3157,7 +3157,7 @@
                                 "keys": [
                                     {
                                         "type": "GlobalReference",
-                                        "value": "http://acplt.org/Values/TestValueId"
+                                        "value": "http://example.org/Values/TestValueId"
                                     }
                                 ]
                             },
@@ -3177,7 +3177,7 @@
                     "keys": [
                         {
                             "type": "GlobalReference",
-                            "value": "http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
+                            "value": "http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription"
                         }
                     ]
                 }
@@ -3185,7 +3185,7 @@
         },
         {
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Mandatory"
+            "id": "https://example.org/Test_ConceptDescription_Mandatory"
         },
         {
             "idShort": "TestConceptDescription",
@@ -3200,7 +3200,7 @@
                 }
             ],
             "modelType": "ConceptDescription",
-            "id": "https://acplt.org/Test_ConceptDescription_Missing",
+            "id": "https://example.org/Test_ConceptDescription_Missing",
             "administration": {
                 "version": "9",
                 "revision": "0"

--- a/compliance_tool/test/files/test_demo_full_example_wrong_attribute.xml
+++ b/compliance_tool/test/files/test_demo_full_example_wrong_attribute.xml
@@ -21,13 +21,13 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell</aas:id>
       <aas:embeddedDataSpecifications>
         <aas:embeddedDataSpecification>
           <aas:dataSpecification>
@@ -67,11 +67,11 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                    <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:unitId>
-              <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+              <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
               <aas:symbol>SU</aas:symbol>
               <aas:dataType>REAL_MEASURE</aas:dataType>
               <aas:definition>
@@ -94,7 +94,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -106,7 +106,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -129,13 +129,13 @@
         <aas:keys>
           <aas:key>
             <aas:type>AssetAdministrationShell</aas:type>
-            <aas:value>https://acplt.org/TestAssetAdministrationShell2</aas:value>
+            <aas:value>https://example.org/TestAssetAdministrationShell2</aas:value>
           </aas:key>
         </aas:keys>
       </aas:derivedFrom>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:semanticId>
@@ -143,7 +143,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:semanticId>
@@ -154,13 +154,13 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
           </aas:specificAssetId>
         </aas:specificAssetIds>
-        <aas:assetType>http://acplt.org/TestAssetType/</aas:assetType>
+        <aas:assetType>http://example.org/TestAssetType/</aas:assetType>
         <aas:defaultThumbnail>
           <aas:path>file:///path/to/thumbnail.png</aas:path>
           <aas:contentType>image/png</aas:contentType>
@@ -174,14 +174,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -192,14 +192,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel</aas:value>
+              <aas:value>https://example.org/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -208,17 +208,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
       <aas:submodels>
         <aas:reference>
@@ -226,7 +226,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel2_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel2_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -235,17 +235,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -264,10 +264,10 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Missing</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Missing</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Missing/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Missing/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:name>TestKey</aas:name>
@@ -277,7 +277,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -294,7 +294,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Missing</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Missing</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -322,20 +322,20 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/Identification</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -352,7 +352,7 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>AssetAdministrationShell</aas:type>
-                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                      <aas:value>http://example.org/RefersTo/ExampleRefersTo</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:reference>
@@ -383,7 +383,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ConceptQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>100</aas:value>
               <aas:valueId>
@@ -391,14 +391,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:qualifier>
             <aas:qualifier>
               <aas:kind>TemplateQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier2</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier2</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>50</aas:value>
               <aas:valueId>
@@ -406,7 +406,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -419,7 +419,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -449,7 +449,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ValueQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier3</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier3</aas:type>
               <aas:valueType>xs:dateTime</aas:valueType>
               <aas:value>2023-04-07T16:59:54.870123</aas:value>
               <aas:valueId>
@@ -457,7 +457,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -470,7 +470,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -491,16 +491,16 @@
       </aas:description>
       <aas:administration>
         <aas:version>9</aas:version>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/BillOfMaterial</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/BillOfMaterial</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -546,7 +546,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -557,7 +557,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -580,7 +580,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -591,14 +591,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:property>
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
-          <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+          <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
           <aas:specificAssetIds>
             <aas:specificAssetId>
               <aas:name>TestKey</aas:name>
@@ -608,7 +608,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                    <aas:value>http://example.org/SpecificAssetId/</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:externalSubjectId>
@@ -661,19 +661,19 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_Submodel</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel</aas:id>
+      <aas:id>https://example.org/Test_Submodel</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -696,7 +696,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>ConceptDescription</aas:type>
-                <aas:value>https://acplt.org/Test_ConceptDescription</aas:value>
+                <aas:value>https://example.org/Test_ConceptDescription</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -705,7 +705,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -718,7 +718,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -745,7 +745,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -754,7 +754,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -767,7 +767,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -809,7 +809,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -844,7 +844,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -855,7 +855,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -894,7 +894,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -905,7 +905,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -944,7 +944,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -955,7 +955,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -982,7 +982,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1005,7 +1005,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1014,7 +1014,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1030,7 +1030,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -1056,7 +1056,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1079,7 +1079,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1104,7 +1104,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1129,7 +1129,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1154,7 +1154,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                    <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1164,7 +1164,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticIdListElement>
@@ -1198,7 +1198,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1208,7 +1208,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId1</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId1</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1217,7 +1217,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId2</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1261,11 +1261,11 @@
                             <aas:keys>
                               <aas:key>
                                 <aas:type>GlobalReference</aas:type>
-                                <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                                <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                               </aas:key>
                             </aas:keys>
                           </aas:unitId>
-                          <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                          <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                           <aas:symbol>SU</aas:symbol>
                           <aas:dataType>REAL_MEASURE</aas:dataType>
                           <aas:definition>
@@ -1288,7 +1288,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1300,7 +1300,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1325,7 +1325,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1357,7 +1357,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1367,7 +1367,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty2/SupplementalId</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty2/SupplementalId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1379,7 +1379,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1406,14 +1406,14 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Properties/ExampleProperty/Referred</aas:value>
+                      <aas:value>http://example.org/Properties/ExampleProperty/Referred</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:referredSemanticId>
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1432,7 +1432,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleMultiLanguageValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleMultiLanguageValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -1455,7 +1455,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1481,7 +1481,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1490,7 +1490,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -1504,7 +1504,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:submodelElements>
         <aas:relationshipElement>
@@ -1514,7 +1514,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1527,7 +1527,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1543,7 +1543,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1556,7 +1556,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1578,7 +1578,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1635,7 +1635,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel2_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
     </aas:submodel>
     <aas:submodel>
@@ -1654,14 +1654,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Missing</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Missing</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -1684,7 +1684,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1693,7 +1693,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1706,7 +1706,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1733,7 +1733,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1742,7 +1742,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1755,7 +1755,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1797,7 +1797,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1832,7 +1832,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1843,7 +1843,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1882,7 +1882,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1893,7 +1893,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1932,7 +1932,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1943,7 +1943,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1970,7 +1970,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1993,7 +1993,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2002,7 +2002,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2018,7 +2018,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2044,7 +2044,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2067,7 +2067,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2092,7 +2092,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2117,7 +2117,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2150,13 +2150,13 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
               <aas:qualifiers>
                 <aas:qualifier>
-                  <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+                  <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:qualifier>
               </aas:qualifiers>
@@ -2181,7 +2181,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2207,7 +2207,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2216,7 +2216,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -2245,14 +2245,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Template</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Template</aas:id>
       <aas:kind>Template</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -2275,7 +2275,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2284,7 +2284,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2297,7 +2297,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2324,7 +2324,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2333,7 +2333,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2346,7 +2346,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2373,7 +2373,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2398,7 +2398,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2428,7 +2428,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2458,7 +2458,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2486,7 +2486,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2509,7 +2509,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2518,7 +2518,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2534,7 +2534,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2560,7 +2560,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2570,7 +2570,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2593,7 +2593,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2616,7 +2616,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2640,7 +2640,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                        <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2663,7 +2663,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2688,7 +2688,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2713,7 +2713,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                        <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2738,7 +2738,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                        <aas:value>http://example.org/Files/ExampleFile</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2762,7 +2762,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                        <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2786,7 +2786,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2811,7 +2811,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2821,7 +2821,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2883,11 +2883,11 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                      <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:unitId>
-                <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                 <aas:symbol>SU</aas:symbol>
                 <aas:dataType>REAL_MEASURE</aas:dataType>
                 <aas:definition>
@@ -2910,7 +2910,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2922,7 +2922,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2947,27 +2947,27 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription</aas:id>
       <aas:isCaseOf>
         <aas:reference>
           <aas:type>ExternalReference</aas:type>
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
+              <aas:value>http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:isCaseOf>
     </aas:conceptDescription>
     <aas:conceptDescription>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Mandatory</aas:id>
     </aas:conceptDescription>
     <aas:conceptDescription>
       <aas:idShort>TestConceptDescription</aas:idShort>
@@ -2985,7 +2985,7 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Missing</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Missing</aas:id>
     </aas:conceptDescription>
   </aas:conceptDescriptions>
 </aas:environment>

--- a/compliance_tool/test/files/test_demo_full_example_xml_aasx/aasx/data.xml
+++ b/compliance_tool/test/files/test_demo_full_example_xml_aasx/aasx/data.xml
@@ -21,13 +21,13 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell</aas:id>
       <aas:embeddedDataSpecifications>
         <aas:embeddedDataSpecification>
           <aas:dataSpecification>
@@ -67,11 +67,11 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                    <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:unitId>
-              <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+              <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
               <aas:symbol>SU</aas:symbol>
               <aas:dataType>REAL_MEASURE</aas:dataType>
               <aas:definition>
@@ -94,7 +94,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -106,7 +106,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -129,13 +129,13 @@
         <aas:keys>
           <aas:key>
             <aas:type>AssetAdministrationShell</aas:type>
-            <aas:value>https://acplt.org/TestAssetAdministrationShell2</aas:value>
+            <aas:value>https://example.org/TestAssetAdministrationShell2</aas:value>
           </aas:key>
         </aas:keys>
       </aas:derivedFrom>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:semanticId>
@@ -143,7 +143,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:semanticId>
@@ -154,7 +154,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -173,14 +173,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -191,14 +191,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel</aas:value>
+              <aas:value>https://example.org/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -207,7 +207,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -216,17 +216,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Template</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Template</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
       <aas:submodels>
         <aas:reference>
@@ -234,7 +234,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel2_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel2_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -243,17 +243,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -272,10 +272,10 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Missing</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Missing</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Missing/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Missing/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:name>TestKey</aas:name>
@@ -285,7 +285,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -302,7 +302,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Missing</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Missing</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -330,20 +330,20 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/Identification</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -360,7 +360,7 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>AssetAdministrationShell</aas:type>
-                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                      <aas:value>http://example.org/RefersTo/ExampleRefersTo</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:reference>
@@ -391,7 +391,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ConceptQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>100</aas:value>
               <aas:valueId>
@@ -399,14 +399,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:qualifier>
             <aas:qualifier>
               <aas:kind>TemplateQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier2</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier2</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>50</aas:value>
               <aas:valueId>
@@ -414,7 +414,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -427,7 +427,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -457,7 +457,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ValueQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier3</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier3</aas:type>
               <aas:valueType>xs:dateTime</aas:valueType>
               <aas:value>2023-04-07T16:59:54.870123</aas:value>
               <aas:valueId>
@@ -465,7 +465,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -478,7 +478,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -499,16 +499,16 @@
       </aas:description>
       <aas:administration>
         <aas:version>9</aas:version>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/BillOfMaterial</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/BillOfMaterial</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -554,7 +554,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -565,7 +565,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -588,7 +588,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -599,14 +599,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:property>
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
-          <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+          <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
           <aas:specificAssetIds>
             <aas:specificAssetId>
               <aas:name>TestKey</aas:name>
@@ -616,7 +616,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                    <aas:value>http://example.org/SpecificAssetId/</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:externalSubjectId>
@@ -669,19 +669,19 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_Submodel</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel</aas:id>
+      <aas:id>https://example.org/Test_Submodel</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -704,7 +704,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>ConceptDescription</aas:type>
-                <aas:value>https://acplt.org/Test_ConceptDescription</aas:value>
+                <aas:value>https://example.org/Test_ConceptDescription</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -713,7 +713,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -726,7 +726,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -753,7 +753,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -762,7 +762,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -775,7 +775,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -817,7 +817,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -852,7 +852,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -863,7 +863,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -902,7 +902,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -913,7 +913,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -952,7 +952,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -963,7 +963,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -990,7 +990,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1013,7 +1013,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1022,7 +1022,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1038,7 +1038,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -1064,7 +1064,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1087,7 +1087,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1112,7 +1112,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1137,7 +1137,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1162,7 +1162,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                    <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1172,7 +1172,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticIdListElement>
@@ -1206,7 +1206,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1216,7 +1216,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId1</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId1</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1225,7 +1225,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId2</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1269,11 +1269,11 @@
                             <aas:keys>
                               <aas:key>
                                 <aas:type>GlobalReference</aas:type>
-                                <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                                <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                               </aas:key>
                             </aas:keys>
                           </aas:unitId>
-                          <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                          <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                           <aas:symbol>SU</aas:symbol>
                           <aas:dataType>REAL_MEASURE</aas:dataType>
                           <aas:definition>
@@ -1296,7 +1296,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1308,7 +1308,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1333,7 +1333,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1365,7 +1365,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1375,7 +1375,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty2/SupplementalId</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty2/SupplementalId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1387,7 +1387,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1414,14 +1414,14 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Properties/ExampleProperty/Referred</aas:value>
+                      <aas:value>http://example.org/Properties/ExampleProperty/Referred</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:referredSemanticId>
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1440,7 +1440,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleMultiLanguageValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleMultiLanguageValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -1463,7 +1463,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1489,7 +1489,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1498,7 +1498,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -1512,7 +1512,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:submodelElements>
         <aas:relationshipElement>
@@ -1522,7 +1522,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1535,7 +1535,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1551,7 +1551,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1564,7 +1564,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1586,7 +1586,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1643,7 +1643,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel2_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
     </aas:submodel>
     <aas:submodel>
@@ -1662,14 +1662,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Missing</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Missing</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -1692,7 +1692,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1701,7 +1701,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1714,7 +1714,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1741,7 +1741,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1750,7 +1750,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1763,7 +1763,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1805,7 +1805,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1840,7 +1840,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1851,7 +1851,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1890,7 +1890,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1901,7 +1901,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1940,7 +1940,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1951,7 +1951,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1978,7 +1978,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2001,7 +2001,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2010,7 +2010,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2026,7 +2026,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2052,7 +2052,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2075,7 +2075,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2100,7 +2100,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2125,7 +2125,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2158,13 +2158,13 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
               <aas:qualifiers>
                 <aas:qualifier>
-                  <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+                  <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:qualifier>
               </aas:qualifiers>
@@ -2189,7 +2189,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2215,7 +2215,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2224,7 +2224,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -2253,14 +2253,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Template</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Template</aas:id>
       <aas:kind>Template</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -2283,7 +2283,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2292,7 +2292,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2305,7 +2305,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2332,7 +2332,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2341,7 +2341,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2354,7 +2354,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2381,7 +2381,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2406,7 +2406,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2436,7 +2436,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2466,7 +2466,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2494,7 +2494,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2517,7 +2517,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2526,7 +2526,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2542,7 +2542,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2568,7 +2568,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2578,7 +2578,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2601,7 +2601,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2624,7 +2624,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2648,7 +2648,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                        <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2671,7 +2671,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2696,7 +2696,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2721,7 +2721,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                        <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2746,7 +2746,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                        <aas:value>http://example.org/Files/ExampleFile</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2770,7 +2770,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                        <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2794,7 +2794,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2819,7 +2819,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2829,7 +2829,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2891,11 +2891,11 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                      <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:unitId>
-                <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                 <aas:symbol>SU</aas:symbol>
                 <aas:dataType>REAL_MEASURE</aas:dataType>
                 <aas:definition>
@@ -2918,7 +2918,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2930,7 +2930,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2955,27 +2955,27 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription</aas:id>
       <aas:isCaseOf>
         <aas:reference>
           <aas:type>ExternalReference</aas:type>
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
+              <aas:value>http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:isCaseOf>
     </aas:conceptDescription>
     <aas:conceptDescription>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Mandatory</aas:id>
     </aas:conceptDescription>
     <aas:conceptDescription>
       <aas:idShort>TestConceptDescription</aas:idShort>
@@ -2993,7 +2993,7 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Missing</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Missing</aas:id>
     </aas:conceptDescription>
   </aas:conceptDescriptions>
 </aas:environment>

--- a/compliance_tool/test/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
+++ b/compliance_tool/test/files/test_demo_full_example_xml_wrong_attribute_aasx/aasx/data.xml
@@ -21,13 +21,13 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_AssetAdministrationShell</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_AssetAdministrationShell</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell</aas:id>
       <aas:embeddedDataSpecifications>
         <aas:embeddedDataSpecification>
           <aas:dataSpecification>
@@ -67,11 +67,11 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                    <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:unitId>
-              <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+              <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
               <aas:symbol>SU</aas:symbol>
               <aas:dataType>REAL_MEASURE</aas:dataType>
               <aas:definition>
@@ -94,7 +94,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -106,7 +106,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                          <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:valueId>
@@ -129,13 +129,13 @@
         <aas:keys>
           <aas:key>
             <aas:type>AssetAdministrationShell</aas:type>
-            <aas:value>https://acplt.org/TestAssetAdministrationShell2</aas:value>
+            <aas:value>https://example.org/TestAssetAdministrationShell2</aas:value>
           </aas:key>
         </aas:keys>
       </aas:derivedFrom>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:semanticId>
@@ -143,7 +143,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:semanticId>
@@ -154,7 +154,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -173,14 +173,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -191,14 +191,14 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+                <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
               </aas:key>
             </aas:keys>
           </aas:referredSemanticId>
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel</aas:value>
+              <aas:value>https://example.org/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -207,7 +207,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
+              <aas:value>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -216,17 +216,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Template</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Template</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
       <aas:submodels>
         <aas:reference>
@@ -234,7 +234,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel2_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel2_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -243,17 +243,17 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Mandatory</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Mandatory</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:submodels>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell2_Mandatory</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset2_Mandatory/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset2_Mandatory/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
     <aas:assetAdministrationShell>
@@ -272,10 +272,10 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell_Missing</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell_Missing</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/Test_Asset_Missing/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/Test_Asset_Missing/</aas:globalAssetId>
         <aas:specificAssetIds>
           <aas:specificAssetId>
             <aas:name>TestKey</aas:name>
@@ -285,7 +285,7 @@
               <aas:keys>
                 <aas:key>
                   <aas:type>GlobalReference</aas:type>
-                  <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                  <aas:value>http://example.org/SpecificAssetId/</aas:value>
                 </aas:key>
               </aas:keys>
             </aas:externalSubjectId>
@@ -302,7 +302,7 @@
           <aas:keys>
             <aas:key>
               <aas:type>Submodel</aas:type>
-              <aas:value>https://acplt.org/Test_Submodel_Missing</aas:value>
+              <aas:value>https://example.org/Test_Submodel_Missing</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
@@ -330,20 +330,20 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/TestAsset/Identification</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/TestAsset/Identification</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/Identification</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/Identification</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/Identification</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/AssetIdentification</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/AssetIdentification</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -360,7 +360,7 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>AssetAdministrationShell</aas:type>
-                      <aas:value>http://acplt.org/RefersTo/ExampleRefersTo</aas:value>
+                      <aas:value>http://example.org/RefersTo/ExampleRefersTo</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:reference>
@@ -391,7 +391,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ConceptQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>100</aas:value>
               <aas:valueId>
@@ -399,14 +399,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:qualifier>
             <aas:qualifier>
               <aas:kind>TemplateQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier2</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier2</aas:type>
               <aas:valueType>xs:int</aas:valueType>
               <aas:value>50</aas:value>
               <aas:valueId>
@@ -414,7 +414,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -427,7 +427,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -457,7 +457,7 @@
           <aas:qualifiers>
             <aas:qualifier>
               <aas:kind>ValueQualifier</aas:kind>
-              <aas:type>http://acplt.org/Qualifier/ExampleQualifier3</aas:type>
+              <aas:type>http://example.org/Qualifier/ExampleQualifier3</aas:type>
               <aas:valueType>xs:dateTime</aas:valueType>
               <aas:value>2023-04-07T16:59:54.870123</aas:value>
               <aas:valueId>
@@ -465,7 +465,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -478,7 +478,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
               </aas:key>
             </aas:keys>
           </aas:valueId>
@@ -499,16 +499,16 @@
       </aas:description>
       <aas:administration>
         <aas:version>9</aas:version>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/TestAsset/BillOfMaterial</aas:templateId>
       </aas:administration>
-      <aas:id>http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
+      <aas:id>http://example.org/Submodels/Assets/TestAsset/BillOfMaterial</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ModelReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>Submodel</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/BillOfMaterial</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/BillOfMaterial</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -554,7 +554,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -565,7 +565,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -588,7 +588,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -599,14 +599,14 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
             </aas:property>
           </aas:statements>
           <aas:entityType>SelfManagedEntity</aas:entityType>
-          <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+          <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
           <aas:specificAssetIds>
             <aas:specificAssetId>
               <aas:name>TestKey</aas:name>
@@ -616,7 +616,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SpecificAssetId/</aas:value>
+                    <aas:value>http://example.org/SpecificAssetId/</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:externalSubjectId>
@@ -669,19 +669,19 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_Submodel</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_Submodel</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel</aas:id>
+      <aas:id>https://example.org/Test_Submodel</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -704,7 +704,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>ConceptDescription</aas:type>
-                <aas:value>https://acplt.org/Test_ConceptDescription</aas:value>
+                <aas:value>https://example.org/Test_ConceptDescription</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -713,7 +713,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -726,7 +726,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -753,7 +753,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -762,7 +762,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -775,7 +775,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -817,7 +817,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -852,7 +852,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -863,7 +863,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -902,7 +902,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -913,7 +913,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -952,7 +952,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -963,7 +963,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -990,7 +990,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1013,7 +1013,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1022,7 +1022,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1038,7 +1038,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -1064,7 +1064,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1087,7 +1087,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1112,7 +1112,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1137,7 +1137,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1162,7 +1162,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                    <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1172,7 +1172,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticIdListElement>
@@ -1206,7 +1206,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1216,7 +1216,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId1</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId1</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1225,7 +1225,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty/SupplementalId2</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty/SupplementalId2</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1269,11 +1269,11 @@
                             <aas:keys>
                               <aas:key>
                                 <aas:type>GlobalReference</aas:type>
-                                <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                                <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                               </aas:key>
                             </aas:keys>
                           </aas:unitId>
-                          <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                          <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                           <aas:symbol>SU</aas:symbol>
                           <aas:dataType>REAL_MEASURE</aas:dataType>
                           <aas:definition>
@@ -1296,7 +1296,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1308,7 +1308,7 @@
                                   <aas:keys>
                                     <aas:key>
                                       <aas:type>GlobalReference</aas:type>
-                                      <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                                      <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                                     </aas:key>
                                   </aas:keys>
                                 </aas:valueId>
@@ -1333,7 +1333,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1365,7 +1365,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1375,7 +1375,7 @@
                       <aas:keys>
                         <aas:key>
                           <aas:type>GlobalReference</aas:type>
-                          <aas:value>http://acplt.org/Properties/ExampleProperty2/SupplementalId</aas:value>
+                          <aas:value>http://example.org/Properties/ExampleProperty2/SupplementalId</aas:value>
                         </aas:key>
                       </aas:keys>
                     </aas:reference>
@@ -1387,7 +1387,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1414,14 +1414,14 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Properties/ExampleProperty/Referred</aas:value>
+                      <aas:value>http://example.org/Properties/ExampleProperty/Referred</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:referredSemanticId>
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1440,7 +1440,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ValueId/ExampleMultiLanguageValueId</aas:value>
+                    <aas:value>http://example.org/ValueId/ExampleMultiLanguageValueId</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:valueId>
@@ -1463,7 +1463,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1489,7 +1489,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -1498,7 +1498,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -1512,7 +1512,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:submodelElements>
         <aas:relationshipElement>
@@ -1522,7 +1522,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1535,7 +1535,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1551,7 +1551,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1564,7 +1564,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1586,7 +1586,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1643,7 +1643,7 @@
       </aas:submodelElements>
     </aas:submodel>
     <aas:submodel>
-      <aas:id>https://acplt.org/Test_Submodel2_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_Submodel2_Mandatory</aas:id>
       <aas:kind>Instance</aas:kind>
     </aas:submodel>
     <aas:submodel>
@@ -1662,14 +1662,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Missing</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Missing</aas:id>
       <aas:kind>Instance</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -1692,7 +1692,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1701,7 +1701,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1714,7 +1714,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1741,7 +1741,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1750,7 +1750,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1763,7 +1763,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -1805,7 +1805,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -1840,7 +1840,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1851,7 +1851,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1890,7 +1890,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1901,7 +1901,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1940,7 +1940,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -1951,7 +1951,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                        <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:valueId>
@@ -1978,7 +1978,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2001,7 +2001,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2010,7 +2010,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2026,7 +2026,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2052,7 +2052,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2075,7 +2075,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                    <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2100,7 +2100,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                    <aas:value>http://example.org/Files/ExampleFile</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2125,7 +2125,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                    <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2158,13 +2158,13 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                    <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
               <aas:qualifiers>
                 <aas:qualifier>
-                  <aas:type>http://acplt.org/Qualifier/ExampleQualifier</aas:type>
+                  <aas:type>http://example.org/Qualifier/ExampleQualifier</aas:type>
                   <aas:valueType>xs:string</aas:valueType>
                 </aas:qualifier>
               </aas:qualifiers>
@@ -2189,7 +2189,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                    <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2215,7 +2215,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                    <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2224,7 +2224,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>Submodel</aas:type>
-                    <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                    <aas:value>http://example.org/Test_Submodel</aas:value>
                   </aas:key>
                   <aas:key>
                     <aas:type>Property</aas:type>
@@ -2253,14 +2253,14 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_Submodel_Template</aas:id>
+      <aas:id>https://example.org/Test_Submodel_Template</aas:id>
       <aas:kind>Template</aas:kind>
       <aas:semanticId>
         <aas:type>ExternalReference</aas:type>
         <aas:keys>
           <aas:key>
             <aas:type>GlobalReference</aas:type>
-            <aas:value>http://acplt.org/SubmodelTemplates/ExampleSubmodel</aas:value>
+            <aas:value>http://example.org/SubmodelTemplates/ExampleSubmodel</aas:value>
           </aas:key>
         </aas:keys>
       </aas:semanticId>
@@ -2283,7 +2283,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2292,7 +2292,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2305,7 +2305,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2332,7 +2332,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
+                <aas:value>http://example.org/RelationshipElements/ExampleAnnotatedRelationshipElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2341,7 +2341,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2354,7 +2354,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2381,7 +2381,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Operations/ExampleOperation</aas:value>
+                <aas:value>http://example.org/Operations/ExampleOperation</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2406,7 +2406,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2436,7 +2436,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2466,7 +2466,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExamplePropertyInOutput</aas:value>
+                        <aas:value>http://example.org/Properties/ExamplePropertyInOutput</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2494,7 +2494,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Capabilities/ExampleCapability</aas:value>
+                <aas:value>http://example.org/Capabilities/ExampleCapability</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2517,7 +2517,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/Events/ExampleBasicEventElement</aas:value>
+                <aas:value>http://example.org/Events/ExampleBasicEventElement</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2526,7 +2526,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/Test_Submodel</aas:value>
+                <aas:value>http://example.org/Test_Submodel</aas:value>
               </aas:key>
               <aas:key>
                 <aas:type>Property</aas:type>
@@ -2542,7 +2542,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>Submodel</aas:type>
-                <aas:value>http://acplt.org/ExampleMessageBroker</aas:value>
+                <aas:value>http://example.org/ExampleMessageBroker</aas:value>
               </aas:key>
             </aas:keys>
           </aas:messageBroker>
@@ -2568,7 +2568,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2578,7 +2578,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2601,7 +2601,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2624,7 +2624,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Properties/ExampleProperty</aas:value>
+                        <aas:value>http://example.org/Properties/ExampleProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2648,7 +2648,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
+                        <aas:value>http://example.org/MultiLanguageProperties/ExampleMultiLanguageProperty</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2671,7 +2671,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2696,7 +2696,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Ranges/ExampleRange</aas:value>
+                        <aas:value>http://example.org/Ranges/ExampleRange</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2721,7 +2721,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Blobs/ExampleBlob</aas:value>
+                        <aas:value>http://example.org/Blobs/ExampleBlob</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2746,7 +2746,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/Files/ExampleFile</aas:value>
+                        <aas:value>http://example.org/Files/ExampleFile</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2770,7 +2770,7 @@
                     <aas:keys>
                       <aas:key>
                         <aas:type>GlobalReference</aas:type>
-                        <aas:value>http://acplt.org/ReferenceElements/ExampleReferenceElement</aas:value>
+                        <aas:value>http://example.org/ReferenceElements/ExampleReferenceElement</aas:value>
                       </aas:key>
                     </aas:keys>
                   </aas:semanticId>
@@ -2794,7 +2794,7 @@
                 <aas:keys>
                   <aas:key>
                     <aas:type>GlobalReference</aas:type>
-                    <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                    <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
                   </aas:key>
                 </aas:keys>
               </aas:semanticId>
@@ -2819,7 +2819,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
+                <aas:value>http://example.org/SubmodelElementLists/ExampleSubmodelElementList</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticId>
@@ -2829,7 +2829,7 @@
             <aas:keys>
               <aas:key>
                 <aas:type>GlobalReference</aas:type>
-                <aas:value>http://acplt.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
+                <aas:value>http://example.org/SubmodelElementCollections/ExampleSubmodelElementCollection</aas:value>
               </aas:key>
             </aas:keys>
           </aas:semanticIdListElement>
@@ -2891,11 +2891,11 @@
                   <aas:keys>
                     <aas:key>
                       <aas:type>GlobalReference</aas:type>
-                      <aas:value>http://acplt.org/Units/SpaceUnit</aas:value>
+                      <aas:value>http://example.org/Units/SpaceUnit</aas:value>
                     </aas:key>
                   </aas:keys>
                 </aas:unitId>
-                <aas:sourceOfDefinition>http://acplt.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
+                <aas:sourceOfDefinition>http://example.org/DataSpec/ExampleDef</aas:sourceOfDefinition>
                 <aas:symbol>SU</aas:symbol>
                 <aas:dataType>REAL_MEASURE</aas:dataType>
                 <aas:definition>
@@ -2918,7 +2918,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2930,7 +2930,7 @@
                         <aas:keys>
                           <aas:key>
                             <aas:type>GlobalReference</aas:type>
-                            <aas:value>http://acplt.org/ValueId/ExampleValueId2</aas:value>
+                            <aas:value>http://example.org/ValueId/ExampleValueId2</aas:value>
                           </aas:key>
                         </aas:keys>
                       </aas:valueId>
@@ -2955,27 +2955,27 @@
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
+              <aas:value>http://example.org/AdministrativeInformation/Test_ConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:creator>
-        <aas:templateId>http://acplt.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
+        <aas:templateId>http://example.org/AdministrativeInformationTemplates/Test_ConceptDescription</aas:templateId>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription</aas:id>
       <aas:isCaseOf>
         <aas:reference>
           <aas:type>ExternalReference</aas:type>
           <aas:keys>
             <aas:key>
               <aas:type>GlobalReference</aas:type>
-              <aas:value>http://acplt.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
+              <aas:value>http://example.org/DataSpecifications/ConceptDescriptions/TestConceptDescription</aas:value>
             </aas:key>
           </aas:keys>
         </aas:reference>
       </aas:isCaseOf>
     </aas:conceptDescription>
     <aas:conceptDescription>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Mandatory</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Mandatory</aas:id>
     </aas:conceptDescription>
     <aas:conceptDescription>
       <aas:idShort>TestConceptDescription</aas:idShort>
@@ -2993,7 +2993,7 @@
         <aas:version>9</aas:version>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_ConceptDescription_Missing</aas:id>
+      <aas:id>https://example.org/Test_ConceptDescription_Missing</aas:id>
     </aas:conceptDescription>
   </aas:conceptDescriptions>
 </aas:environment>

--- a/compliance_tool/test/files/test_deserializable_aas_warning.json
+++ b/compliance_tool/test/files/test_deserializable_aas_warning.json
@@ -1,7 +1,7 @@
 {
 	"assetAdministrationShells": [
 		{
-			"id": "https://acplt.org/Test_AssetAdministrationShell",
+			"id": "https://example.org/Test_AssetAdministrationShell",
 			"idShort": "TestAssetAdministrationShell",
 			"administration": {
 				"revision": "0"
@@ -9,7 +9,7 @@
 			"modelType": "AssetAdministrationShell",
 			"assetInformation": {
                 "assetKind": "Instance",
-				"globalAssetId": "http://acplt.org/TestAsset/"
+				"globalAssetId": "http://example.org/TestAsset/"
             }
 		}
 	]

--- a/compliance_tool/test/files/test_deserializable_aas_warning.xml
+++ b/compliance_tool/test/files/test_deserializable_aas_warning.xml
@@ -6,10 +6,10 @@
       <aas:administration>
         <aas:revision>0</aas:revision>
       </aas:administration>
-      <aas:id>https://acplt.org/Test_AssetAdministrationShell</aas:id>
+      <aas:id>https://example.org/Test_AssetAdministrationShell</aas:id>
       <aas:assetInformation>
         <aas:assetKind>Instance</aas:assetKind>
-        <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+        <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
       </aas:assetInformation>
     </aas:assetAdministrationShell>
   </aas:assetAdministrationShells>

--- a/compliance_tool/test/files/test_not_deserializable_aas.json
+++ b/compliance_tool/test/files/test_not_deserializable_aas.json
@@ -1,12 +1,12 @@
 {
     "assetAdministrationShells": [
         {
-            "id": "https://acplt.org/Test_AssetAdministrationShell",
+            "id": "https://example.org/Test_AssetAdministrationShell",
             "idShort": "TestAssetAdministrationShell",
             "modelType": "Test",
             "assetInformation": {
                 "assetKind": "Instance",
-                "globalAssetId": "http://acplt.org/Test_Asset/"
+                "globalAssetId": "http://example.org/Test_Asset/"
             }
         }
     ],

--- a/compliance_tool/test/files/test_not_deserializable_aas.xml
+++ b/compliance_tool/test/files/test_not_deserializable_aas.xml
@@ -3,7 +3,7 @@
     <aas:assetAdministrationShells>
         <aas:submodel>
             <aas:idShort/>
-            <aas:id>https://acplt.org/Test_Submodel2_Mandatory</aas:id>
+            <aas:id>https://example.org/Test_Submodel2_Mandatory</aas:id>
             <aas:kind>Instance</aas:kind>
             <aas:submodelElements/>
         </aas:submodel>

--- a/compliance_tool/test/test_compliance_check_aasx.py
+++ b/compliance_tool/test/test_compliance_check_aasx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/test/test_compliance_check_aasx.py
+++ b/compliance_tool/test/test_compliance_check_aasx.py
@@ -70,7 +70,7 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
         self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(2, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[3].status)
@@ -123,7 +123,7 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell123 (value=\'TestAssetAdministrationShell\')',
                          manager.format_step(4, verbose_level=1))
 
@@ -136,7 +136,7 @@ class ComplianceToolAASXTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(4, verbose_level=1))
         self.assertEqual(Status.NOT_EXECUTED, manager.steps[5].status)

--- a/compliance_tool/test/test_compliance_check_json.py
+++ b/compliance_tool/test/test_compliance_check_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/test/test_compliance_check_json.py
+++ b/compliance_tool/test/test_compliance_check_json.py
@@ -128,7 +128,7 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
         self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(2, verbose_level=1))
 
@@ -177,7 +177,7 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell123 (value=\'TestAssetAdministrationShell\')',
                          manager.format_step(4, verbose_level=1))
 
@@ -190,6 +190,6 @@ class ComplianceToolJsonTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(4, verbose_level=1))

--- a/compliance_tool/test/test_compliance_check_xml.py
+++ b/compliance_tool/test/test_compliance_check_xml.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/test/test_compliance_check_xml.py
+++ b/compliance_tool/test/test_compliance_check_xml.py
@@ -120,7 +120,7 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[1].status)
         self.assertEqual(Status.FAILED, manager.steps[2].status)
         self.assertEqual('FAILED:       Check if data is equal to example data\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(2, verbose_level=1))
 
@@ -169,7 +169,7 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell123 (value=\'TestAssetAdministrationShell\')',
                          manager.format_step(4, verbose_level=1))
 
@@ -182,6 +182,6 @@ class ComplianceToolXmlTest(unittest.TestCase):
         self.assertEqual(Status.SUCCESS, manager.steps[3].status)
         self.assertEqual(Status.FAILED, manager.steps[4].status)
         self.assertEqual('FAILED:       Check if data in files are equal\n - ERROR: Attribute id_short of '
-                         'AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell] must be == '
+                         'AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell] must be == '
                          'TestAssetAdministrationShell (value=\'TestAssetAdministrationShell123\')',
                          manager.format_step(4, verbose_level=1))

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -87,7 +87,7 @@ Create a `Submodel`:
 ```python
 from basyx.aas import model  # Import all BaSyx Python SDK classes from the model package
 
-identifier = 'https://acplt.org/Simple_Submodel'
+identifier = 'https://example.org/Simple_Submodel'
 submodel = model.Submodel(identifier)
 ```
 
@@ -97,7 +97,7 @@ Create a `Property` and add it to the `Submodel`:
 semantic_reference = model.ExternalReference(
     (model.Key(
         type_=model.KeyTypes.GLOBAL_REFERENCE,
-        value='http://acplt.org/Properties/SimpleProperty'
+        value='http://example.org/Properties/SimpleProperty'
     ),)
 )
 property = model.Property(

--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -332,10 +332,10 @@ class AASXWriter:
         cp.created = datetime.datetime.now()
 
         with AASXWriter("filename.aasx") as writer:
-            writer.write_aas("https://acplt.org/AssetAdministrationShell",
+            writer.write_aas("https://example.org/AssetAdministrationShell",
                              object_store,
                              file_store)
-            writer.write_aas("https://acplt.org/AssetAdministrationShell2",
+            writer.write_aas("https://example.org/AssetAdministrationShell2",
                              object_store,
                              file_store)
             writer.write_core_properties(cp)

--- a/sdk/basyx/aas/examples/data/__init__.py
+++ b/sdk/basyx/aas/examples/data/__init__.py
@@ -55,12 +55,12 @@ def create_example_aas_binding() -> model.DictIdentifiableStore:
     identifiable_store.update(example_aas_missing_attributes.create_full_example())
     identifiable_store.add(example_submodel_template.create_example_submodel_template())
 
-    aas = identifiable_store.get_item('https://acplt.org/Test_AssetAdministrationShell')
-    sm = identifiable_store.get_item('https://acplt.org/Test_Submodel_Template')
+    aas = identifiable_store.get_item('https://example.org/Test_AssetAdministrationShell')
+    sm = identifiable_store.get_item('https://example.org/Test_Submodel_Template')
     assert (isinstance(aas, model.aas.AssetAdministrationShell))  # make mypy happy
     assert (isinstance(sm, model.submodel.Submodel))  # make mypy happy
     aas.submodel.add(model.ModelReference.from_referable(sm))
 
-    cd = identifiable_store.get_item('https://acplt.org/Test_ConceptDescription_Mandatory')
+    cd = identifiable_store.get_item('https://example.org/Test_ConceptDescription_Mandatory')
     assert (isinstance(cd, model.concept.ConceptDescription))  # make mypy happy
     return identifiable_store

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -32,17 +32,17 @@ _embedded_data_specification_iec61360 = model.EmbeddedDataSpecification(
                                                  'en-US': 'This is a DataSpecification for testing purposes'}),
         short_name=model.ShortNameTypeIEC61360({'de': 'Test Spec', 'en-US': 'TestSpec'}), unit='SpaceUnit',
         unit_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                   value='http://acplt.org/Units/SpaceUnit'),)),
-        source_of_definition='http://acplt.org/DataSpec/ExampleDef', symbol='SU', value_format="M",
+                                                   value='http://example.org/Units/SpaceUnit'),)),
+        source_of_definition='http://example.org/DataSpec/ExampleDef', symbol='SU', value_format="M",
         value_list={
             model.ValueReferencePair(
                 value='exampleValue',
                 value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                            value='http://acplt.org/ValueId/ExampleValueId'),)), ),
+                                                            value='http://example.org/ValueId/ExampleValueId'),)), ),
             model.ValueReferencePair(
                 value='exampleValue2',
                 value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                            value='http://acplt.org/ValueId/ExampleValueId2'),)), )},
+                                                            value='http://example.org/ValueId/ExampleValueId2'),)), )},
         value="TEST", level_types={model.IEC61360LevelType.MIN, model.IEC61360LevelType.MAX})
 )
 
@@ -74,27 +74,27 @@ def create_example_asset_identification_submodel() -> model.Submodel:
 
     """
     qualifier = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier',
+        type_='http://example.org/Qualifier/ExampleQualifier',
         value_type=model.datatypes.Int,
         value=100,
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         kind=model.QualifierKind.CONCEPT_QUALIFIER)
 
     qualifier2 = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier2',
+        type_='http://example.org/Qualifier/ExampleQualifier2',
         value_type=model.datatypes.Int,
         value=50,
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         kind=model.QualifierKind.TEMPLATE_QUALIFIER)
 
     qualifier3 = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier3',
+        type_='http://example.org/Qualifier/ExampleQualifier3',
         value_type=model.datatypes.DateTime,
         value=model.datatypes.DateTime(2023, 4, 7, 16, 59, 54, 870123),
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         kind=model.QualifierKind.VALUE_QUALIFIER)
 
     extension = model.Extension(
@@ -102,7 +102,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value="ExampleExtensionValue",
         refers_to=[model.ModelReference((model.Key(type_=model.KeyTypes.ASSET_ADMINISTRATION_SHELL,
-                                                   value='http://acplt.org/RefersTo/ExampleRefersTo'),),
+                                                   value='http://example.org/RefersTo/ExampleRefersTo'),),
                                         model.AssetAdministrationShell)],)
 
     # Property-Element conform to 'Verwaltungsschale in der Praxis' page 41 ManufacturerName:
@@ -112,7 +112,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='ACPLT',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         category="PARAMETER",
         description=model.MultiLanguageTextType({
             'en-US': 'Legally valid designation of the natural or judicial person which '
@@ -140,7 +140,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='978-8234-234-342',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         category="PARAMETER",
         description=model.MultiLanguageTextType({
             'en-US': 'Legally valid designation of the natural or judicial person which '
@@ -165,7 +165,7 @@ def create_example_asset_identification_submodel() -> model.Submodel:
 
     # asset identification submodel which will be included in the asset object
     identification_submodel = model.Submodel(
-        id_='http://acplt.org/Submodels/Assets/TestAsset/Identification',
+        id_='http://example.org/Submodels/Assets/TestAsset/Identification',
         submodel_element=(identification_submodel_element_manufacturer_name,
                           identification_submodel_element_instance_id),
         id_short='Identification',
@@ -179,13 +179,13 @@ def create_example_asset_identification_submodel() -> model.Submodel:
                                                        revision='0',
                                                        creator=model.ExternalReference((
                                                            model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     'http://acplt.org/AdministrativeInformation/'
+                                                                     'http://example.org/AdministrativeInformation/'
                                                                      'TestAsset/Identification'),
                                                        )),
-                                                       template_id='http://acplt.org/AdministrativeInformation'
+                                                       template_id='http://example.org/AdministrativeInformation'
                                                                    'Templates/TestAsset/Identification'),
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                    value='http://acplt.org/SubmodelTemplates/AssetIdentification'),),
+                                                    value='http://example.org/SubmodelTemplates/AssetIdentification'),),
                                          model.Submodel),
         qualifier=(),
         kind=model.ModellingKind.INSTANCE,
@@ -208,13 +208,13 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         category='CONSTANT',
         description=model.MultiLanguageTextType({'en-US': 'Example Property object',
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -226,13 +226,13 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue2',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         category='CONSTANT',
         description=model.MultiLanguageTextType({'en-US': 'Example Property object',
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -243,12 +243,12 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         id_short='ExampleEntity',
         entity_type=model.EntityType.SELF_MANAGED_ENTITY,
         statement={submodel_element_property, submodel_element_property2},
-        global_asset_id='http://acplt.org/TestAsset/',
+        global_asset_id='http://example.org/TestAsset/',
         specific_asset_id={
             model.SpecificAssetId(name="TestKey", value="TestValue",
                                   external_subject_id=model.ExternalReference(
                                       (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                 value='http://acplt.org/SpecificAssetId/'),))
+                                                 value='http://example.org/SpecificAssetId/'),))
                                   )},
         category="PARAMETER",
         description=model.MultiLanguageTextType({
@@ -302,7 +302,7 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
 
     # bill of material submodel which will be included in the asset object
     bill_of_material = model.Submodel(
-        id_='http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial',
+        id_='http://example.org/Submodels/Assets/TestAsset/BillOfMaterial',
         submodel_element=(entity,
                           entity_2),
         id_short='BillOfMaterial',
@@ -313,10 +313,10 @@ def create_example_bill_of_material_submodel() -> model.Submodel:
         }),
         parent=None,
         administration=model.AdministrativeInformation(version='9',
-                                                       template_id='http://acplt.org/AdministrativeInformation'
+                                                       template_id='http://example.org/AdministrativeInformation'
                                                                    'Templates/TestAsset/BillOfMaterial'),
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                    value='http://acplt.org/SubmodelTemplates/BillOfMaterial'),),
+                                                    value='http://example.org/SubmodelTemplates/BillOfMaterial'),),
                                          model.Submodel),
         qualifier=(),
         kind=model.ModellingKind.INSTANCE,
@@ -340,7 +340,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -348,14 +348,14 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),), ),
+                                                       value='http://example.org/Properties/ExampleProperty'),), ),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     value='http://acplt.org/Properties/'
+                                                                     value='http://example.org/Properties/'
                                                                            'ExampleProperty/SupplementalId1'),)),
                                   model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     value='http://acplt.org/Properties/'
+                                                                     value='http://example.org/Properties/'
                                                                            'ExampleProperty/SupplementalId2'),))),
         embedded_data_specifications=(_embedded_data_specification_iec61360,))
 
@@ -364,7 +364,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -372,11 +372,11 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     value='http://acplt.org/Properties/'
+                                                                     value='http://example.org/Properties/'
                                                                            'ExampleProperty2/SupplementalId'),)),),
         embedded_data_specifications=()
     )
@@ -386,17 +386,17 @@ def create_example_submodel() -> model.Submodel:
         value=model.MultiLanguageTextType({'en-US': 'Example value of a MultiLanguageProperty element',
                                            'de': 'Beispielwert für ein MultiLanguageProperty-Element'}),
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleMultiLanguageValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleMultiLanguageValueId'),)),
         category='CONSTANT',
         description=model.MultiLanguageTextType({'en-US': 'Example MultiLanguageProperty object',
                                                  'de': 'Beispiel MultiLanguageProperty Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/MultiLanguageProperties/'
+                                                       value='http://example.org/MultiLanguageProperties/'
                                                              'ExampleMultiLanguageProperty'),),
                                             referred_semantic_id=model.ExternalReference((model.Key(
                                               type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                              value='http://acplt.org/Properties/ExampleProperty/Referred'),))),
+                                              value='http://example.org/Properties/ExampleProperty/Referred'),))),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -413,7 +413,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Range Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Ranges/ExampleRange'),)),
+                                                       value='http://example.org/Ranges/ExampleRange'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -429,7 +429,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Blob Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Blobs/ExampleBlob'),)),
+                                                       value='http://example.org/Blobs/ExampleBlob'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -445,7 +445,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel File Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Files/ExampleFile'),)),
+                                                       value='http://example.org/Files/ExampleFile'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -464,7 +464,7 @@ def create_example_submodel() -> model.Submodel:
         }),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Files/ExampleFile'),)),
+                                                       value='http://example.org/Files/ExampleFile'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -474,7 +474,7 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_reference_element = model.ReferenceElement(
         id_short='ExampleReferenceElement',
         value=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
@@ -484,7 +484,7 @@ def create_example_submodel() -> model.Submodel:
         parent=None,
         semantic_id=model.ExternalReference((model.Key(
             type_=model.KeyTypes.GLOBAL_REFERENCE,
-            value='http://acplt.org/ReferenceElements/ExampleReferenceElement'
+            value='http://example.org/ReferenceElements/ExampleReferenceElement'
         ),)),
         qualifier=(),
         extension=(),
@@ -497,7 +497,7 @@ def create_example_submodel() -> model.Submodel:
         first=model.ModelReference((
             model.Key(
                 type_=model.KeyTypes.SUBMODEL,
-                value='http://acplt.org/Test_Submodel'),
+                value='http://example.org/Test_Submodel'),
             model.Key(
                 type_=model.KeyTypes.PROPERTY,
                 value='ExampleProperty'),
@@ -505,7 +505,7 @@ def create_example_submodel() -> model.Submodel:
         second=model.ModelReference((
             model.Key(
                 type_=model.KeyTypes.SUBMODEL,
-                value='http://acplt.org/Test_Submodel'),
+                value='http://example.org/Test_Submodel'),
             model.Key(
                 type_=model.KeyTypes.PROPERTY,
                 value='ExampleProperty2'),
@@ -515,7 +515,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel RelationshipElement Element'}),
         parent=None,
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.CONCEPT_DESCRIPTION,
-                                                    value='https://acplt.org/Test_ConceptDescription'),),
+                                                    value='https://example.org/Test_ConceptDescription'),),
                                          model.ConceptDescription),
         qualifier=(),
         extension=(),
@@ -525,11 +525,11 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_annotated_relationship_element = model.AnnotatedRelationshipElement(
         id_short='ExampleAnnotatedRelationshipElement',
-        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
-        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty2'),),
                                     model.Property),
@@ -550,7 +550,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel AnnotatedRelationshipElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/RelationshipElements/'
+                                                       value='http://example.org/RelationshipElements/'
                                                              'ExampleAnnotatedRelationshipElement'),)),
         qualifier=(),
         extension=(),
@@ -563,7 +563,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -571,7 +571,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -583,7 +583,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -591,7 +591,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -603,7 +603,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -611,7 +611,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -628,7 +628,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Operation Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Operations/'
+                                                       value='http://example.org/Operations/'
                                                              'ExampleOperation'),)),
         qualifier=(),
         extension=(),
@@ -643,7 +643,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Capability Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Capabilities/'
+                                                       value='http://example.org/Capabilities/'
                                                              'ExampleCapability'),)),
         qualifier=(),
         extension=(),
@@ -653,7 +653,7 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY,
                                                  value='ExampleProperty'),),
                                       model.Property),
@@ -661,7 +661,7 @@ def create_example_submodel() -> model.Submodel:
         state=model.StateOfEvent.ON,
         message_topic='ExampleTopic',
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
-                                                       "http://acplt.org/ExampleMessageBroker"),),
+                                                       "http://example.org/ExampleMessageBroker"),),
                                             model.Submodel),
         last_update=model.datatypes.DateTime(2022, 11, 12, 23, 50, 23, 123456, datetime.timezone.utc),
         min_interval=model.datatypes.Duration(microseconds=1),
@@ -672,7 +672,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel BasicEventElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Events/ExampleBasicEventElement'),)),
+                                                       value='http://example.org/Events/ExampleBasicEventElement'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -685,7 +685,7 @@ def create_example_submodel() -> model.Submodel:
         value=(submodel_element_property, submodel_element_property_2),
         semantic_id_list_element=model.ExternalReference((model.Key(
             type_=model.KeyTypes.GLOBAL_REFERENCE,
-            value='http://acplt.org/Properties/ExampleProperty'
+            value='http://example.org/Properties/ExampleProperty'
         ),)),
         value_type_list_element=model.datatypes.String,
         order_relevant=True,
@@ -694,7 +694,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementList Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementLists/'
+                                                       value='http://example.org/SubmodelElementLists/'
                                                              'ExampleSubmodelElementList'),)),
         qualifier=(),
         extension=(),
@@ -716,7 +716,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementCollection Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementCollections/'
+                                                       value='http://example.org/SubmodelElementCollections/'
                                                              'ExampleSubmodelElementCollection'),)),
         qualifier=(),
         extension=(),
@@ -725,7 +725,7 @@ def create_example_submodel() -> model.Submodel:
     )
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel',
+        id_='https://example.org/Test_Submodel',
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -741,11 +741,11 @@ def create_example_submodel() -> model.Submodel:
                                                        revision='0',
                                                        creator=model.ExternalReference((
                                                            model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     'http://acplt.org/AdministrativeInformation/'
+                                                                     'http://example.org/AdministrativeInformation/'
                                                                      'Test_Submodel'),
                                                        )),),
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelTemplates/'
+                                                       value='http://example.org/SubmodelTemplates/'
                                                              'ExampleSubmodel'),)),
         qualifier=(),
         kind=model.ModellingKind.INSTANCE,
@@ -763,9 +763,9 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription',
+        id_='https://example.org/Test_ConceptDescription',
         is_case_of={model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/DataSpecifications/'
+                                                       value='http://example.org/DataSpecifications/'
                                                              'ConceptDescriptions/TestConceptDescription'),))},
         id_short='TestConceptDescription',
         category=None,
@@ -776,10 +776,10 @@ def create_example_concept_description() -> model.ConceptDescription:
                                                        revision='0',
                                                        creator=model.ExternalReference((
                                                            model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     'http://acplt.org/AdministrativeInformation/'
+                                                                     'http://example.org/AdministrativeInformation/'
                                                                      'Test_ConceptDescription'),
                                                        )),
-                                                       template_id='http://acplt.org/AdministrativeInformation'
+                                                       template_id='http://example.org/AdministrativeInformation'
                                                                    'Templates/Test_ConceptDescription',
                                                        embedded_data_specifications=(
                                                            _embedded_data_specification_iec61360,
@@ -799,17 +799,17 @@ def create_example_asset_administration_shell() -> \
 
     asset_information = model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
-        global_asset_id='http://acplt.org/TestAsset/',
+        global_asset_id='http://example.org/TestAsset/',
         specific_asset_id={model.SpecificAssetId(name="TestKey",
                                                  value="TestValue",
                                                  external_subject_id=model.ExternalReference(
                                                             (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                       value='http://acplt.org/SpecificAssetId/'),)),
+                                                                       value='http://example.org/SpecificAssetId/'),)),
                                                  semantic_id=model.ExternalReference((model.Key(
                                                      model.KeyTypes.GLOBAL_REFERENCE,
-                                                     "http://acplt.org/SpecificAssetId/"
+                                                     "http://example.org/SpecificAssetId/"
                                                  ),)))},
-        asset_type='http://acplt.org/TestAssetType/',
+        asset_type='http://example.org/TestAssetType/',
         default_thumbnail=model.Resource(
             "file:///path/to/thumbnail.png",
             "image/png"
@@ -818,7 +818,7 @@ def create_example_asset_administration_shell() -> \
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell',
+        id_='https://example.org/Test_AssetAdministrationShell',
         id_short='TestAssetAdministrationShell',
         category=None,
         description=model.MultiLanguageTextType({
@@ -830,32 +830,32 @@ def create_example_asset_administration_shell() -> \
                                                        revision='0',
                                                        creator=model.ExternalReference((
                                                            model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                     'http://acplt.org/AdministrativeInformation/'
+                                                                     'http://example.org/AdministrativeInformation/'
                                                                      'Test_AssetAdministrationShell'),
                                                        )),
-                                                       template_id='http://acplt.org/AdministrativeInformation'
+                                                       template_id='http://example.org/AdministrativeInformation'
                                                                    'Templates/Test_AssetAdministrationShell'),
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='https://acplt.org/Test_Submodel'),),
+                                                  value='https://example.org/Test_Submodel'),),
                                        model.Submodel,
                                        model.ExternalReference((
                                            model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                     value='http://acplt.org/SubmodelTemplates/ExampleSubmodel'),
+                                                     value='http://example.org/SubmodelTemplates/ExampleSubmodel'),
                                        ))),
                   model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='http://acplt.org/Submodels/Assets/TestAsset/Identification'),),
+                                                  value='http://example.org/Submodels/Assets/TestAsset/Identification'),),
                                        model.Submodel,
                                        model.ModelReference((
                                            model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                     value='http://acplt.org/SubmodelTemplates/AssetIdentification'),),
+                                                     value='http://example.org/SubmodelTemplates/AssetIdentification'),),
                                            model.Submodel
                                        )),
                   model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial'),),
+                                                  value='http://example.org/Submodels/Assets/TestAsset/BillOfMaterial'),),
                                        model.Submodel),
                   },
         derived_from=model.ModelReference((model.Key(type_=model.KeyTypes.ASSET_ADMINISTRATION_SHELL,
-                                                     value='https://acplt.org/TestAssetAdministrationShell2'),),
+                                                     value='https://example.org/TestAssetAdministrationShell2'),),
                                           model.AssetAdministrationShell),
         extension=(),
         embedded_data_specifications=(_embedded_data_specification_iec61360,)

--- a/sdk/basyx/aas/examples/data/example_aas.py
+++ b/sdk/basyx/aas/examples/data/example_aas.py
@@ -185,7 +185,8 @@ def create_example_asset_identification_submodel() -> model.Submodel:
                                                        template_id='http://example.org/AdministrativeInformation'
                                                                    'Templates/TestAsset/Identification'),
         semantic_id=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                    value='http://example.org/SubmodelTemplates/AssetIdentification'),),
+                                                    value='http://example.org/SubmodelTemplates/'
+                                                    'AssetIdentification'),),
                                          model.Submodel),
         qualifier=(),
         kind=model.ModellingKind.INSTANCE,
@@ -611,7 +612,8 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/'
+                                                             'ExamplePropertyInOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -653,7 +655,8 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
+                                                 value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY,
                                                  value='ExampleProperty'),),
                                       model.Property),
@@ -843,15 +846,18 @@ def create_example_asset_administration_shell() -> \
                                                      value='http://example.org/SubmodelTemplates/ExampleSubmodel'),
                                        ))),
                   model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='http://example.org/Submodels/Assets/TestAsset/Identification'),),
+                                                  value='http://example.org/Submodels/Assets/'
+                                                        'TestAsset/Identification'),),
                                        model.Submodel,
                                        model.ModelReference((
                                            model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                     value='http://example.org/SubmodelTemplates/AssetIdentification'),),
+                                                     value='http://example.org/SubmodelTemplates/'
+                                                           'AssetIdentification'),),
                                            model.Submodel
                                        )),
                   model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='http://example.org/Submodels/Assets/TestAsset/BillOfMaterial'),),
+                                                  value='http://example.org/Submodels/Assets/'
+                                                        'TestAsset/BillOfMaterial'),),
                                        model.Submodel),
                   },
         derived_from=model.ModelReference((model.Key(type_=model.KeyTypes.ASSET_ADMINISTRATION_SHELL,

--- a/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
@@ -106,7 +106,8 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
+                                                 value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY, value='ExampleProperty'),),
                                       model.Property),
         direction=model.Direction.INPUT,

--- a/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_mandatory_attributes.py
@@ -75,12 +75,12 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_relationship_element = model.RelationshipElement(
         id_short='ExampleRelationshipElement',
         first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
         second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                               value='http://acplt.org/Test_Submodel'),
+                                               value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property))
@@ -88,12 +88,12 @@ def create_example_submodel() -> model.Submodel:
     submodel_element_annotated_relationship_element = model.AnnotatedRelationshipElement(
         id_short='ExampleAnnotatedRelationshipElement',
         first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
         second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                               value='http://acplt.org/Test_Submodel'),
+                                               value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property))
@@ -106,7 +106,7 @@ def create_example_submodel() -> model.Submodel:
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY, value='ExampleProperty'),),
                                       model.Property),
         direction=model.Direction.INPUT,
@@ -136,7 +136,7 @@ def create_example_submodel() -> model.Submodel:
         value=())
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Mandatory',
+        id_='https://example.org/Test_Submodel_Mandatory',
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -154,7 +154,7 @@ def create_example_empty_submodel() -> model.Submodel:
     :return: example submodel
     """
     return model.Submodel(
-        id_='https://acplt.org/Test_Submodel2_Mandatory')
+        id_='https://example.org/Test_Submodel2_Mandatory')
 
 
 def create_example_concept_description() -> model.ConceptDescription:
@@ -164,7 +164,7 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription_Mandatory')
+        id_='https://example.org/Test_ConceptDescription_Mandatory')
     return concept_description
 
 
@@ -178,16 +178,16 @@ def create_example_asset_administration_shell() -> \
     """
     asset_information = model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
-        global_asset_id='http://acplt.org/Test_Asset_Mandatory/')
+        global_asset_id='http://example.org/Test_Asset_Mandatory/')
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell_Mandatory',
+        id_='https://example.org/Test_AssetAdministrationShell_Mandatory',
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='https://acplt.org/Test_Submodel_Mandatory'),),
+                                                  value='https://example.org/Test_Submodel_Mandatory'),),
                                        model.Submodel),
                   model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='https://acplt.org/Test_Submodel2_Mandatory'),),
+                                                  value='https://example.org/Test_Submodel2_Mandatory'),),
                                        model.Submodel)},)
     return asset_administration_shell
 
@@ -201,8 +201,8 @@ def create_example_empty_asset_administration_shell() -> model.AssetAdministrati
     """
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=model.AssetInformation(
-            global_asset_id='http://acplt.org/TestAsset2_Mandatory/'),
-        id_='https://acplt.org/Test_AssetAdministrationShell2_Mandatory')
+            global_asset_id='http://example.org/TestAsset2_Mandatory/'),
+        id_='https://example.org/Test_AssetAdministrationShell2_Mandatory')
     return asset_administration_shell
 
 

--- a/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -40,7 +40,7 @@ def create_example_submodel() -> model.Submodel:
     :return: example submodel
     """
     qualifier = model.Qualifier(
-        type_='http://acplt.org/Qualifier/ExampleQualifier',
+        type_='http://example.org/Qualifier/ExampleQualifier',
         value_type=model.datatypes.String)
 
     submodel_element_property = model.Property(
@@ -53,7 +53,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier={qualifier})
 
     submodel_element_multi_language_property = model.MultiLanguageProperty(
@@ -66,7 +66,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel MultiLanguageProperty Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/MultiLanguageProperties/'
+                                                       value='http://example.org/MultiLanguageProperties/'
                                                              'ExampleMultiLanguageProperty'),)),
         qualifier=())
 
@@ -80,7 +80,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Range Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Ranges/ExampleRange'),)),
+                                                       value='http://example.org/Ranges/ExampleRange'),)),
         qualifier=())
 
     submodel_element_blob = model.Blob(
@@ -92,7 +92,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Blob Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Blobs/ExampleBlob'),)),
+                                                       value='http://example.org/Blobs/ExampleBlob'),)),
         qualifier=())
 
     submodel_element_file = model.File(
@@ -104,13 +104,13 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel File Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Files/ExampleFile'),)),
+                                                       value='http://example.org/Files/ExampleFile'),)),
         qualifier=())
 
     submodel_element_reference_element = model.ReferenceElement(
         id_short='ExampleReferenceElement',
         value=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),), model.Submodel),
         category='PARAMETER',
@@ -119,19 +119,19 @@ def create_example_submodel() -> model.Submodel:
         parent=None,
         semantic_id=model.ExternalReference((model.Key(
             type_=model.KeyTypes.GLOBAL_REFERENCE,
-            value='http://acplt.org/ReferenceElements/ExampleReferenceElement'
+            value='http://example.org/ReferenceElements/ExampleReferenceElement'
         ),)),
         qualifier=())
 
     submodel_element_relationship_element = model.RelationshipElement(
         id_short='ExampleRelationshipElement',
         first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
         second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                               value='http://acplt.org/Test_Submodel'),
+                                               value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property),
@@ -140,19 +140,19 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel RelationshipElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/RelationshipElements/'
+                                                       value='http://example.org/RelationshipElements/'
                                                              'ExampleRelationshipElement'),)),
         qualifier=())
 
     submodel_element_annotated_relationship_element = model.AnnotatedRelationshipElement(
         id_short='ExampleAnnotatedRelationshipElement',
         first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                              value='http://acplt.org/Test_Submodel'),
+                                              value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
         second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                               value='http://acplt.org/Test_Submodel'),
+                                               value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property),
@@ -173,7 +173,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel AnnotatedRelationshipElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/RelationshipElements/'
+                                                       value='http://example.org/RelationshipElements/'
                                                              'ExampleAnnotatedRelationshipElement'),)),
         qualifier=())
 
@@ -182,7 +182,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -190,7 +190,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier=())
 
     input_variable_property = model.Property(
@@ -198,7 +198,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -206,7 +206,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInput'),)),
         qualifier=())
 
     output_variable_property = model.Property(
@@ -214,7 +214,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -222,7 +222,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -233,7 +233,7 @@ def create_example_submodel() -> model.Submodel:
         value_type=model.datatypes.String,
         value='exampleValue',
         value_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                    value='http://acplt.org/ValueId/ExampleValueId'),)),
+                                                    value='http://example.org/ValueId/ExampleValueId'),)),
         display_name=model.MultiLanguageNameType({'en-US': 'ExampleProperty',
                                                   'de': 'BeispielProperty'}),
         category='CONSTANT',
@@ -241,7 +241,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -257,7 +257,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Operation Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Operations/'
+                                                       value='http://example.org/Operations/'
                                                              'ExampleOperation'),)),
         qualifier=())
 
@@ -268,14 +268,14 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Capability Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Capabilities/'
+                                                       value='http://example.org/Capabilities/'
                                                              'ExampleCapability'),)),
         qualifier=())
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
         observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                 value='http://acplt.org/Test_Submodel'),
+                                                 value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY,
                                                  value='ExampleProperty'),),
                                       model.Property),
@@ -283,7 +283,7 @@ def create_example_submodel() -> model.Submodel:
         state=model.StateOfEvent.ON,
         message_topic='ExampleTopic',
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
-                                                       "http://acplt.org/ExampleMessageBroker"),),
+                                                       "http://example.org/ExampleMessageBroker"),),
                                             model.Submodel),
         last_update=model.datatypes.DateTime(2022, 11, 12, 23, 50, 23, 123456, datetime.timezone.utc),
         min_interval=model.datatypes.Duration(microseconds=1),
@@ -294,7 +294,7 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel BasicEventElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Events/ExampleBasicEventElement'),)),
+                                                       value='http://example.org/Events/ExampleBasicEventElement'),)),
         qualifier=())
 
     submodel_element_submodel_element_collection = model.SubmodelElementCollection(
@@ -310,12 +310,12 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementCollection Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementCollections/'
+                                                       value='http://example.org/SubmodelElementCollections/'
                                                              'ExampleSubmodelElementCollection'),)),
         qualifier=())
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Missing',
+        id_='https://example.org/Test_Submodel_Missing',
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -330,7 +330,7 @@ def create_example_submodel() -> model.Submodel:
         administration=model.AdministrativeInformation(version='9',
                                                        revision='0'),
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelTemplates/'
+                                                       value='http://example.org/SubmodelTemplates/'
                                                              'ExampleSubmodel'),)),
         qualifier=(),
         kind=model.ModellingKind.INSTANCE)
@@ -344,7 +344,7 @@ def create_example_concept_description() -> model.ConceptDescription:
     :return: example concept description
     """
     concept_description = model.ConceptDescription(
-        id_='https://acplt.org/Test_ConceptDescription_Missing',
+        id_='https://example.org/Test_ConceptDescription_Missing',
         is_case_of=None,
         id_short='TestConceptDescription',
         category=None,
@@ -370,16 +370,16 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
 
     asset_information = model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
-        global_asset_id='http://acplt.org/Test_Asset_Missing/',
+        global_asset_id='http://example.org/Test_Asset_Missing/',
         specific_asset_id={model.SpecificAssetId(name="TestKey", value="TestValue",
                                                  external_subject_id=model.ExternalReference(
                                                             (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                       value='http://acplt.org/SpecificAssetId/'),)))},
+                                                                       value='http://example.org/SpecificAssetId/'),)))},
         default_thumbnail=resource)
 
     asset_administration_shell = model.AssetAdministrationShell(
         asset_information=asset_information,
-        id_='https://acplt.org/Test_AssetAdministrationShell_Missing',
+        id_='https://example.org/Test_AssetAdministrationShell_Missing',
         id_short='TestAssetAdministrationShell',
         category=None,
         description=model.MultiLanguageTextType({'en-US': 'An Example Asset Administration Shell for the test '
@@ -389,7 +389,7 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
         administration=model.AdministrativeInformation(version='9',
                                                        revision='0'),
         submodel={model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                  value='https://acplt.org/Test_Submodel_Missing'),),
+                                                  value='https://example.org/Test_Submodel_Missing'),),
                                        model.Submodel)},
         derived_from=None)
     return asset_administration_shell

--- a/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
+++ b/sdk/basyx/aas/examples/data/example_aas_missing_attributes.py
@@ -241,7 +241,8 @@ def create_example_submodel() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/'
+                                                             'ExamplePropertyInOutput'),)),
         qualifier=(),
         extension=(),
         supplemental_semantic_id=(),
@@ -374,7 +375,8 @@ def create_example_asset_administration_shell() -> model.AssetAdministrationShel
         specific_asset_id={model.SpecificAssetId(name="TestKey", value="TestValue",
                                                  external_subject_id=model.ExternalReference(
                                                             (model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                       value='http://example.org/SpecificAssetId/'),)))},
+                                                                       value='http://example.org/'
+                                                                             'SpecificAssetId/'),)))},
         default_thumbnail=resource)
 
     asset_administration_shell = model.AssetAdministrationShell(

--- a/sdk/basyx/aas/examples/data/example_submodel_template.py
+++ b/sdk/basyx/aas/examples/data/example_submodel_template.py
@@ -36,7 +36,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExampleProperty'),)),
+                                                       value='http://example.org/Properties/ExampleProperty'),)),
         qualifier=())
 
     submodel_element_multi_language_property = model.MultiLanguageProperty(
@@ -48,7 +48,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel MultiLanguageProperty Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/MultiLanguageProperties/'
+                                                       value='http://example.org/MultiLanguageProperties/'
                                                              'ExampleMultiLanguageProperty'),)),
         qualifier=(),)
 
@@ -62,7 +62,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Range Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Ranges/ExampleRange'),)),
+                                                       value='http://example.org/Ranges/ExampleRange'),)),
         qualifier=(),)
 
     submodel_element_range_2 = model.Range(
@@ -75,7 +75,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Range Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Ranges/ExampleRange'),)),
+                                                       value='http://example.org/Ranges/ExampleRange'),)),
         qualifier=())
 
     submodel_element_blob = model.Blob(
@@ -87,7 +87,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                 'de': 'Beispiel Blob Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Blobs/ExampleBlob'),)),
+                                                       value='http://example.org/Blobs/ExampleBlob'),)),
         qualifier=())
 
     submodel_element_file = model.File(
@@ -99,7 +99,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel File Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Files/ExampleFile'),)),
+                                                       value='http://example.org/Files/ExampleFile'),)),
         qualifier=())
 
     submodel_element_reference_element = model.ReferenceElement(
@@ -111,17 +111,17 @@ def create_example_submodel_template() -> model.Submodel:
         parent=None,
         semantic_id=model.ExternalReference((model.Key(
             type_=model.KeyTypes.GLOBAL_REFERENCE,
-            value='http://acplt.org/ReferenceElements/ExampleReferenceElement'
+            value='http://example.org/ReferenceElements/ExampleReferenceElement'
         ),)),
         qualifier=())
 
     submodel_element_relationship_element = model.RelationshipElement(
         id_short='ExampleRelationshipElement',
-        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
-        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property),
@@ -130,17 +130,17 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel RelationshipElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/RelationshipElements/'
+                                                       value='http://example.org/RelationshipElements/'
                                                              'ExampleRelationshipElement'),)),
         qualifier=())
 
     submodel_element_annotated_relationship_element = model.AnnotatedRelationshipElement(
         id_short='ExampleAnnotatedRelationshipElement',
-        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        first=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                     model.Key(type_=model.KeyTypes.PROPERTY,
                                               value='ExampleProperty'),),
                                    model.Property),
-        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        second=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                      model.Key(type_=model.KeyTypes.PROPERTY,
                                                value='ExampleProperty'),),
                                     model.Property),
@@ -150,7 +150,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel AnnotatedRelationshipElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/RelationshipElements/'
+                                                       value='http://example.org/RelationshipElements/'
                                                              'ExampleAnnotatedRelationshipElement'),)),
         qualifier=())
 
@@ -164,7 +164,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInput'),)),
         qualifier=())
 
     output_variable_property = model.Property(
@@ -177,7 +177,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyOutput'),)),
         qualifier=())
 
     in_output_variable_property = model.Property(
@@ -190,7 +190,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
         qualifier=())
 
     submodel_element_operation = model.Operation(
@@ -203,7 +203,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Operation Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Operations/'
+                                                       value='http://example.org/Operations/'
                                                              'ExampleOperation'),)),
         qualifier=())
 
@@ -214,13 +214,13 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Capability Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Capabilities/'
+                                                       value='http://example.org/Capabilities/'
                                                              'ExampleCapability'),)),
         qualifier=())
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://acplt.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY,
                                                  value='ExampleProperty'),),
                                       model.Property),
@@ -228,7 +228,7 @@ def create_example_submodel_template() -> model.Submodel:
         state=model.StateOfEvent.ON,
         message_topic='ExampleTopic',
         message_broker=model.ModelReference((model.Key(model.KeyTypes.SUBMODEL,
-                                                       "http://acplt.org/ExampleMessageBroker"),),
+                                                       "http://example.org/ExampleMessageBroker"),),
                                             model.Submodel),
         last_update=model.datatypes.DateTime(2022, 11, 12, 23, 50, 23, 123456, datetime.timezone.utc),
         min_interval=model.datatypes.Duration(microseconds=1),
@@ -239,7 +239,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel BasicEventElement Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/Events/ExampleBasicEventElement'),)),
+                                                       value='http://example.org/Events/ExampleBasicEventElement'),)),
         qualifier=())
 
     submodel_element_submodel_element_collection = model.SubmodelElementCollection(
@@ -257,7 +257,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementCollection Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementCollections/'
+                                                       value='http://example.org/SubmodelElementCollections/'
                                                              'ExampleSubmodelElementCollection'),)),
         qualifier=())
 
@@ -269,7 +269,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementCollection Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementCollections/'
+                                                       value='http://example.org/SubmodelElementCollections/'
                                                              'ExampleSubmodelElementCollection'),)),
         qualifier=())
 
@@ -278,7 +278,7 @@ def create_example_submodel_template() -> model.Submodel:
         type_value_list_element=model.SubmodelElementCollection,
         value=(submodel_element_submodel_element_collection, submodel_element_submodel_element_collection_2),
         semantic_id_list_element=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                    value='http://acplt.org/SubmodelElementCollections/'
+                                                                    value='http://example.org/SubmodelElementCollections/'
                                                                           'ExampleSubmodelElementCollection'),)),
         order_relevant=True,
         category='PARAMETER',
@@ -286,7 +286,7 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementList Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementLists/'
+                                                       value='http://example.org/SubmodelElementLists/'
                                                              'ExampleSubmodelElementList'),)),
         qualifier=())
 
@@ -295,7 +295,7 @@ def create_example_submodel_template() -> model.Submodel:
         type_value_list_element=model.Capability,
         value=(),
         semantic_id_list_element=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                    value='http://acplt.org/SubmodelElementCollections/'
+                                                                    value='http://example.org/SubmodelElementCollections/'
                                                                           'ExampleSubmodelElementCollection'),)),
         order_relevant=True,
         category='PARAMETER',
@@ -303,12 +303,12 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel SubmodelElementList Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelElementLists/'
+                                                       value='http://example.org/SubmodelElementLists/'
                                                              'ExampleSubmodelElementList'),)),
         qualifier=())
 
     submodel = model.Submodel(
-        id_='https://acplt.org/Test_Submodel_Template',
+        id_='https://example.org/Test_Submodel_Template',
         submodel_element=(submodel_element_relationship_element,
                           submodel_element_annotated_relationship_element,
                           submodel_element_operation,
@@ -324,7 +324,7 @@ def create_example_submodel_template() -> model.Submodel:
         administration=model.AdministrativeInformation(version='9',
                                                        revision='0'),
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://acplt.org/SubmodelTemplates/'
+                                                       value='http://example.org/SubmodelTemplates/'
                                                              'ExampleSubmodel'),)),
         qualifier=(),
         kind=model.ModellingKind.TEMPLATE)

--- a/sdk/basyx/aas/examples/data/example_submodel_template.py
+++ b/sdk/basyx/aas/examples/data/example_submodel_template.py
@@ -190,7 +190,8 @@ def create_example_submodel_template() -> model.Submodel:
                                                  'de': 'Beispiel Property Element'}),
         parent=None,
         semantic_id=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                       value='http://example.org/Properties/ExamplePropertyInOutput'),)),
+                                                       value='http://example.org/Properties/'
+                                                             'ExamplePropertyInOutput'),)),
         qualifier=())
 
     submodel_element_operation = model.Operation(
@@ -220,7 +221,8 @@ def create_example_submodel_template() -> model.Submodel:
 
     submodel_element_basic_event_element = model.BasicEventElement(
         id_short='ExampleBasicEventElement',
-        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL, value='http://example.org/Test_Submodel'),
+        observed=model.ModelReference((model.Key(type_=model.KeyTypes.SUBMODEL,
+                                                 value='http://example.org/Test_Submodel'),
                                        model.Key(type_=model.KeyTypes.PROPERTY,
                                                  value='ExampleProperty'),),
                                       model.Property),
@@ -278,8 +280,9 @@ def create_example_submodel_template() -> model.Submodel:
         type_value_list_element=model.SubmodelElementCollection,
         value=(submodel_element_submodel_element_collection, submodel_element_submodel_element_collection_2),
         semantic_id_list_element=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                    value='http://example.org/SubmodelElementCollections/'
-                                                                          'ExampleSubmodelElementCollection'),)),
+                                                                    value='http://example.org/'
+                                                                    'SubmodelElementCollections/'
+                                                                    'ExampleSubmodelElementCollection'),)),
         order_relevant=True,
         category='PARAMETER',
         description=model.MultiLanguageTextType({'en-US': 'Example SubmodelElementList object',
@@ -295,7 +298,8 @@ def create_example_submodel_template() -> model.Submodel:
         type_value_list_element=model.Capability,
         value=(),
         semantic_id_list_element=model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                    value='http://example.org/SubmodelElementCollections/'
+                                                                    value='http://example.org/'
+                                                                    'SubmodelElementCollections/'
                                                                           'ExampleSubmodelElementCollection'),)),
         order_relevant=True,
         category='PARAMETER',

--- a/sdk/basyx/aas/examples/tutorial_aasx.py
+++ b/sdk/basyx/aas/examples/tutorial_aasx.py
@@ -30,20 +30,20 @@ from basyx.aas.adapter import aasx
 # See `tutorial_create_simple_aas.py` for more details.
 
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel'
+    id_='https://example.org/Simple_Submodel'
 )
 aas = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_='https://example.org/Simple_AAS',
     asset_information=model.AssetInformation(
         asset_kind=model.AssetKind.INSTANCE,
-        global_asset_id='http://acplt.org/Simple_Asset'
+        global_asset_id='http://example.org/Simple_Asset'
     ),
     submodel={model.ModelReference.from_referable(submodel)}
 )
 
 # Another submodel, which is not related to the AAS:
 unrelated_submodel = model.Submodel(
-    id_='https://acplt.org/Unrelated_Submodel'
+    id_='https://example.org/Unrelated_Submodel'
 )
 
 # We add these objects to an IdentifiableStore for easy retrieval by id.
@@ -102,7 +102,7 @@ with aasx.AASXWriter("MyAASXPackage.aasx") as writer:
     # ATTENTION: As of Version 3.0 RC01 of Details of the Asset Administration Shell, it is no longer valid to add more
     # than one "aas-spec" part (JSON/XML part with AAS objects) to an AASX package. Thus, `write_aas` MUST
     # only be called once per AASX package!
-    writer.write_aas(aas_ids=['https://acplt.org/Simple_AAS'],
+    writer.write_aas(aas_ids=['https://example.org/Simple_AAS'],
                      object_store=identifiable_store,
                      file_store=file_store)
 
@@ -154,6 +154,6 @@ with aasx.AASXReader("MyAASXPackage.aasx") as reader:
 
 
 # Some quick checks to make sure, reading worked as expected
-assert 'https://acplt.org/Simple_Submodel' in new_identifiable_store
+assert 'https://example.org/Simple_Submodel' in new_identifiable_store
 assert actual_file_name in new_file_store
 assert new_meta_data.creator == "Chair of Process Control Engineering"

--- a/sdk/basyx/aas/examples/tutorial_create_simple_aas.py
+++ b/sdk/basyx/aas/examples/tutorial_create_simple_aas.py
@@ -26,11 +26,11 @@ from basyx.aas import model
 # Step 1.1: create the AssetInformation object
 asset_information = model.AssetInformation(
     asset_kind=model.AssetKind.INSTANCE,
-    global_asset_id='http://acplt.org/Simple_Asset'
+    global_asset_id='http://example.org/Simple_Asset'
 )
 
 # step 1.2: create the Asset Administration Shell
-identifier = 'https://acplt.org/Simple_AAS'
+identifier = 'https://example.org/Simple_AAS'
 aas = model.AssetAdministrationShell(
     id_=identifier,  # set identifier
     asset_information=asset_information
@@ -42,7 +42,7 @@ aas = model.AssetAdministrationShell(
 #############################################################
 
 # Step 2.1: create the Submodel object
-identifier = 'https://acplt.org/Simple_Submodel'
+identifier = 'https://example.org/Simple_Submodel'
 submodel = model.Submodel(
     id_=identifier
 )
@@ -55,10 +55,10 @@ aas.submodel.add(model.ModelReference.from_referable(submodel))
 # ALTERNATIVE: step 1 and 2 can alternatively be done in one step
 # In this version, the Submodel reference is passed to the Asset Administration Shell's constructor.
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel'
+    id_='https://example.org/Simple_Submodel'
 )
 aas = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_='https://example.org/Simple_AAS',
     asset_information=asset_information,
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -73,7 +73,7 @@ aas = model.AssetAdministrationShell(
 semantic_reference = model.ExternalReference(
     (model.Key(
         type_=model.KeyTypes.GLOBAL_REFERENCE,
-        value='http://acplt.org/Properties/SimpleProperty'
+        value='http://example.org/Properties/SimpleProperty'
     ),)
 )
 
@@ -93,7 +93,7 @@ submodel.submodel_element.add(property_)
 # ALTERNATIVE: step 2 and 3 can also be combined in a single statement:
 # Again, we pass the Property to the Submodel's constructor instead of adding it afterward.
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_='https://example.org/Simple_Submodel',
     submodel_element={
         model.Property(
             id_short='ExampleProperty',
@@ -102,7 +102,7 @@ submodel = model.Submodel(
             semantic_id=model.ExternalReference(
                 (model.Key(
                     type_=model.KeyTypes.GLOBAL_REFERENCE,
-                    value='http://acplt.org/Properties/SimpleProperty'
+                    value='http://example.org/Properties/SimpleProperty'
                 ),)
             )
         )

--- a/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
+++ b/sdk/basyx/aas/examples/tutorial_serialization_deserialization.py
@@ -32,7 +32,7 @@ import basyx.aas.adapter.json
 # For more details, take a look at `tutorial_create_simple_aas.py`
 
 submodel = model.Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_='https://example.org/Simple_Submodel',
     submodel_element={
         model.Property(
             id_short='ExampleProperty',
@@ -40,13 +40,13 @@ submodel = model.Submodel(
             value='exampleValue',
             semantic_id=model.ExternalReference((model.Key(
                     type_=model.KeyTypes.GLOBAL_REFERENCE,
-                    value='http://acplt.org/Properties/SimpleProperty'
+                    value='http://example.org/Properties/SimpleProperty'
                 ),)
             )
         )}
 )
 aashell = model.AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_='https://example.org/Simple_AAS',
     asset_information=model.AssetInformation(global_asset_id="test"),
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -124,5 +124,5 @@ xml_file_data = basyx.aas.adapter.xml.read_aas_xml_file('data.xml')
 
 # step 5.3: Retrieving the objects from the IdentifiableStore
 # For more information on the available techniques, see `tutorial_storage.py`.
-submodel_from_xml = xml_file_data.get_item('https://acplt.org/Simple_Submodel')
+submodel_from_xml = xml_file_data.get_item('https://example.org/Simple_Submodel')
 assert isinstance(submodel_from_xml, model.Submodel)

--- a/sdk/basyx/aas/examples/tutorial_storage.py
+++ b/sdk/basyx/aas/examples/tutorial_storage.py
@@ -31,7 +31,7 @@ from basyx.aas.model import AssetInformation, AssetAdministrationShell, Submodel
 
 asset_information = AssetInformation(
     asset_kind=model.AssetKind.INSTANCE,
-    global_asset_id='http://acplt.org/Simple_Asset'
+    global_asset_id='http://example.org/Simple_Asset'
 )
 
 prop = model.Property(
@@ -41,16 +41,16 @@ prop = model.Property(
     semantic_id=model.ExternalReference(
         (model.Key(
             type_=model.KeyTypes.GLOBAL_REFERENCE,
-            value='http://acplt.org/Properties/SimpleProperty'
+            value='http://example.org/Properties/SimpleProperty'
         ),)
     )
 )
 submodel = Submodel(
-    id_='https://acplt.org/Simple_Submodel',
+    id_='https://example.org/Simple_Submodel',
     submodel_element={prop}
 )
 aas = AssetAdministrationShell(
-    id_='https://acplt.org/Simple_AAS',
+    id_='https://example.org/Simple_AAS',
     asset_information=asset_information,
     submodel={model.ModelReference.from_referable(submodel)}
 )
@@ -81,7 +81,7 @@ identifiable_store.add(aas)
 #################################################################
 
 tmp_submodel = identifiable_store.get_item(
-    'https://acplt.org/Simple_Submodel')
+    'https://example.org/Simple_Submodel')
 
 assert submodel is tmp_submodel
 
@@ -104,7 +104,7 @@ assert submodel is submodels[0]
 property_reference = model.ModelReference(
     (model.Key(
         type_=model.KeyTypes.SUBMODEL,
-        value='https://acplt.org/Simple_Submodel'),
+        value='https://example.org/Simple_Submodel'),
      model.Key(
          type_=model.KeyTypes.PROPERTY,
          value='ExampleProperty'),

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -115,7 +115,7 @@ class AASXWriterTest(unittest.TestCase):
                 with warnings.catch_warnings(record=True) as w:
                     with aasx.AASXWriter(filename) as writer:
                         # TODO test writing multiple AAS
-                        writer.write_aas('https://acplt.org/Test_AssetAdministrationShell',
+                        writer.write_aas('https://example.org/Test_AssetAdministrationShell',
                                          data, files, write_json=write_json)
                         writer.write_core_properties(cp)
 
@@ -171,7 +171,7 @@ class AASXReaderTest(unittest.TestCase):
 
         with aasx.AASXWriter(filename) as writer:
             writer.write_aas(
-                'https://acplt.org/Test_AssetAdministrationShell',
+                'https://example.org/Test_AssetAdministrationShell',
                 data, files, write_json=False
             )
             writer.write_core_properties(cp)
@@ -269,7 +269,7 @@ class AASXWriterReferencedSubmodelsTest(unittest.TestCase):
             id_="Test_AAS",
             asset_information=model.AssetInformation(
                 asset_kind=model.AssetKind.INSTANCE,
-                global_asset_id="http://acplt.org/Test_Asset"
+                global_asset_id="http://example.org/Test_Asset"
             ),
             submodel={model.ModelReference.from_referable(referenced_submodel)}
         )

--- a/sdk/test/adapter/json/test_json_deserialization.py
+++ b/sdk/test/adapter/json/test_json_deserialization.py
@@ -29,10 +29,10 @@ class JsonDeserializationTest(unittest.TestCase):
                 "submodels": [
                     {
                         "modelType": "AssetAdministrationShell",
-                        "id": "https://acplt.org/Test_Asset",
+                        "id": "https://example.org/Test_Asset",
                         "assetInformation": {
                             "assetKind": "Instance",
-                            "globalAssetId": "https://acplt.org/Test_AssetId"
+                            "globalAssetId": "https://example.org/Test_AssetId"
                         }
                     }
                 ]
@@ -70,11 +70,11 @@ class JsonDeserializationTest(unittest.TestCase):
                 },
                 {
                     "modelType": "Submodel",
-                    "id": ["https://acplt.org/Test_Submodel_broken_id", "IRI"]
+                    "id": ["https://example.org/Test_Submodel_broken_id", "IRI"]
                 },
                 {
                     "modelType": "Submodel",
-                    "id": "https://acplt.org/Test_Submodel"
+                    "id": "https://example.org/Test_Submodel"
                 }
             ]"""
         # In strict mode, we should catch an exception
@@ -91,18 +91,18 @@ class JsonDeserializationTest(unittest.TestCase):
         self.assertIsInstance(parsed_data[0], dict)
         self.assertIsInstance(parsed_data[1], dict)
         self.assertIsInstance(parsed_data[2], model.Submodel)
-        self.assertEqual("https://acplt.org/Test_Submodel", parsed_data[2].id)
+        self.assertEqual("https://example.org/Test_Submodel", parsed_data[2].id)
 
     def test_wrong_submodel_element_type(self) -> None:
         data = """
             [
                 {
                     "modelType": "Submodel",
-                    "id": "http://acplt.org/Submodels/Assets/TestAsset/Identification",
+                    "id": "http://example.org/Submodels/Assets/TestAsset/Identification",
                     "submodelElements": [
                         {
                             "modelType": "Submodel",
-                            "id": "https://acplt.org/Test_Submodel"
+                            "id": "https://example.org/Test_Submodel"
                         },
                         {
                             "modelType": {
@@ -142,15 +142,15 @@ class JsonDeserializationTest(unittest.TestCase):
             {
                 "assetAdministrationShells": [{
                     "modelType": "AssetAdministrationShell",
-                    "id": "http://acplt.org/test_aas",
+                    "id": "http://example.org/test_aas",
                     "assetInformation": {
                         "assetKind": "Instance",
-                        "globalAssetId": "https://acplt.org/Test_AssetId"
+                        "globalAssetId": "https://example.org/Test_AssetId"
                     }
                 }],
                 "submodels": [{
                     "modelType": "Submodel",
-                    "id": "http://acplt.org/test_aas"
+                    "id": "http://example.org/test_aas"
                 }],
                 "conceptDescriptions": []
             }"""
@@ -163,7 +163,7 @@ class JsonDeserializationTest(unittest.TestCase):
             read_aas_json_file(string_io, failsafe=False)
 
     def test_duplicate_identifier_identifiable_store(self) -> None:
-        sm_id = "http://acplt.org/test_submodel"
+        sm_id = "http://example.org/test_submodel"
 
         def get_clean_store() -> model.DictIdentifiableStore:
             store: model.DictIdentifiableStore[model.Identifiable] = model.DictIdentifiableStore()
@@ -175,7 +175,7 @@ class JsonDeserializationTest(unittest.TestCase):
             {
                 "submodels": [{
                     "modelType": "Submodel",
-                    "id": "http://acplt.org/test_submodel",
+                    "id": "http://example.org/test_submodel",
                     "idShort": "test456"
                 }],
                 "assetAdministrationShells": [],
@@ -234,7 +234,7 @@ class JsonDeserializationDerivingTest(unittest.TestCase):
             [
                 {
                     "modelType": "Submodel",
-                    "id": "https://acplt.org/Test_Submodel"
+                    "id": "https://example.org/Test_Submodel"
                 }
             ]"""
         parsed_data = json.loads(data, cls=EnhancedAASDecoder)
@@ -248,7 +248,7 @@ class JsonDeserializationStrippedObjectsTest(unittest.TestCase):
         data = """
             {
                 "modelType": "Submodel",
-                "id": "http://acplt.org/test_stripped_submodel",
+                "id": "http://example.org/test_stripped_submodel",
                 "submodelElements": [{
                     "modelType": "Operation",
                     "idShort": "test_operation",
@@ -289,7 +289,7 @@ class JsonDeserializationStrippedObjectsTest(unittest.TestCase):
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Test_Submodel"
+                            "value": "http://example.org/Test_Submodel"
                         },
                         {
                             "type": "AnnotatedRelationshipElement",
@@ -302,7 +302,7 @@ class JsonDeserializationStrippedObjectsTest(unittest.TestCase):
                     "keys": [
                         {
                             "type": "Submodel",
-                            "value": "http://acplt.org/Test_Submodel"
+                            "value": "http://example.org/Test_Submodel"
                         },
                         {
                             "type": "AnnotatedRelationshipElement",
@@ -381,7 +381,7 @@ class JsonDeserializationStrippedObjectsTest(unittest.TestCase):
         data = """
             {
                 "modelType": "AssetAdministrationShell",
-                "id": "http://acplt.org/test_aas",
+                "id": "http://example.org/test_aas",
                 "assetInformation": {
                     "assetKind": "Instance",
                     "globalAssetId": "test_asset"
@@ -390,7 +390,7 @@ class JsonDeserializationStrippedObjectsTest(unittest.TestCase):
                     "type": "ModelReference",
                     "keys": [{
                         "type": "Submodel",
-                        "value": "http://acplt.org/test_submodel"
+                        "value": "http://example.org/test_submodel"
                     }]
                 }]
             }"""

--- a/sdk/test/adapter/json/test_json_serialization.py
+++ b/sdk/test/adapter/json/test_json_serialization.py
@@ -63,7 +63,7 @@ class JsonSerializationSchemaTest(unittest.TestCase):
         # must be a Reference. (This seems to be a bug in the JSONSchema.)
         submodel = model.Submodel(submodel_identifier,
                                   semantic_id=model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                       "http://acplt.org/TestSemanticId"),)))
+                                                                       "http://example.org/TestSemanticId"),)))
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="test"),
                                                   aas_identifier, submodel={submodel_reference})
 
@@ -185,7 +185,7 @@ class JsonSerializationStrippedObjectsTest(unittest.TestCase):
         qualifier2 = model.Qualifier("test_qualifier2", str)
         operation = model.Operation("test_operation", qualifier={qualifier})
         submodel = model.Submodel(
-            "http://acplt.org/test_submodel",
+            "http://example.org/test_submodel",
             submodel_element=[operation],
             qualifier={qualifier2}
         )
@@ -196,7 +196,7 @@ class JsonSerializationStrippedObjectsTest(unittest.TestCase):
     def test_stripped_annotated_relationship_element(self) -> None:
         mlp = model.MultiLanguageProperty("test_multi_language_property", category="PARAMETER")
         ref = model.ModelReference(
-            (model.Key(model.KeyTypes.SUBMODEL, "http://acplt.org/test_ref"),),
+            (model.Key(model.KeyTypes.SUBMODEL, "http://example.org/test_ref"),),
             model.Submodel
         )
         are = model.AnnotatedRelationshipElement(
@@ -222,12 +222,12 @@ class JsonSerializationStrippedObjectsTest(unittest.TestCase):
 
     def test_stripped_asset_administration_shell(self) -> None:
         submodel_ref = model.ModelReference(
-            (model.Key(model.KeyTypes.SUBMODEL, "http://acplt.org/test_ref"),),
+            (model.Key(model.KeyTypes.SUBMODEL, "http://example.org/test_ref"),),
             model.Submodel
         )
         aas = model.AssetAdministrationShell(
-            model.AssetInformation(global_asset_id="http://acplt.org/test_ref"),
-            "http://acplt.org/test_aas",
+            model.AssetInformation(global_asset_id="http://example.org/test_ref"),
+            "http://example.org/test_aas",
             submodel={submodel_ref}
         )
 

--- a/sdk/test/adapter/xml/test_xml_deserialization.py
+++ b/sdk/test/adapter/xml/test_xml_deserialization.py
@@ -77,9 +77,9 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:assetAdministrationShells>
             <aas:assetAdministrationShell>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
                 <aas:assetInformation>
-                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                    <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -90,10 +90,10 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:assetAdministrationShells>
             <aas:assetAdministrationShell>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind></aas:assetKind>
-                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                    <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -104,10 +104,10 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:assetAdministrationShells>
             <aas:assetAdministrationShell>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>invalidKind</aas:assetKind>
-                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                    <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
@@ -118,7 +118,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:submodelElements>
                     <aas:submodelElementList>
                         <aas:orderRelevant>False</aas:orderRelevant>
@@ -135,7 +135,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
             </aas:submodel>
         </aas:submodels>
         """)
@@ -151,17 +151,17 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:assetAdministrationShells>
             <aas:assetAdministrationShell>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>Instance</aas:assetKind>
-                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                    <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
                 <aas:derivedFrom>
                     <aas:type>ModelReference</aas:type>
                     <aas:keys>
                         <aas:key>
                             <aas:type>Submodel</aas:type>
-                            <aas:value>http://acplt.org/test_ref</aas:value>
+                            <aas:value>http://example.org/test_ref</aas:value>
                         </aas:key>
                     </aas:keys>
                 </aas:derivedFrom>
@@ -170,14 +170,14 @@ class XmlDeserializationTest(unittest.TestCase):
         """)
         with self.assertLogs(logging.getLogger(), level=logging.WARNING) as context:
             read_aas_xml_file(io.StringIO(xml), failsafe=False)
-        for s in ("SUBMODEL", "http://acplt.org/test_ref", "AssetAdministrationShell"):
+        for s in ("SUBMODEL", "http://example.org/test_ref", "AssetAdministrationShell"):
             self.assertIn(s, context.output[0])
 
     def test_invalid_submodel_element(self) -> None:
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:submodelElements>
                     <aas:invalidSubmodelElement/>
                 </aas:submodelElements>
@@ -190,7 +190,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:qualifiers>
                     <aas:qualifier/>
                 </aas:qualifiers>
@@ -203,7 +203,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:submodelElements>
                     <aas:operation>
                         <aas:idShort>test_operation</aas:idShort>
@@ -223,7 +223,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:submodelElements>
                     <aas:operation>
                         <aas:idShort>test_operation</aas:idShort>
@@ -256,23 +256,23 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:assetAdministrationShells>
             <aas:assetAdministrationShell>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
                 <aas:assetInformation>
                     <aas:assetKind>Instance</aas:assetKind>
-                    <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                    <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
                 </aas:assetInformation>
             </aas:assetAdministrationShell>
         </aas:assetAdministrationShells>
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_aas</aas:id>
+                <aas:id>http://example.org/test_aas</aas:id>
             </aas:submodel>
         </aas:submodels>
         """)
         self._assertInExceptionAndLog(xml, "duplicate identifier", KeyError, logging.ERROR)
 
     def test_duplicate_identifier_identifiable_store(self) -> None:
-        sm_id = "http://acplt.org/test_submodel"
+        sm_id = "http://example.org/test_submodel"
 
         def get_clean_store() -> model.DictIdentifiableStore:
             store: model.DictIdentifiableStore[model.Identifiable] = model.DictIdentifiableStore()
@@ -283,7 +283,7 @@ class XmlDeserializationTest(unittest.TestCase):
         xml = _xml_wrap("""
         <aas:submodels>
             <aas:submodel>
-                <aas:id>http://acplt.org/test_submodel</aas:id>
+                <aas:id>http://example.org/test_submodel</aas:id>
                 <aas:idShort>test456</aas:idShort>
             </aas:submodel>
         </aas:submodels>
@@ -325,7 +325,7 @@ class XmlDeserializationTest(unittest.TestCase):
     def test_read_aas_xml_element(self) -> None:
         xml = f"""
         <aas:submodel xmlns:aas="{XML_NS_MAP["aas"]}">
-            <aas:id>http://acplt.org/test_submodel</aas:id>
+            <aas:id>http://example.org/test_submodel</aas:id>
         </aas:submodel>
         """
         string_io = io.StringIO(xml)
@@ -354,7 +354,7 @@ class XmlDeserializationStrippedObjectsTest(unittest.TestCase):
     def test_stripped_qualifiable(self) -> None:
         xml = f"""
         <aas:submodel xmlns:aas="{XML_NS_MAP["aas"]}">
-            <aas:id>http://acplt.org/test_stripped_submodel</aas:id>
+            <aas:id>http://example.org/test_stripped_submodel</aas:id>
             <aas:submodelElements>
                 <aas:operation>
                     <aas:idShort>test_operation</aas:idShort>
@@ -394,10 +394,10 @@ class XmlDeserializationStrippedObjectsTest(unittest.TestCase):
     def test_stripped_asset_administration_shell(self) -> None:
         xml = f"""
         <aas:assetAdministrationShell xmlns:aas="{XML_NS_MAP["aas"]}">
-            <aas:id>http://acplt.org/test_aas</aas:id>
+            <aas:id>http://example.org/test_aas</aas:id>
             <aas:assetInformation>
                 <aas:assetKind>Instance</aas:assetKind>
-                <aas:globalAssetId>http://acplt.org/TestAsset/</aas:globalAssetId>
+                <aas:globalAssetId>http://example.org/TestAsset/</aas:globalAssetId>
             </aas:assetInformation>
             <aas:submodels>
                 <aas:reference>
@@ -405,7 +405,7 @@ class XmlDeserializationStrippedObjectsTest(unittest.TestCase):
                     <aas:keys>
                         <aas:key>
                             <aas:type>Submodel</aas:type>
-                            <aas:value>http://acplt.org/test_ref</aas:value>
+                            <aas:value>http://example.org/test_ref</aas:value>
                         </aas:key>
                     </aas:keys>
                 </aas:reference>
@@ -443,7 +443,7 @@ class XmlDeserializationDerivingTest(unittest.TestCase):
 
         xml = f"""
         <aas:submodel xmlns:aas="{XML_NS_MAP["aas"]}">
-            <aas:id>http://acplt.org/test_stripped_submodel</aas:id>
+            <aas:id>http://example.org/test_stripped_submodel</aas:id>
         </aas:submodel>
         """
         string_io = io.StringIO(xml)

--- a/sdk/test/adapter/xml/test_xml_serialization.py
+++ b/sdk/test/adapter/xml/test_xml_serialization.py
@@ -61,7 +61,8 @@ class XMLSerializationSchemaTest(unittest.TestCase):
         submodel_reference = model.ModelReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier,
                                   semantic_id=model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                                 "http://example.org/TestSemanticId"),)))
+                                                                                 "http://example.org/"
+                                                                                 "TestSemanticId"),)))
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="Test"),
                                                   aas_identifier, submodel={submodel_reference})
         # serialize object to xml

--- a/sdk/test/adapter/xml/test_xml_serialization.py
+++ b/sdk/test/adapter/xml/test_xml_serialization.py
@@ -61,7 +61,7 @@ class XMLSerializationSchemaTest(unittest.TestCase):
         submodel_reference = model.ModelReference(submodel_key, model.Submodel)
         submodel = model.Submodel(submodel_identifier,
                                   semantic_id=model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE,
-                                                                                 "http://acplt.org/TestSemanticId"),)))
+                                                                                 "http://example.org/TestSemanticId"),)))
         test_aas = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="Test"),
                                                   aas_identifier, submodel={submodel_reference})
         # serialize object to xml

--- a/sdk/test/backend/test_couchdb.py
+++ b/sdk/test/backend/test_couchdb.py
@@ -44,12 +44,12 @@ class CouchDBBackendTest(unittest.TestCase):
         self.couch_identifiable_store.add(test_object)
 
         # When retrieving the object, we should get the *same* instance as we added
-        test_object_retrieved = self.couch_identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        test_object_retrieved = self.couch_identifiable_store.get_item('https://example.org/Test_Submodel')
         self.assertIs(test_object, test_object_retrieved)
 
         # When retrieving it again, we should still get the same object
         del test_object
-        test_object_retrieved_again = self.couch_identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        test_object_retrieved_again = self.couch_identifiable_store.get_item('https://example.org/Test_Submodel')
         self.assertIs(test_object_retrieved, test_object_retrieved_again)
 
     def test_example_submodel_storing(self) -> None:
@@ -61,7 +61,7 @@ class CouchDBBackendTest(unittest.TestCase):
         self.assertIn(example_submodel, self.couch_identifiable_store)
 
         # Restore example submodel and check data
-        submodel_restored = self.couch_identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        submodel_restored = self.couch_identifiable_store.get_item('https://example.org/Test_Submodel')
         assert (isinstance(submodel_restored, model.Submodel))
         checker = AASDataChecker(raise_immediately=True)
         check_example_submodel(checker, submodel_restored)
@@ -94,19 +94,19 @@ class CouchDBBackendTest(unittest.TestCase):
         self.couch_identifiable_store.add(example_submodel)
         with self.assertRaises(KeyError) as cm:
             self.couch_identifiable_store.add(example_submodel)
-        self.assertEqual("'Identifiable with id https://acplt.org/Test_Submodel already exists in "
+        self.assertEqual("'Identifiable with id https://example.org/Test_Submodel already exists in "
                          "CouchDB database'", str(cm.exception))
 
         # Querying a deleted object should raise a KeyError
-        retrieved_submodel = self.couch_identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        retrieved_submodel = self.couch_identifiable_store.get_item('https://example.org/Test_Submodel')
         self.couch_identifiable_store.discard(example_submodel)
         with self.assertRaises(KeyError) as cm:
-            self.couch_identifiable_store.get_item('https://acplt.org/Test_Submodel')
-        self.assertEqual("'No Identifiable with id https://acplt.org/Test_Submodel found in CouchDB database'",
+            self.couch_identifiable_store.get_item('https://example.org/Test_Submodel')
+        self.assertEqual("'No Identifiable with id https://example.org/Test_Submodel found in CouchDB database'",
                          str(cm.exception))
 
         # Double deleting should also raise a KeyError
         with self.assertRaises(KeyError) as cm:
             self.couch_identifiable_store.discard(retrieved_submodel)
-        self.assertEqual("'No AAS object with id https://acplt.org/Test_Submodel exists in "
+        self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "CouchDB database'", str(cm.exception))

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -39,12 +39,12 @@ class LocalFileBackendTest(TestCase):
         self.identifiable_store.add(test_object)
 
         # When retrieving the object, we should get the *same* instance as we added
-        test_object_retrieved = self.identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        test_object_retrieved = self.identifiable_store.get_item('https://example.org/Test_Submodel')
         self.assertIs(test_object, test_object_retrieved)
 
         # When retrieving it again, we should still get the same object
         del test_object
-        test_object_retrieved_again = self.identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        test_object_retrieved_again = self.identifiable_store.get_item('https://example.org/Test_Submodel')
         self.assertIs(test_object_retrieved, test_object_retrieved_again)
 
     def test_example_submodel_storing(self) -> None:
@@ -56,7 +56,7 @@ class LocalFileBackendTest(TestCase):
         self.assertIn(example_submodel, self.identifiable_store)
 
         # Restore example submodel and check data
-        submodel_restored = self.identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        submodel_restored = self.identifiable_store.get_item('https://example.org/Test_Submodel')
         assert (isinstance(submodel_restored, model.Submodel))
         checker = AASDataChecker(raise_immediately=True)
         check_example_submodel(checker, submodel_restored)
@@ -89,22 +89,22 @@ class LocalFileBackendTest(TestCase):
         self.identifiable_store.add(example_submodel)
         with self.assertRaises(KeyError) as cm:
             self.identifiable_store.add(example_submodel)
-        self.assertEqual("'Identifiable with id https://acplt.org/Test_Submodel already exists in "
+        self.assertEqual("'Identifiable with id https://example.org/Test_Submodel already exists in "
                          "local file database'", str(cm.exception))
 
         # Querying a deleted object should raise a KeyError
-        retrieved_submodel = self.identifiable_store.get_item('https://acplt.org/Test_Submodel')
+        retrieved_submodel = self.identifiable_store.get_item('https://example.org/Test_Submodel')
         self.identifiable_store.discard(example_submodel)
         with self.assertRaises(KeyError) as cm:
-            self.identifiable_store.get_item('https://acplt.org/Test_Submodel')
-        self.assertEqual("'No Identifiable with id https://acplt.org/Test_Submodel "
+            self.identifiable_store.get_item('https://example.org/Test_Submodel')
+        self.assertEqual("'No Identifiable with id https://example.org/Test_Submodel "
                          "found in local file database'",
                          str(cm.exception))
 
         # Double deleting should also raise a KeyError
         with self.assertRaises(KeyError) as cm:
             self.identifiable_store.discard(retrieved_submodel)
-        self.assertEqual("'No AAS object with id https://acplt.org/Test_Submodel exists in "
+        self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "local file database'", str(cm.exception))
 
     def test_reload_discard(self) -> None:

--- a/sdk/test/examples/test__init__.py
+++ b/sdk/test/examples/test__init__.py
@@ -20,9 +20,9 @@ class TestExampleFunctions(unittest.TestCase):
 
         # Check that the object store contains expected elements
         expected_ids = [
-            'https://acplt.org/Test_AssetAdministrationShell',
-            'https://acplt.org/Test_Submodel_Template',
-            'https://acplt.org/Test_ConceptDescription_Mandatory'
+            'https://example.org/Test_AssetAdministrationShell',
+            'https://example.org/Test_Submodel_Template',
+            'https://example.org/Test_ConceptDescription_Mandatory'
         ]
         for id in expected_ids:
             self.assertIsNotNone(identifiable_store.get_item(id))
@@ -34,9 +34,9 @@ class TestExampleFunctions(unittest.TestCase):
         self.assertGreater(len(identifiable_store), 0)
 
         # Check that the object store contains expected elements
-        aas_id = 'https://acplt.org/Test_AssetAdministrationShell'
-        sm_id = 'https://acplt.org/Test_Submodel_Template'
-        cd_id = 'https://acplt.org/Test_ConceptDescription_Mandatory'
+        aas_id = 'https://example.org/Test_AssetAdministrationShell'
+        sm_id = 'https://example.org/Test_Submodel_Template'
+        cd_id = 'https://example.org/Test_ConceptDescription_Mandatory'
 
         aas = identifiable_store.get_item(aas_id)
         sm = identifiable_store.get_item(sm_id)

--- a/sdk/test/examples/test_examples.py
+++ b/sdk/test/examples/test_examples.py
@@ -43,7 +43,7 @@ class ExampleAASTest(unittest.TestCase):
         identifiable_store = model.DictIdentifiableStore()
         with self.assertRaises(AssertionError) as cm:
             example_aas.check_full_example(checker, identifiable_store)
-        self.assertIn("AssetAdministrationShell[https://acplt.org/Test_AssetAdministrationShell]",
+        self.assertIn("AssetAdministrationShell[https://example.org/Test_AssetAdministrationShell]",
                       str(cm.exception))
 
         identifiable_store = example_aas.create_full_example()

--- a/sdk/test/examples/test_helpers.py
+++ b/sdk/test/examples/test_helpers.py
@@ -253,14 +253,14 @@ class AASDataCheckerTest(unittest.TestCase):
         rel1 = model.AnnotatedRelationshipElement(id_short='test',
                                                   first=model.ModelReference((
                                                       model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                                value='http://acplt.org/Test_Submodel'),
+                                                                value='http://example.org/Test_Submodel'),
                                                       model.Key(
                                                           type_=model.KeyTypes.PROPERTY,
                                                           value='ExampleProperty'),),
                                                                            model.Property),
                                                   second=model.ModelReference((
                                                       model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                                value='http://acplt.org/Test_Submodel'),
+                                                                value='http://example.org/Test_Submodel'),
                                                       model.Key(type_=model.KeyTypes.PROPERTY,
                                                                 value='ExampleProperty'),),
                                                       model.Property),
@@ -268,13 +268,13 @@ class AASDataCheckerTest(unittest.TestCase):
         rel2 = model.AnnotatedRelationshipElement(id_short='test',
                                                   first=model.ModelReference((
                                                       model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                                value='http://acplt.org/Test_Submodel'),
+                                                                value='http://example.org/Test_Submodel'),
                                                       model.Key(type_=model.KeyTypes.PROPERTY,
                                                                 value='ExampleProperty'),),
                                                       model.Property),
                                                   second=model.ModelReference((
                                                       model.Key(type_=model.KeyTypes.SUBMODEL,
-                                                                value='http://acplt.org/Test_Submodel'),
+                                                                value='http://example.org/Test_Submodel'),
                                                       model.Key(type_=model.KeyTypes.PROPERTY,
                                                                 value='ExampleProperty'),),
                                                       model.Property),

--- a/sdk/test/examples/test_helpers.py
+++ b/sdk/test/examples/test_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_aas.py
+++ b/sdk/test/model/test_aas.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_aas.py
+++ b/sdk/test/model/test_aas.py
@@ -16,14 +16,14 @@ class AssetInformationTest(unittest.TestCase):
             model.AssetInformation(model.AssetKind.INSTANCE)
         self.assertEqual("An AssetInformation has to have a globalAssetId or a specificAssetId (Constraint AASd-131)",
                          str(cm.exception))
-        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://acplt.org/TestAsset")
+        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://example.org/TestAsset")
         model.AssetInformation(model.AssetKind.INSTANCE, specific_asset_id=(model.SpecificAssetId("test", "test"),))
-        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://acplt.org/TestAsset",
+        model.AssetInformation(model.AssetKind.INSTANCE, global_asset_id="https://example.org/TestAsset",
                                specific_asset_id=(model.SpecificAssetId("test", "test"),))
 
     def test_aasd_131_set(self) -> None:
         asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
-                                                   global_asset_id="https://acplt.org/TestAsset",
+                                                   global_asset_id="https://example.org/TestAsset",
                                                    specific_asset_id=(model.SpecificAssetId("test", "test"),))
         asset_information.global_asset_id = None
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -32,7 +32,7 @@ class AssetInformationTest(unittest.TestCase):
                          str(cm.exception))
 
         asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
-                                                   global_asset_id="https://acplt.org/TestAsset",
+                                                   global_asset_id="https://example.org/TestAsset",
                                                    specific_asset_id=(model.SpecificAssetId("test", "test"),))
         asset_information.specific_asset_id = model.ConstrainedList(())
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -42,7 +42,7 @@ class AssetInformationTest(unittest.TestCase):
 
     def test_aasd_131_specific_asset_id_add(self) -> None:
         asset_information = model.AssetInformation(model.AssetKind.INSTANCE,
-                                                   global_asset_id="https://acplt.org/TestAsset")
+                                                   global_asset_id="https://example.org/TestAsset")
         specific_asset_id1 = model.SpecificAssetId("test", "test")
         specific_asset_id2 = model.SpecificAssetId("test", "test")
         asset_information.specific_asset_id.append(specific_asset_id1)

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -247,7 +247,7 @@ class ReferableTest(unittest.TestCase):
         self.assertIs(example_relel.parent, example_submodel)
 
     def test_update_commit_qualifier_extension_semantic_id(self):
-        submodel = model.Submodel("https://acplt.org/Test_Submodel")
+        submodel = model.Submodel("https://example.org/Test_Submodel")
         qualifier = model.Qualifier("test", model.datatypes.String)
         extension = model.Extension("test")
         collection = model.SubmodelElementCollection("test")
@@ -308,11 +308,11 @@ class ModelNamespaceTest(unittest.TestCase):
 
     def setUp(self):
         self.propSemanticID = model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                 value='http://acplt.org/Test1'),))
+                                                                 value='http://example.org/Test1'),))
         self.propSemanticID2 = model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                  value='http://acplt.org/Test2'),))
+                                                                  value='http://example.org/Test2'),))
         self.propSemanticID3 = model.ExternalReference((model.Key(type_=model.KeyTypes.GLOBAL_REFERENCE,
-                                                                  value='http://acplt.org/Test3'),))
+                                                                  value='http://example.org/Test3'),))
         self.prop1 = model.Property("Prop1", model.datatypes.Int, semantic_id=self.propSemanticID)
         self.prop2 = model.Property("Prop2", model.datatypes.Int, semantic_id=self.propSemanticID)
         self.prop3 = model.Property("Prop2", model.datatypes.Int, semantic_id=self.propSemanticID2)
@@ -340,7 +340,7 @@ class ModelNamespaceTest(unittest.TestCase):
             self.namespace.set1.add(self.prop2)
         self.assertEqual(
             "Object with attribute (name='semantic_id', value='ExternalReference(key=(Key("
-            "type=GLOBAL_REFERENCE, value=http://acplt.org/Test1),))') is already present in this set of objects "
+            "type=GLOBAL_REFERENCE, value=http://example.org/Test1),))') is already present in this set of objects "
             "(Constraint AASd-000)",
             str(cm.exception))
         self.namespace.set2.add(self.prop5)
@@ -355,7 +355,7 @@ class ModelNamespaceTest(unittest.TestCase):
             self.namespace.set2.add(self.prop4)
         self.assertEqual(
             "Object with attribute (name='semantic_id', value='"
-            "ExternalReference(key=(Key(type=GLOBAL_REFERENCE, value=http://acplt.org/Test1),))')"
+            "ExternalReference(key=(Key(type=GLOBAL_REFERENCE, value=http://example.org/Test1),))')"
             " is already present in another set in the same namespace (Constraint AASd-000)",
             str(cm.exception))
 

--- a/sdk/test/model/test_provider.py
+++ b/sdk/test/model/test_provider.py
@@ -13,9 +13,9 @@ from basyx.aas import model
 class ProvidersTest(unittest.TestCase):
     def setUp(self) -> None:
         self.aas1 = model.AssetAdministrationShell(
-            model.AssetInformation(global_asset_id="http://acplt.org/TestAsset1/"), "urn:x-test:aas1")
+            model.AssetInformation(global_asset_id="http://example.org/TestAsset1/"), "urn:x-test:aas1")
         self.aas2 = model.AssetAdministrationShell(
-            model.AssetInformation(global_asset_id="http://acplt.org/TestAsset2/"), "urn:x-test:aas2")
+            model.AssetInformation(global_asset_id="http://example.org/TestAsset2/"), "urn:x-test:aas2")
         self.submodel1 = model.Submodel("urn:x-test:submodel1")
         self.submodel2 = model.Submodel("urn:x-test:submodel2")
 
@@ -26,7 +26,7 @@ class ProvidersTest(unittest.TestCase):
         self.assertIn(self.aas1, identifiable_store)
         property = model.Property('test', model.datatypes.String)
         self.assertFalse(property in identifiable_store)
-        aas3 = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="http://acplt.org/TestAsset/"),
+        aas3 = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="http://example.org/TestAsset/"),
                                               "urn:x-test:aas1")
         with self.assertRaises(KeyError) as cm:
             identifiable_store.add(aas3)

--- a/sdk/test/model/test_submodel.py
+++ b/sdk/test/model/test_submodel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.
@@ -17,10 +17,12 @@ class EntityTest(unittest.TestCase):
             model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY)
         self.assertEqual("A self-managed entity has to have a globalAssetId or a specificAssetId (Constraint AASd-014)",
                          str(cm.exception))
-        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://example.org/TestAsset")
+        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
+                     global_asset_id="https://example.org/TestAsset")
         model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
                      specific_asset_id=(model.SpecificAssetId("test", "test"),))
-        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://example.org/TestAsset",
+        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
+                     global_asset_id="https://example.org/TestAsset",
                      specific_asset_id=(model.SpecificAssetId("test", "test"),))
 
     def test_aasd_014_init_co_managed(self) -> None:

--- a/sdk/test/model/test_submodel.py
+++ b/sdk/test/model/test_submodel.py
@@ -17,17 +17,17 @@ class EntityTest(unittest.TestCase):
             model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY)
         self.assertEqual("A self-managed entity has to have a globalAssetId or a specificAssetId (Constraint AASd-014)",
                          str(cm.exception))
-        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://acplt.org/TestAsset")
+        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://example.org/TestAsset")
         model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
                      specific_asset_id=(model.SpecificAssetId("test", "test"),))
-        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://acplt.org/TestAsset",
+        model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="https://example.org/TestAsset",
                      specific_asset_id=(model.SpecificAssetId("test", "test"),))
 
     def test_aasd_014_init_co_managed(self) -> None:
         model.Entity("TestEntity", model.EntityType.CO_MANAGED_ENTITY)
         with self.assertRaises(model.AASConstraintViolation) as cm:
             model.Entity("TestEntity", model.EntityType.CO_MANAGED_ENTITY,
-                         global_asset_id="https://acplt.org/TestAsset")
+                         global_asset_id="https://example.org/TestAsset")
         self.assertEqual("A co-managed entity has to have neither a globalAssetId nor a specificAssetId "
                          "(Constraint AASd-014)", str(cm.exception))
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -37,14 +37,14 @@ class EntityTest(unittest.TestCase):
                          "(Constraint AASd-014)", str(cm.exception))
         with self.assertRaises(model.AASConstraintViolation) as cm:
             model.Entity("TestEntity", model.EntityType.CO_MANAGED_ENTITY,
-                         global_asset_id="https://acplt.org/TestAsset",
+                         global_asset_id="https://example.org/TestAsset",
                          specific_asset_id=(model.SpecificAssetId("test", "test"),))
         self.assertEqual("A co-managed entity has to have neither a globalAssetId nor a specificAssetId "
                          "(Constraint AASd-014)", str(cm.exception))
 
     def test_aasd_014_set_self_managed(self) -> None:
         entity = model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
-                              global_asset_id="https://acplt.org/TestAsset",
+                              global_asset_id="https://example.org/TestAsset",
                               specific_asset_id=(model.SpecificAssetId("test", "test"),))
         entity.global_asset_id = None
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -53,7 +53,7 @@ class EntityTest(unittest.TestCase):
                          str(cm.exception))
 
         entity = model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
-                              global_asset_id="https://acplt.org/TestAsset",
+                              global_asset_id="https://example.org/TestAsset",
                               specific_asset_id=(model.SpecificAssetId("test", "test"),))
         entity.specific_asset_id = model.ConstrainedList(())
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -64,7 +64,7 @@ class EntityTest(unittest.TestCase):
     def test_aasd_014_set_co_managed(self) -> None:
         entity = model.Entity("TestEntity", model.EntityType.CO_MANAGED_ENTITY)
         with self.assertRaises(model.AASConstraintViolation) as cm:
-            entity.global_asset_id = "https://acplt.org/TestAsset"
+            entity.global_asset_id = "https://example.org/TestAsset"
         self.assertEqual("A co-managed entity has to have neither a globalAssetId nor a specificAssetId "
                          "(Constraint AASd-014)", str(cm.exception))
         with self.assertRaises(model.AASConstraintViolation) as cm:
@@ -74,7 +74,7 @@ class EntityTest(unittest.TestCase):
 
     def test_aasd_014_specific_asset_id_add_self_managed(self) -> None:
         entity = model.Entity("TestEntity", model.EntityType.SELF_MANAGED_ENTITY,
-                              global_asset_id="https://acplt.org/TestAsset")
+                              global_asset_id="https://example.org/TestAsset")
         specific_asset_id1 = model.SpecificAssetId("test", "test")
         specific_asset_id2 = model.SpecificAssetId("test", "test")
         entity.specific_asset_id.append(specific_asset_id1)

--- a/sdk/test/util/test_identification.py
+++ b/sdk/test/util/test_identification.py
@@ -34,24 +34,24 @@ class IdentifierGeneratorTest(unittest.TestCase):
             generator = NamespaceIRIGenerator("http", provider)
         self.assertEqual('Namespace must be a valid IRI, ending with #, / or =', str(cm.exception))
 
-        generator = NamespaceIRIGenerator("http://acplt.org/AAS/", provider)
-        self.assertEqual("http://acplt.org/AAS/", generator.namespace)
+        generator = NamespaceIRIGenerator("http://example.org/AAS/", provider)
+        self.assertEqual("http://example.org/AAS/", generator.namespace)
 
         identification = generator.generate_id()
-        self.assertEqual(identification, "http://acplt.org/AAS/0000")
+        self.assertEqual(identification, "http://example.org/AAS/0000")
         provider.add(model.Submodel(identification))
 
         for i in range(10):
             identification = generator.generate_id()
             self.assertNotIn(identification, provider)
             provider.add(model.Submodel(identification))
-        self.assertEqual(identification, "http://acplt.org/AAS/0010")
+        self.assertEqual(identification, "http://example.org/AAS/0010")
 
         identification = generator.generate_id("Spülmaschine")
-        self.assertEqual(identification, "http://acplt.org/AAS/Spülmaschine")
+        self.assertEqual(identification, "http://example.org/AAS/Spülmaschine")
         provider.add(model.Submodel(identification))
 
         for i in range(10):
             identification = generator.generate_id("Spülmaschine")
             self.assertNotIn(identification, provider)
-            self.assertNotEqual(identification, "http://acplt.org/AAS/Spülmaschine")
+            self.assertNotEqual(identification, "http://example.org/AAS/Spülmaschine")


### PR DESCRIPTION

Replaces all references to `https://acplt.org/` and `http://acplt.org/` with `https://example.org/` and `http://example.org/` respectively throughout the codebase.

Closes #460

## All Changes i have done -

- **1,505 replacements** across **43 text files**
- **2 regenerated [.aasx](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/basyx-python-sdk/compliance_tool/test/files/test_empty.aasx:0:0-0:0) binary packages** ([test_demo_full_example_json.aasx](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/basyx-python-sdk/compliance_tool/test/files/test_demo_full_example_json.aasx:0:0-0:0), [test_demo_full_example_xml.aasx](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/basyx-python-sdk/compliance_tool/test/files/test_demo_full_example_xml.aasx:0:0-0:0))

### Affected areas

| Category | Files |
|---|---|
| Example data generators (`sdk/basyx/aas/examples/data/`) | 5 |
| Tutorials (`sdk/basyx/aas/examples/`) | 4 |
| SDK test files (`sdk/test/`) | 14 |
| SDK adapter docstrings & docs | 3 |
| Compliance tool source & tests | 4 |
| Compliance tool serialized fixtures (JSON/XML) | 11 |
| Compliance tool `.aasx` binary packages | 2 |

### I did not change-
- URL path suffixes (e.g., `/Test_Submodel`, `/Properties/ExampleProperty`) are preserved as-is
- URL schemes (`http://` vs `https://`) are preserved as-is
- No functional/logic changes — this is a pure identifier rename

## Ouputs:- 
<img width="1913" height="357" alt="image" src="https://github.com/user-attachments/assets/d67f2ed4-719d-495d-a8dc-b5dd8bebaf38" />
<img width="1915" height="310" alt="image" src="https://github.com/user-attachments/assets/2390a24e-1d0a-4ef8-a4ab-8890ec18e6d5" />
<img width="1283" height="86" alt="image" src="https://github.com/user-attachments/assets/ad7eb59c-ca49-4bcd-91ef-26699f61e9c8" />




