### PR TITLE
fix: remove erroneous len guard that broke multi globalAssetId filtering

### DIFF
--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -270,8 +270,7 @@ class WSGIApp(ObjectStoreWSGIApp):
             aas = filter(lambda shell: (
                     (not specific_asset_ids or all(specific_asset_id in shell.asset_information.specific_asset_id
                                                    for specific_asset_id in specific_asset_ids)) and
-                    (len(global_asset_ids) <= 1 and
-                        (not global_asset_ids or shell.asset_information.global_asset_id in global_asset_ids))
+                    (not global_asset_ids or shell.asset_information.global_asset_id in global_asset_ids)
             ), aas)
 
         paginated_aas, end_index = self._get_slice(request, aas)


### PR DESCRIPTION
## Summary

Fixes a bug where `GET /shells?assetIds` with 2+ `globalAssetId` query parameters silently returns an empty `200` response instead of correctly filtered results.

## Root Cause

In `server/app/interfaces/repository.py:273`, the lambda filter had a guard condition `len(global_asset_ids) <= 1` that short-circuits the entire AND clause to `False` when 2+ `globalAssetId` parameters are provided. This causes every shell to be rejected before the `in` membership check can execute.

## Solution

Remove the `len(global_asset_ids) <= 1` guard. The `in` operator already handles zero, one, or many IDs correctly — matching the same pattern used for `specific_asset_ids` filtering on lines 271-272.

### Before
```python
(len(global_asset_ids) <= 1 and
    (not global_asset_ids or shell.asset_information.global_asset_id in global_asset_ids))
```

### After
```python
(not global_asset_ids or shell.asset_information.global_asset_id in global_asset_ids)
```

## Testing

- Verified logic: 0 IDs → all pass; 1 ID → filters correctly; 2+ IDs → now filters correctly (was broken)
- Behavior is now consistent with the adjacent `specific_asset_ids` filtering pattern

Fixes #500