### PR TITLE
Always include paging_metadata in paginated list responses

### DIFF
--- a/server/app/interfaces/base.py
+++ b/server/app/interfaces/base.py
@@ -240,11 +240,7 @@ class BaseWSGIApp:
         paginated_slice = iter(items[:limit])
         next_cursor = str(cursor + limit + 1) if has_more else None
 
-        if next_cursor is not None or cursor > 0:
-            # add metadata if cursor was present in request
-            paging_metadata = PagingMetadata(cursor=next_cursor)
-        else:
-            paging_metadata = None
+        paging_metadata = PagingMetadata(cursor=next_cursor)
         return paginated_slice, paging_metadata
 
     def handle_request(self, request: Request):


### PR DESCRIPTION
## Summary

- Fix: paginated list endpoints now always return `GetPagedResult` wrapper (`{"result": [...], "paging_metadata": {...}}`)
- Previous behavior: wrapper was omitted when all results fit on first page, returning a plain array
- AAS Part 2 API spec requires the wrapper on every list response: https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1.2/http-rest-api/http-rest-api.html#pagination
