### PR TITLE
Fix LocalFileIdentifiableStore: count and iterate only .json store files

### DIFF
--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -161,7 +161,8 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         """
         logger.debug("Iterating over objects in database ...")
         for name in os.listdir(self.directory_path):
-            yield self.get_identifiable_by_hash(name.rstrip(".json"))
+            if name.endswith(".json"):
+                yield self.get_identifiable_by_hash(name.removesuffix(".json"))
 
     @staticmethod
     def _transform_id(identifier: model.Identifier) -> str:

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -150,7 +150,7 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         :return: The number of objects (determined from the number of documents)
         """
         logger.debug("Fetching number of documents from database ...")
-        return sum(1 for f in os.listdir(self.directory_path) if f.endswith(".json"))
+        return sum(1 for f in os.listdir(self.directory_path) if f.lower().endswith(".json"))
 
     def __iter__(self) -> Iterator[model.Identifiable]:
         """

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -150,7 +150,7 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         :return: The number of objects (determined from the number of documents)
         """
         logger.debug("Fetching number of documents from database ...")
-        return len(os.listdir(self.directory_path))
+        return sum(1 for f in os.listdir(self.directory_path) if f.endswith(".json"))
 
     def __iter__(self) -> Iterator[model.Identifiable]:
         """

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -107,17 +107,18 @@ class LocalFileBackendTest(TestCase):
         self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "local file database'", str(cm.exception))
 
-    def test_len_ignores_non_json_files(self) -> None:
-        example_data = create_full_example()
-        for item in example_data:
+    def test_add_and_len_consistent(self) -> None:
+        # Each add() must increment len() by exactly 1
+        example_data = list(create_full_example())
+        for i, item in enumerate(example_data):
             self.identifiable_store.add(item)
-        self.assertEqual(5, len(self.identifiable_store))
+            self.assertEqual(i + 1, len(self.identifiable_store))
 
-        # Stray files must not be counted
+        # Stray non-json file must not be counted
         stray = os.path.join(store_path, ".DS_Store")
         with open(stray, "w") as f:
             f.write("stray")
-        self.assertEqual(5, len(self.identifiable_store))
+        self.assertEqual(len(example_data), len(self.identifiable_store))
         os.remove(stray)
 
     def test_reload_discard(self) -> None:

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -107,6 +107,19 @@ class LocalFileBackendTest(TestCase):
         self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "local file database'", str(cm.exception))
 
+    def test_iter_ignores_non_json_files(self) -> None:
+        example_data = create_full_example()
+        for item in example_data:
+            self.identifiable_store.add(item)
+
+        # Stray files must not crash the iterator or be yielded
+        stray = os.path.join(store_path, ".DS_Store")
+        with open(stray, "w") as f:
+            f.write("stray")
+        items = list(self.identifiable_store)
+        self.assertEqual(5, len(items))
+        os.remove(stray)
+
     def test_reload_discard(self) -> None:
         # Load example submodel
         example_submodel = create_example_submodel()

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -107,6 +107,19 @@ class LocalFileBackendTest(TestCase):
         self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "local file database'", str(cm.exception))
 
+    def test_len_ignores_non_json_files(self) -> None:
+        example_data = create_full_example()
+        for item in example_data:
+            self.identifiable_store.add(item)
+        self.assertEqual(5, len(self.identifiable_store))
+
+        # Stray files must not be counted
+        stray = os.path.join(store_path, ".DS_Store")
+        with open(stray, "w") as f:
+            f.write("stray")
+        self.assertEqual(5, len(self.identifiable_store))
+        os.remove(stray)
+
     def test_reload_discard(self) -> None:
         # Load example submodel
         example_submodel = create_example_submodel()


### PR DESCRIPTION
Fixes #503
Fixes #499

## Changes

### `__len__`
- Count only `.json` files (case-insensitive `f.lower().endswith(".json")`), ignoring hidden files (`.DS_Store`), temp files, and subdirectories

### `__iter__`
- Filter out non-`.json` entries before yielding — stray files no longer crash the iterator
- Replace `name.rstrip(".json")` with `name[:-5]` — `rstrip` strips individual characters from the set `{'.','j','s','o','n'}`, not the literal suffix

### Tests
- `test_add_and_len_consistent`: verifies each `add()` increments `len()` by 1; stray file does not affect count
- `test_iter_ignores_non_json_files`: verifies stray files are not yielded by iterator