### PR TITLE
Fix --quite typo: rename to --quiet in compliance_tool CLI

### DIFF
--- a/compliance_tool/aas_compliance_tool/cli.py
+++ b/compliance_tool/aas_compliance_tool/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/compliance_tool/aas_compliance_tool/cli.py
+++ b/compliance_tool/aas_compliance_tool/cli.py
@@ -76,7 +76,7 @@ def parse_cli_arguments() -> argparse.ArgumentParser:
     parser.add_argument('-v', '--verbose', help="Print detailed information for each check. Multiple -v options "
                                                 "increase the verbosity. 1: Detailed error information, 2: Additional "
                                                 "detailed success information", action='count', default=0)
-    parser.add_argument('-q', '--quite', help="no information output if successful", action='store_true')
+    parser.add_argument('-q', '--quiet', help="no information output if successful", action='store_true')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--json', help="Use AAS json format when checking or creating files", action='store_true')
     group.add_argument('--xml', help="Use AAS xml format when checking or creating files", action='store_true')
@@ -177,9 +177,8 @@ def main():
                                                                 **data_checker_kwargs)
         else:
             parser.error("f or files requires two file path.")
-            exit()
 
-    if manager.status is Status.SUCCESS and args.quite:
+    if manager.status is Status.SUCCESS and args.quiet:
         exit()
 
     print(manager.format_state_manager(args.verbose))

--- a/compliance_tool/test/test_aas_compliance_tool.py
+++ b/compliance_tool/test/test_aas_compliance_tool.py
@@ -115,8 +115,14 @@ class ComplianceToolTest(unittest.TestCase):
         self.assertNotIn('ERROR', str(output.stderr))
         self.assertIn('INFO', str(output.stdout))
 
-        # test quite
+        # test quiet (short form)
         output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json", "-q")
+        self.assertEqual(0, output.returncode)
+        self.assertEqual("b''", str(output.stdout))
+
+        # test quiet (long form -- previously misspelled as --quite)
+        output = _run_compliance_tool("e", os.path.join(test_file_path, "test_demo_full_example.json"), "--json",
+                                      "--quiet")
         self.assertEqual(0, output.returncode)
         self.assertEqual("b''", str(output.stdout))
 


### PR DESCRIPTION
Fixes #505

## Changes
- Rename `--quite` → `--quiet` in `add_argument` (line 79) and all usages
- Remove unreachable `exit()` after `parser.error()` (line 180) — `parser.error()` calls `sys.exit(2)` internally
- Add test for `--quiet` long-form flag in `test_parse_args`