### PR TITLE
Fix OrderedNamespaceSet.__setitem__: int remove-before-add and slice exhausted iterator

### DIFF
--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -2248,7 +2248,7 @@ class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NS
                 for i in successful_new_items:
                     super().remove(i)
                 raise
-            self._order[s] = new_items
+            self._order[s] = successful_new_items
         for i in deleted_items:
             super().remove(i)
 

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -2232,9 +2232,15 @@ class OrderedNamespaceSet(NamespaceSet[_NSO], MutableSequence[_NSO], Generic[_NS
 
     def __setitem__(self, s, o) -> None:
         if isinstance(s, int):
-            deleted_items = [self._order[s]]
-            super().add(o)
+            old_item = self._order[s]
+            super().remove(old_item)
+            try:
+                super().add(o)
+            except Exception:
+                super().add(old_item)
+                raise
             self._order[s] = o
+            return
         else:
             deleted_items = self._order[s]
             new_items = itertools.islice(o, len(deleted_items))

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -722,6 +722,35 @@ class ModelOrderedNamespaceTest(ModelNamespaceTest):
                          f"{self._namespace_class.__name__}[{self.namespace.id}]'",  # type: ignore[has-type]
                          str(cm2.exception))
 
+    def test_ordered_namespaceset_slice_setitem_preserves_order(self) -> None:
+        # Replace a slice of items; the new items must appear in the correct positions after replacement
+        ns = ExampleOrderedNamespace()
+        sid1 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/sid1"),))
+        sid2 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/sid2"),))
+        sid3 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/sid3"),))
+        sid4 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/sid4"),))
+        sid5 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/sid5"),))
+        p1 = model.Property("PA", model.datatypes.Int, semantic_id=sid1)
+        p2 = model.Property("PB", model.datatypes.Int, semantic_id=sid2)
+        p3 = model.Property("PC", model.datatypes.Int, semantic_id=sid3)
+        ns.set1.add(p1)
+        ns.set1.add(p2)
+        ns.set1.add(p3)
+        self.assertEqual([p1, p2, p3], list(ns.set1))
+
+        # Replace slice [0:2] (p1, p2) with two new items
+        new1 = model.Property("PX", model.datatypes.Int, semantic_id=sid4)
+        new2 = model.Property("PY", model.datatypes.Int, semantic_id=sid5)
+        ns.set1[0:2] = [new1, new2]
+
+        # After replacement: [new1, new2, p3]
+        result = list(ns.set1)
+        self.assertEqual([new1, new2, p3], result)
+        self.assertIsNone(p1.parent)
+        self.assertIsNone(p2.parent)
+        self.assertIs(ns, new1.parent)
+        self.assertIs(ns, new2.parent)
+
 
 class ExternalReferenceTest(unittest.TestCase):
     def test_constraints(self):

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -722,20 +722,32 @@ class ModelOrderedNamespaceTest(ModelNamespaceTest):
                          f"{self._namespace_class.__name__}[{self.namespace.id}]'",  # type: ignore[has-type]
                          str(cm2.exception))
 
-    def test_ordered_namespaceset_int_setitem_same_id_short(self) -> None:
-        # Replacing item at index with new item sharing same id_short must succeed;
-        # the add-before-remove order causes a false AASConstraintViolation otherwise
+    def test_ordered_namespaceset_int_setitem_preserves_index(self) -> None:
+        # __setitem__ int must place the new item at the exact index of the replaced item.
+        # Items before and after the replaced index must not shift.
         ns = ExampleOrderedNamespace()
         sid1 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s1"),))
         sid2 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s2"),))
-        old = model.Property("SameName", model.datatypes.Int, semantic_id=sid1)
-        new = model.Property("SameName", model.datatypes.Int, semantic_id=sid2)
+        sid3 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s3"),))
+        sid4 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s4"),))
+        p0 = model.Property("PA", model.datatypes.Int, semantic_id=sid1)
+        old = model.Property("PB", model.datatypes.Int, semantic_id=sid2)
+        p2 = model.Property("PC", model.datatypes.Int, semantic_id=sid3)
+        new = model.Property("PB", model.datatypes.Int, semantic_id=sid4)  # same id_short as old
+        ns.set1.add(p0)
         ns.set1.add(old)
-        # Replace old with new — both have id_short "SameName"; must not raise AASConstraintViolation
-        ns.set1[0] = new
-        self.assertEqual([new], list(ns.set1))
-        self.assertIsNone(old.parent)
+        ns.set1.add(p2)
+        # set1 is [p0, old, p2] at indices [0, 1, 2]
+
+        # Replace middle item (index 1) — same id_short must not raise AASConstraintViolation
+        ns.set1[1] = new
+
+        # p0 stays at 0, new is at 1, p2 stays at 2 — no index shift
+        self.assertIs(p0, ns.set1[0])
+        self.assertIs(new, ns.set1[1])
+        self.assertIs(p2, ns.set1[2])
         self.assertIs(ns, new.parent)
+        self.assertIsNone(old.parent)
 
 
 class ExternalReferenceTest(unittest.TestCase):

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -722,6 +722,21 @@ class ModelOrderedNamespaceTest(ModelNamespaceTest):
                          f"{self._namespace_class.__name__}[{self.namespace.id}]'",  # type: ignore[has-type]
                          str(cm2.exception))
 
+    def test_ordered_namespaceset_int_setitem_same_id_short(self) -> None:
+        # Replacing item at index with new item sharing same id_short must succeed;
+        # the add-before-remove order causes a false AASConstraintViolation otherwise
+        ns = ExampleOrderedNamespace()
+        sid1 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s1"),))
+        sid2 = model.ExternalReference((model.Key(model.KeyTypes.GLOBAL_REFERENCE, "http://example.org/s2"),))
+        old = model.Property("SameName", model.datatypes.Int, semantic_id=sid1)
+        new = model.Property("SameName", model.datatypes.Int, semantic_id=sid2)
+        ns.set1.add(old)
+        # Replace old with new — both have id_short "SameName"; must not raise AASConstraintViolation
+        ns.set1[0] = new
+        self.assertEqual([new], list(ns.set1))
+        self.assertIsNone(old.parent)
+        self.assertIs(ns, new.parent)
+
 
 class ExternalReferenceTest(unittest.TestCase):
     def test_constraints(self):


### PR DESCRIPTION
Fixes #498
Fixes #494

## Changes

### `__setitem__` int (index replacement)
- Remove old item from backends **before** adding new item — prevents false `AASConstraintViolation` when new item shares an attribute (e.g. `id_short`) with the item being replaced
- Rollback: re-adds old item if the subsequent `add` fails

### `__setitem__` slice
- Replace `self._order[s] = new_items` with `self._order[s] = successful_new_items` — `new_items` is an exhausted `islice` iterator; assigning it back to the list slice wrote an empty sequence, silently discarding all new items

### Tests
- `test_ordered_namespaceset_int_setitem_preserves_index`: builds `[p0, old, p2]`, replaces index 1 with `new` (same `id_short`), asserts result is `[p0, new, p2]` — no index shift, no `AASConstraintViolation`
- `test_ordered_namespaceset_slice_setitem_preserves_order`: replaces a 2-item slice, verifies new items appear at correct positions