### PR TITLE
fix: pass paging_metadata kwarg correctly in get_aas_submodel_refs and get_concept_description_all

### DIFF
--- a/server/app/interfaces/discovery.py
+++ b/server/app/interfaces/discovery.py
@@ -161,7 +161,7 @@ class DiscoveryAPI(BaseWSGIApp):
             matching_aas_keys.update(aas_keys)
 
         paginated_slice, cursor = self._get_slice(request, list(matching_aas_keys))
-        return response_t(list(paginated_slice), cursor=cursor)
+        return response_t(list(paginated_slice), paging_metadata=cursor)
 
     def search_all_aas_ids_by_asset_link(
         self, request: Request, url_args: dict, response_t: Type[APIResponse], **_kwargs
@@ -172,7 +172,7 @@ class DiscoveryAPI(BaseWSGIApp):
             aas_keys = self.persistent_store.search_aas_ids_by_asset_link(asset_link)
             matching_aas_keys.update(aas_keys)
         paginated_slice, cursor = self._get_slice(request, list(matching_aas_keys))
-        return response_t(list(paginated_slice), cursor=cursor)
+        return response_t(list(paginated_slice), paging_metadata=cursor)
 
     def get_all_specific_asset_ids_by_aas_id(
         self, request: Request, url_args: dict, response_t: Type[APIResponse], **_kwargs

--- a/server/app/interfaces/discovery.py
+++ b/server/app/interfaces/discovery.py
@@ -191,13 +191,8 @@ class DiscoveryAPI(BaseWSGIApp):
             aas_keys = self.persistent_store.search_aas_ids_by_asset_link(asset_link)
             matching_aas_keys.update(aas_keys)
 
-<<<<<<< fix/submodel-refs-concept-desc-paging-metadata
-        paginated_slice, cursor = self._get_slice(request, list(matching_aas_keys))
-        return response_t(list(paginated_slice), paging_metadata=cursor)
-=======
         paginated_slice, paging_metadata = self._get_slice(request, list(matching_aas_keys))
         return response_t(list(paginated_slice), paging_metadata=paging_metadata)
->>>>>>> develop
 
     def search_all_aas_ids_by_asset_link(
         self, request: Request, url_args: dict, response_t: Type[APIResponse], **_kwargs
@@ -207,13 +202,8 @@ class DiscoveryAPI(BaseWSGIApp):
         for asset_link in asset_links:
             aas_keys = self.persistent_store.search_aas_ids_by_asset_link(asset_link)
             matching_aas_keys.update(aas_keys)
-<<<<<<< fix/submodel-refs-concept-desc-paging-metadata
-        paginated_slice, cursor = self._get_slice(request, list(matching_aas_keys))
-        return response_t(list(paginated_slice), paging_metadata=cursor)
-=======
         paginated_slice, paging_metadata = self._get_slice(request, list(matching_aas_keys))
         return response_t(list(paginated_slice), paging_metadata=paging_metadata)
->>>>>>> develop
 
     def get_all_specific_asset_ids_by_aas_id(
         self, request: Request, url_args: dict, response_t: Type[APIResponse], **_kwargs

--- a/server/app/interfaces/registry.py
+++ b/server/app/interfaces/registry.py
@@ -225,7 +225,7 @@ class RegistryAPI(ObjectStoreWSGIApp):
     ) -> Response:
         aas_descriptor = self._get_aas_descriptor(url_args)
         submodel_descriptors, cursor = self._get_slice(request, aas_descriptor.submodel_descriptors)
-        return response_t(list(submodel_descriptors), cursor=cursor)
+        return response_t(list(submodel_descriptors), paging_metadata=cursor)
 
     def get_submodel_descriptor_by_id_through_superpath(
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs

--- a/server/app/interfaces/registry.py
+++ b/server/app/interfaces/registry.py
@@ -224,8 +224,8 @@ class RegistryAPI(ObjectStoreWSGIApp):
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs
     ) -> Response:
         aas_descriptor = self._get_aas_descriptor(url_args)
-        submodel_descriptors, cursor = self._get_slice(request, aas_descriptor.submodel_descriptors)
-        return response_t(list(submodel_descriptors), paging_metadata=cursor)
+        submodel_descriptors, paging_metadata = self._get_slice(request, aas_descriptor.submodel_descriptors)
+        return response_t(list(submodel_descriptors), paging_metadata=paging_metadata)
 
     def get_submodel_descriptor_by_id_through_superpath(
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -589,7 +589,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         submodel_refs: Iterator[model.ModelReference[model.Submodel]]
         sorted_submodel_refs = sorted(aas.submodel, key=lambda ref: ref.key[0].value)
         submodel_refs, cursor = self._get_slice(request, sorted_submodel_refs)
-        return response_t(list(submodel_refs), cursor=cursor)
+        return response_t(list(submodel_refs), paging_metadata=cursor)
 
     def post_aas_submodel_refs(self, request: Request, url_args: Dict, response_t: Type[APIResponse],
                                map_adapter: MapAdapter, **_kwargs) -> Response:
@@ -948,7 +948,7 @@ class WSGIApp(ObjectStoreWSGIApp):
     ) -> Response:
         concept_descriptions: Iterator[model.ConceptDescription] = self._get_all_obj_of_type(model.ConceptDescription)
         concept_descriptions, cursor = self._get_slice(request, concept_descriptions)
-        return response_t(list(concept_descriptions), cursor=cursor, stripped=is_stripped_request(request))
+        return response_t(list(concept_descriptions), paging_metadata=cursor, stripped=is_stripped_request(request))
 
     def post_concept_description(
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], map_adapter: MapAdapter

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -948,7 +948,8 @@ class WSGIApp(ObjectStoreWSGIApp):
     ) -> Response:
         concept_descriptions: Iterator[model.ConceptDescription] = self._get_all_obj_of_type(model.ConceptDescription)
         concept_descriptions, paging_metadata = self._get_slice(request, concept_descriptions)
-        return response_t(list(concept_descriptions), paging_metadata=paging_metadata, stripped=is_stripped_request(request))
+        return response_t(list(concept_descriptions), paging_metadata=paging_metadata,
+                          stripped=is_stripped_request(request))
 
     def post_concept_description(
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], map_adapter: MapAdapter

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -588,8 +588,8 @@ class WSGIApp(ObjectStoreWSGIApp):
         aas = self._get_shell(url_args)
         submodel_refs: Iterator[model.ModelReference[model.Submodel]]
         sorted_submodel_refs = sorted(aas.submodel, key=lambda ref: ref.key[0].value)
-        submodel_refs, cursor = self._get_slice(request, sorted_submodel_refs)
-        return response_t(list(submodel_refs), paging_metadata=cursor)
+        submodel_refs, paging_metadata = self._get_slice(request, sorted_submodel_refs)
+        return response_t(list(submodel_refs), paging_metadata=paging_metadata)
 
     def post_aas_submodel_refs(self, request: Request, url_args: Dict, response_t: Type[APIResponse],
                                map_adapter: MapAdapter, **_kwargs) -> Response:
@@ -947,8 +947,8 @@ class WSGIApp(ObjectStoreWSGIApp):
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs
     ) -> Response:
         concept_descriptions: Iterator[model.ConceptDescription] = self._get_all_obj_of_type(model.ConceptDescription)
-        concept_descriptions, cursor = self._get_slice(request, concept_descriptions)
-        return response_t(list(concept_descriptions), paging_metadata=cursor, stripped=is_stripped_request(request))
+        concept_descriptions, paging_metadata = self._get_slice(request, concept_descriptions)
+        return response_t(list(concept_descriptions), paging_metadata=paging_metadata, stripped=is_stripped_request(request))
 
     def post_concept_description(
         self, request: Request, url_args: Dict, response_t: Type[APIResponse], map_adapter: MapAdapter


### PR DESCRIPTION
## Summary

Fixes 5 handler methods across 3 files that called `response_t(..., cursor=cursor)`, but `APIResponse.__init__` takes `paging_metadata: Optional[PagingMetadata]`, not `cursor`. All affected endpoints returned 502 Bad Gateway due to the resulting `TypeError`.

## Affected handlers

| File | Handler |
|---|---|
| `repository.py` | `get_aas_submodel_refs` |
| `repository.py` | `get_concept_description_all` |
| `discovery.py` | `get_all_aas_ids_by_asset_link` |
| `discovery.py` | `search_all_aas_ids_by_asset_link` |
| `registry.py` | `get_all_submodel_descriptors_through_superpath` |

Closes #539