### PR TITLE
Remove dead DataSpecificationIEC61360 value_id JSON deserialization code

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -511,8 +511,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
             ret.value_list = cls._construct_value_list(_get_ts(dct, 'valueList', dict))
         if 'value' in dct:
             ret.value = _get_ts(dct, 'value', str)
-        if 'valueId' in dct:
-            ret.value_id = cls._construct_reference(_get_ts(dct, 'valueId', dict))
         if 'levelType' in dct:
             for k, v in _get_ts(dct, 'levelType', dict).items():
                 if v:


### PR DESCRIPTION
Fixes #504

## Changes
- Remove `valueId` deserialization block from `_construct_data_specification_iec61360`: `DataSpecificationIEC61360` has no `value_id` attribute in the AAS v3.0.1 model, so the dynamic assignment was silently discarded on every round-trip