### PR TITLE
Fix assetIds decoding: return 400 instead of 500 on malformed JSON

### DIFF
--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -444,8 +444,11 @@ class WSGIApp(ObjectStoreWSGIApp):
             for asset_id in asset_ids:
                 asset_id_json = base64url_decode(asset_id)
                 asset_dict = json.loads(asset_id_json)
-                name = asset_dict["name"]
-                value = asset_dict["value"]
+                try:
+                    name = asset_dict["name"]
+                    value = asset_dict["value"]
+                except KeyError as e:
+                    raise BadRequest(f"Invalid assetId format: missing field {e}") from e
 
                 if name == "specificAssetId":
                     decoded_specific_id = HTTPApiDecoder.json_list(value, model.SpecificAssetId, False, True)[0]

--- a/server/test/interfaces/test_shells_asset_ids.py
+++ b/server/test/interfaces/test_shells_asset_ids.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 the Eclipse BaSyx Authors
+#
+# This program and the accompanying materials are made available under the terms of the MIT License, available in
+# the LICENSE file of this project.
+#
+# SPDX-License-Identifier: MIT
+
+import base64
+import json
+import unittest
+
+from basyx.aas import model
+from basyx.aas.adapter.aasx import DictSupplementaryFileContainer
+from basyx.aas.examples.data.example_aas import create_full_example
+from werkzeug.test import Client
+
+from app.interfaces.repository import WSGIApp
+
+
+def _encode_asset_id(name: str, value: str) -> str:
+    payload = json.dumps({"name": name, "value": value})
+    return base64.urlsafe_b64encode(payload.encode()).decode()
+
+
+class ShellsAssetIdsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        app = WSGIApp(create_full_example(), DictSupplementaryFileContainer())
+        self.client = Client(app)
+
+    def test_malformed_asset_id_missing_field_returns_400(self) -> None:
+        bad_payload = base64.urlsafe_b64encode(b'{"name": "globalAssetId"}').decode()
+        response = self.client.get(f"/api/v3.1/shells?assetIds={bad_payload}")
+        self.assertEqual(400, response.status_code)


### PR DESCRIPTION
Fixes #502

## Changes
- Wrap `asset_dict["name"]` / `asset_dict["value"]` in a `try/except KeyError` and raise `BadRequest` with a descriptive message — client input validation errors must return 4xx, not 5xx
- Add `test_malformed_asset_id_missing_field_returns_400` unit test using Werkzeug test client