### PR TITLE
fix(server): return 400 on malformed assetIds query parameter (#502)

### DIFF
--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -255,9 +255,17 @@ class WSGIApp(ObjectStoreWSGIApp):
 
             for asset_id in asset_ids:
                 asset_id_json = base64url_decode(asset_id)
-                asset_dict = json.loads(asset_id_json)
-                name = asset_dict["name"]
-                value = asset_dict["value"]
+                try:
+                    asset_dict = json.loads(asset_id_json)
+                except json.JSONDecodeError as e:
+                    raise BadRequest(f"Invalid assetIds query parameter: {e}") from e
+                if not isinstance(asset_dict, dict):
+                    raise BadRequest("Invalid assetIds query parameter: expected a JSON object.")
+                try:
+                    name = asset_dict["name"]
+                    value = asset_dict["value"]
+                except KeyError as e:
+                    raise BadRequest(f"Invalid assetIds query parameter: missing field {e}") from e
 
                 if name == "specificAssetId":
                     decoded_specific_id = HTTPApiDecoder.json_list(value, model.SpecificAssetId,


### PR DESCRIPTION
Fixes #502.

The `_get_shells` handler base64url-decoded each `assetIds` query parameter, JSON-parsed it, then directly indexed `asset_dict["name"]` and `asset_dict["value"]`. A client-supplied payload missing either key (or a non-object JSON value, or invalid JSON) propagated as an unhandled exception, producing a 500 Internal Server Error.

Wrap the JSON parse and the field lookups so client-side validation failures return `BadRequest` (400) with a clear message, matching the rest of the handler's error model.