### PR TITLE
Fix load_directory silently dropping all descriptors

### DIFF
--- a/server/app/adapter/jsonization.py
+++ b/server/app/adapter/jsonization.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Callable, Dict, Optional, Set, Type
+from typing import Callable, Dict, Type
 
 from basyx.aas import model
-from basyx.aas.adapter._generic import ASSET_KIND, ASSET_KIND_INVERSE, JSON_AAS_TOP_LEVEL_KEYS_TO_TYPES, PathOrIO
+from basyx.aas.adapter._generic import ASSET_KIND, ASSET_KIND_INVERSE, JSON_AAS_TOP_LEVEL_KEYS_TO_TYPES
 from basyx.aas.adapter.json import AASToJsonEncoder
-from basyx.aas.adapter.json.json_deserialization import AASFromJsonDecoder, _get_ts, read_aas_json_file_into
+from basyx.aas.adapter.json.json_deserialization import AASFromJsonDecoder, _get_ts
 
 import app.model as server_model
 
@@ -205,27 +205,6 @@ class ServerStrictStrippedAASFromJsonDecoder(ServerStrictAASFromJsonDecoder, Ser
     """
 
     pass
-
-
-def read_server_aas_json_file_into(
-    object_store: model.AbstractObjectStore,
-    file: PathOrIO,
-    replace_existing: bool = False,
-    ignore_existing: bool = False,
-    failsafe: bool = True,
-    stripped: bool = False,
-    decoder: Optional[Type[AASFromJsonDecoder]] = None,
-) -> Set[model.Identifier]:
-    return read_aas_json_file_into(
-        object_store=object_store,
-        file=file,
-        replace_existing=replace_existing,
-        ignore_existing=ignore_existing,
-        failsafe=failsafe,
-        stripped=stripped,
-        decoder=decoder,
-        keys_to_types=JSON_SERVER_AAS_TOP_LEVEL_KEYS_TO_TYPES,
-    )
 
 
 class ServerAASToJsonEncoder(AASToJsonEncoder):

--- a/server/app/model/provider.py
+++ b/server/app/model/provider.py
@@ -51,12 +51,6 @@ class DictDescriptorStore(sdk_provider.AbstractObjectStore[model.Identifier, _DE
         return iter(self._backend.values())
 
 
-_DESCRIPTOR_KEY_TO_CLS = (
-    ("assetAdministrationShellDescriptors", descriptor.AssetAdministrationShellDescriptor),
-    ("submodelDescriptors", descriptor.SubmodelDescriptor),
-)
-
-
 def load_directory(directory: Union[Path, str]) -> DictDescriptorStore:
     """
     Load AAS/Submodel descriptor JSON files from a directory into a :class:`DictDescriptorStore`.
@@ -74,12 +68,17 @@ def load_directory(directory: Union[Path, str]) -> DictDescriptorStore:
             continue
         with open(file) as f:
             data = json.load(f, cls=ServerAASFromJsonDecoder)
-        for key, cls in _DESCRIPTOR_KEY_TO_CLS:
-            for item in data.get(key, []):
-                if isinstance(item, cls):
-                    try:
-                        store.add(item)
-                    except KeyError:
-                        pass
+        for item in data.get("assetAdministrationShellDescriptors", []):
+            if isinstance(item, descriptor.AssetAdministrationShellDescriptor):
+                try:
+                    store.add(item)
+                except KeyError:
+                    pass
+        for item in data.get("submodelDescriptors", []):
+            if isinstance(item, descriptor.SubmodelDescriptor):
+                try:
+                    store.add(item)
+                except KeyError:
+                    pass
 
     return store

--- a/server/app/model/provider.py
+++ b/server/app/model/provider.py
@@ -1,10 +1,10 @@
+import json
 from pathlib import Path
 from typing import IO, Dict, Iterable, Iterator, Union
 
 from basyx.aas import model
 from basyx.aas.model import provider as sdk_provider
 
-import app.adapter as adapter
 from app.model import descriptor
 
 PathOrIO = Union[Path, IO]
@@ -51,29 +51,35 @@ class DictDescriptorStore(sdk_provider.AbstractObjectStore[model.Identifier, _DE
         return iter(self._backend.values())
 
 
+_DESCRIPTOR_KEY_TO_CLS = (
+    ("assetAdministrationShellDescriptors", descriptor.AssetAdministrationShellDescriptor),
+    ("submodelDescriptors", descriptor.SubmodelDescriptor),
+)
+
+
 def load_directory(directory: Union[Path, str]) -> DictDescriptorStore:
     """
-    Create a new :class:`~basyx.aas.model.provider.DictIdentifiableStore` and use it to load Asset Administration Shell
-    and Submodel files in ``AASX``, ``JSON`` and ``XML`` format from a given directory into memory. Additionally, load
-    all embedded supplementary files into a new :class:`~basyx.aas.adapter.aasx.DictSupplementaryFileContainer`.
+    Load AAS/Submodel descriptor JSON files from a directory into a :class:`DictDescriptorStore`.
 
-    :param directory: :class:`~pathlib.Path` or ``str`` pointing to the directory containing all Asset Administration
-        Shell and Submodel files to load
-    :return: Tuple consisting of a :class:`~basyx.aas.model.provider.DictIdentifiableStore` and a
-        :class:`~basyx.aas.adapter.aasx.DictSupplementaryFileContainer` containing all loaded data
+    :param directory: Path to the directory containing JSON descriptor files
+    :return: Populated :class:`DictDescriptorStore`
     """
+    from app.adapter import ServerAASFromJsonDecoder
 
-    dict_descriptor_store: DictDescriptorStore = DictDescriptorStore()
-
+    store = DictDescriptorStore()
     directory = Path(directory)
 
     for file in directory.iterdir():
-        if not file.is_file():
+        if not file.is_file() or file.suffix.lower() != ".json":
             continue
+        with open(file) as f:
+            data = json.load(f, cls=ServerAASFromJsonDecoder)
+        for key, cls in _DESCRIPTOR_KEY_TO_CLS:
+            for item in data.get(key, []):
+                if isinstance(item, cls):
+                    try:
+                        store.add(item)
+                    except KeyError:
+                        pass
 
-        suffix = file.suffix.lower()
-        if suffix == ".json":
-            with open(file) as f:
-                adapter.read_server_aas_json_file_into(dict_descriptor_store, f)
-
-    return dict_descriptor_store
+    return store

--- a/server/app/model/provider.py
+++ b/server/app/model/provider.py
@@ -5,6 +5,7 @@ from typing import IO, Dict, Iterable, Iterator, Union
 from basyx.aas import model
 from basyx.aas.model import provider as sdk_provider
 
+from app.adapter import ServerAASFromJsonDecoder
 from app.model import descriptor
 
 PathOrIO = Union[Path, IO]
@@ -58,8 +59,6 @@ def load_directory(directory: Union[Path, str]) -> DictDescriptorStore:
     :param directory: Path to the directory containing JSON descriptor files
     :return: Populated :class:`DictDescriptorStore`
     """
-    from app.adapter import ServerAASFromJsonDecoder
-
     store = DictDescriptorStore()
     directory = Path(directory)
 


### PR DESCRIPTION
Fixes #544

## Problem

`load_directory()` called `read_server_aas_json_file_into()`, which internally only adds items where `isinstance(item, model.Identifiable)`. `AssetAdministrationShellDescriptor` and `SubmodelDescriptor` are not `Identifiable`, so all descriptors were silently skipped. The registry always started empty.

## Fix

Parse descriptor JSON directly with `ServerAASFromJsonDecoder` and add items to `DictDescriptorStore` via an `isinstance(item, Descriptor)` check.