### PR TITLE
fix: align ServiceSpecificationProfileEnum with IDTA-01002 v3.1.2 spec

### DIFF
--- a/server/app/model/service_specification.py
+++ b/server/app/model/service_specification.py
@@ -5,8 +5,11 @@ import enum
 class ServiceSpecificationProfileEnum(str, enum.Enum):
     """
     Enumeration of all standardized Service Specification Profiles
-    from the AAS Part 2 API Specification (IDTA-01002-3-1).
+    from the AAS Part 2 API Specification (IDTA-01002-3-1-2).
     Each profile is uniquely identified by its semantic URI.
+
+    Reference: https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1.2/
+               http-rest-api/service-specifications-and-profiles.html
     """
 
     # --- Asset Administration Shell (AAS) ---
@@ -15,8 +18,8 @@ class ServiceSpecificationProfileEnum(str, enum.Enum):
 
     # --- Submodel ---
     SUBMODEL_FULL = "https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-001"
-    SUBMODEL_VALUE = "https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-002"
-    SUBMODEL_READ = "https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-003"
+    SUBMODEL_READ = "https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-002"
+    SUBMODEL_VALUE = "https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-003"
 
     # --- AASX File Server ---
     AASX_FILESERVER_FULL = "https://admin-shell.io/aas/API/3/1/AasxFileServerServiceSpecification/SSP-001"
@@ -28,32 +31,40 @@ class ServiceSpecificationProfileEnum(str, enum.Enum):
         "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRegistryServiceSpecification/SSP-002"
     AAS_REGISTRY_BULK = \
         "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRegistryServiceSpecification/SSP-003"
+    AAS_REGISTRY_QUERY = \
+        "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRegistryServiceSpecification/SSP-004"
+    AAS_REGISTRY_MINIMAL_READ = \
+        "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRegistryServiceSpecification/SSP-005"
 
     # --- Submodel Registry ---
     SUBMODEL_REGISTRY_FULL = "https://admin-shell.io/aas/API/3/1/SubmodelRegistryServiceSpecification/SSP-001"
     SUBMODEL_REGISTRY_READ = "https://admin-shell.io/aas/API/3/1/SubmodelRegistryServiceSpecification/SSP-002"
     SUBMODEL_REGISTRY_BULK = "https://admin-shell.io/aas/API/3/1/SubmodelRegistryServiceSpecification/SSP-003"
+    SUBMODEL_REGISTRY_QUERY = "https://admin-shell.io/aas/API/3/1/SubmodelRegistryServiceSpecification/SSP-004"
 
     # --- AAS Repository ---
     AAS_REPOSITORY_FULL = \
         "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRepositoryServiceSpecification/SSP-001"
     AAS_REPOSITORY_READ = \
         "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRepositoryServiceSpecification/SSP-002"
-    AAS_REPOSITORY_BULK = \
+    AAS_REPOSITORY_QUERY = \
         "https://admin-shell.io/aas/API/3/1/AssetAdministrationShellRepositoryServiceSpecification/SSP-003"
 
     # --- Submodel Repository ---
     SUBMODEL_REPOSITORY_FULL = "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-001"
     SUBMODEL_REPOSITORY_READ = "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-002"
-    SUBMODEL_REPOSITORY_BULK = "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-003"
+    SUBMODEL_REPOSITORY_TEMPLATE = \
+        "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-003"
+    SUBMODEL_REPOSITORY_TEMPLATE_READ = \
+        "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-004"
+    SUBMODEL_REPOSITORY_QUERY = \
+        "https://admin-shell.io/aas/API/3/1/SubmodelRepositoryServiceSpecification/SSP-005"
 
     # --- Concept Description Repository ---
     CONCEPT_DESCRIPTION_REPOSITORY_FULL = \
         "https://admin-shell.io/aas/API/3/1/ConceptDescriptionRepositoryServiceSpecification/SSP-001"
-    CONCEPT_DESCRIPTION_REPOSITORY_READ = \
+    CONCEPT_DESCRIPTION_REPOSITORY_QUERY = \
         "https://admin-shell.io/aas/API/3/1/ConceptDescriptionRepositoryServiceSpecification/SSP-002"
-    CONCEPT_DESCRIPTION_REPOSITORY_BULK = \
-        "https://admin-shell.io/aas/API/3/1/ConceptDescriptionRepositoryServiceSpecification/SSP-003"
 
     # --- Discovery ---
     DISCOVERY_FULL = "https://admin-shell.io/aas/API/3/1/DiscoveryServiceSpecification/SSP-001"


### PR DESCRIPTION
## Summary

Corrects `ServiceSpecificationProfileEnum` to match the IDTA-01002 v3.1.2 specification exactly.

Reference: https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1.2/http-rest-api/service-specifications-and-profiles.html

## Bugs fixed (wrong name↔SSP mapping)

| Old name | SSP | Correct name |
|---|---|---|
| `SUBMODEL_VALUE` | SSP-002 | `SUBMODEL_READ` |
| `SUBMODEL_READ` | SSP-003 | `SUBMODEL_VALUE` |
| `AAS_REPOSITORY_BULK` | SSP-003 | `AAS_REPOSITORY_QUERY` (no Bulk profile exists for AAS Repository) |
| `SUBMODEL_REPOSITORY_BULK` | SSP-003 | `SUBMODEL_REPOSITORY_TEMPLATE` |
| `CONCEPT_DESCRIPTION_REPOSITORY_READ` | SSP-002 | `CONCEPT_DESCRIPTION_REPOSITORY_QUERY` |

## Removed (does not exist in spec)

- `CONCEPT_DESCRIPTION_REPOSITORY_BULK` — Concept Description Repository has no SSP-003

## Added (missing from spec)

| Name | SSP | Service |
|---|---|---|
| `AAS_REGISTRY_QUERY` | SSP-004 | AAS Registry |
| `AAS_REGISTRY_MINIMAL_READ` | SSP-005 | AAS Registry |
| `SUBMODEL_REGISTRY_QUERY` | SSP-004 | Submodel Registry |
| `SUBMODEL_REPOSITORY_TEMPLATE_READ` | SSP-004 | Submodel Repository |
| `SUBMODEL_REPOSITORY_QUERY` | SSP-005 | Submodel Repository |

## Breaking changes

Renames existing enum members. Any code referencing `SUBMODEL_VALUE`, `SUBMODEL_READ`, `AAS_REPOSITORY_BULK`, `SUBMODEL_REPOSITORY_BULK`, `CONCEPT_DESCRIPTION_REPOSITORY_READ`, or `CONCEPT_DESCRIPTION_REPOSITORY_BULK` by name will need updating. No usages of the renamed/removed members were found in this repository.