### PR TITLE
Fix LocalFileIdentifiableStore.__iter__: filter non-.json files and use removesuffix

### DIFF
--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -161,7 +161,8 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         """
         logger.debug("Iterating over objects in database ...")
         for name in os.listdir(self.directory_path):
-            yield self.get_identifiable_by_hash(name.rstrip(".json"))
+            if name.endswith(".json"):
+                yield self.get_identifiable_by_hash(name.removesuffix(".json"))
 
     @staticmethod
     def _transform_id(identifier: model.Identifier) -> str:

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -107,6 +107,19 @@ class LocalFileBackendTest(TestCase):
         self.assertEqual("'No AAS object with id https://example.org/Test_Submodel exists in "
                          "local file database'", str(cm.exception))
 
+    def test_iter_ignores_non_json_files(self) -> None:
+        example_data = create_full_example()
+        for item in example_data:
+            self.identifiable_store.add(item)
+
+        # Stray files must not crash the iterator or be yielded
+        stray = os.path.join(store_path, ".DS_Store")
+        with open(stray, "w") as f:
+            f.write("stray")
+        items = list(self.identifiable_store)
+        self.assertEqual(5, len(items))
+        os.remove(stray)
+
     def test_reload_discard(self) -> None:
         # Load example submodel
         example_submodel = create_example_submodel()


### PR DESCRIPTION
Fixes #499

## Changes
- Add `.endswith(".json")` guard — stray files (`.DS_Store`, temp files, subdirectories) no longer crash the iterator
- Replace `name.rstrip(".json")` with `name.removesuffix(".json")` — `rstrip` strips individual characters from the set `{'.','j','s','o','n'}`, not the literal suffix
- Add `test_iter_ignores_non_json_files` unit test