### PR TITLE
Fix registry log output

### DIFF
--- a/server/docker/registry/uwsgi.ini
+++ b/server/docker/registry/uwsgi.ini
@@ -7,4 +7,3 @@ hook-master-start = unix_signal:15 gracefully_kill_them_all
 need-app = true
 die-on-term = true
 show-config = false
-logto = /tmp/uwsgi.log


### PR DESCRIPTION
Previously, the registry uwsgi.ini wrote uWSGI logs to a file inside the container, so registry requests were not visible in the terminal output like the repository and discovery logs.

This made it look as if the registry was not receiving requests.

This change aligns the registry logging behavior with the other services so registry requests are shown consistently in the terminal.