### PR TITLE
Fix DictSupplementaryFileContainer: refcount never incremented, delete_file never frees memory

### DIFF
--- a/sdk/basyx/aas/adapter/aasx.py
+++ b/sdk/basyx/aas/adapter/aasx.py
@@ -880,6 +880,7 @@ class DictSupplementaryFileContainer(AbstractSupplementaryFileContainer):
         if new_name == old_name:
             return new_name
         file_hash, file_content_type = self._name_map[old_name]
+        self._store_refcount[file_hash] -= 1
         del self._name_map[old_name]
         return self._assign_unique_name(new_name, file_hash, file_content_type)
 
@@ -889,6 +890,7 @@ class DictSupplementaryFileContainer(AbstractSupplementaryFileContainer):
         while True:
             if new_name not in self._name_map:
                 self._name_map[new_name] = (sha, content_type)
+                self._store_refcount[sha] += 1
                 return new_name
             elif self._name_map[new_name] == (sha, content_type):
                 return new_name

--- a/sdk/test/adapter/aasx/test_aasx.py
+++ b/sdk/test/adapter/aasx/test_aasx.py
@@ -88,6 +88,24 @@ class TestAASXUtils(unittest.TestCase):
         with self.assertRaises(KeyError):
             container.write_file(duplicate_file, file_content)
 
+    def test_supplementary_file_container_refcount(self) -> None:
+        container = aasx.DictSupplementaryFileContainer()
+        data = b"test content"
+        name1 = container.add_file("/file1.bin", io.BytesIO(data), "application/octet-stream")
+        name2 = container.add_file("/file2.bin", io.BytesIO(data), "application/octet-stream")
+        content_hash = container.get_sha256(name1)
+
+        # Both names point to same content — backing store must be present
+        self.assertIn(content_hash, container._store)
+
+        # Deleting one reference must NOT free the backing store
+        container.delete_file(name1)
+        self.assertIn(content_hash, container._store)
+
+        # Deleting the last reference must free the backing store
+        container.delete_file(name2)
+        self.assertNotIn(content_hash, container._store)
+
 
 class AASXWriterTest(unittest.TestCase):
     def test_writing_reading_example_aas(self) -> None:


### PR DESCRIPTION
Fixes #495

## Changes
- `_assign_unique_name`: increment `_store_refcount[sha]` when creating a new `_name_map` entry (first loop branch) — without this, count stays at 0 and `delete_file`'s `== 0` check never triggers
- `rename_file`: decrement `_store_refcount[file_hash]` when removing the old name entry from `_name_map`, consistent with `delete_file` behavior
- Add `test_supplementary_file_container_refcount` — verifies backing store is freed only after the last reference is deleted