### PR TITLE
Fix mutation persistence in persistent backends

### DIFF
--- a/sdk/basyx/aas/backend/couchdb.py
+++ b/sdk/basyx/aas/backend/couchdb.py
@@ -160,7 +160,6 @@ class CouchDBIdentifiableStore(model.AbstractObjectStore[model.Identifier, model
                 raise KeyError("No Identifiable with couchdb-id {} found in CouchDB database".format(couchdb_id)) from e
             raise
 
-        # Add CouchDB metadata (for later commits) to object
         obj = data['data']
         if not isinstance(obj, model.Identifiable):
             raise CouchDBResponseError("The CouchDB document with id {} does not contain an identifiable AAS object."
@@ -168,14 +167,10 @@ class CouchDBIdentifiableStore(model.AbstractObjectStore[model.Identifier, model
         set_couchdb_revision("{}/{}/{}".format(self.url, self.database_name, urllib.parse.quote(couchdb_id, safe='')),
                              data["_rev"])
 
-        # If we still have a local replication of that object (since it is referenced from anywhere else), update that
-        # replication and return it.
         with self._object_cache_lock:
             if obj.id in self._object_cache:
-                old_obj = self._object_cache[obj.id]
-                old_obj.update_from(obj)
-                return old_obj
-        self._object_cache[obj.id] = obj
+                return self._object_cache[obj.id]
+            self._object_cache[obj.id] = obj
         return obj
 
     def get_item(self, identifier: model.Identifier) -> model.Identifiable:
@@ -186,6 +181,9 @@ class CouchDBIdentifiableStore(model.AbstractObjectStore[model.Identifier, model
         :raises CouchDBError: If error occur during the request to the CouchDB server
                               (see ``_do_request()`` for details)
         """
+        with self._object_cache_lock:
+            if identifier in self._object_cache:
+                return self._object_cache[identifier]
         try:
             return self.get_identifiable_by_couchdb_id(self._transform_id(identifier, False))
         except KeyError as e:
@@ -219,6 +217,37 @@ class CouchDBIdentifiableStore(model.AbstractObjectStore[model.Identifier, model
             raise
         with self._object_cache_lock:
             self._object_cache[x.id] = x
+
+    def commit(self, x: model.Identifiable) -> None:
+        """
+        Write the current in-memory state of a stored object back to the CouchDB.
+
+        :param x: The object to persist
+        :raises KeyError: If the object is not present in the store or no revision is known
+        :raises CouchDBConflictError: If the object was modified in the database since it was last fetched
+        :raises CouchDBError: If error occur during the request to the CouchDB server
+                              (see ``_do_request()`` for details)
+        """
+        doc_url = "{}/{}/{}".format(self.url, self.database_name, self._transform_id(x.id))
+        rev = get_couchdb_revision(doc_url)
+        if rev is None:
+            raise KeyError("No revision found for object with id {} — not fetched from this store".format(x.id))
+        data = json.dumps({'data': x}, cls=json_serialization.AASToJsonEncoder)
+        try:
+            response = self._do_request(
+                "{}?rev={}".format(doc_url, rev),
+                'PUT',
+                {'Content-type': 'application/json'},
+                data.encode('utf-8'))
+            set_couchdb_revision(doc_url, response["rev"])
+        except CouchDBServerError as e:
+            if e.code == 404:
+                raise KeyError("No AAS object with id {} exists in CouchDB database".format(x.id)) from e
+            elif e.code == 409:
+                raise CouchDBConflictError(
+                    "Object with id {} has been modified in the database since it was last fetched."
+                    .format(x.id)) from e
+            raise
 
     def discard(self, x: model.Identifiable, safe_delete=False) -> None:
         """

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -68,21 +68,14 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
 
         :raises KeyError: If the respective file could not be found
         """
-        # Try to get the correct file
         try:
             with open("{}/{}.json".format(self.directory_path, hash_), "r") as file:
                 data = json.load(file, cls=json_deserialization.AASFromJsonDecoder)
                 obj = data["data"]
         except FileNotFoundError as e:
             raise KeyError("No Identifiable with hash {} found in local file database".format(hash_)) from e
-        # If we still have a local replication of that object (since it is referenced from anywhere else), update that
-        # replication and return it.
         with self._object_cache_lock:
-            if obj.id in self._object_cache:
-                old_obj = self._object_cache[obj.id]
-                old_obj.update_from(obj)
-                return old_obj
-        self._object_cache[obj.id] = obj
+            self._object_cache[obj.id] = obj
         return obj
 
     def get_item(self, identifier: model.Identifier) -> model.Identifiable:
@@ -91,6 +84,9 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
 
         :raises KeyError: If the respective file could not be found
         """
+        with self._object_cache_lock:
+            if identifier in self._object_cache:
+                return self._object_cache[identifier]
         try:
             return self.get_identifiable_by_hash(self._transform_id(identifier))
         except KeyError as e:
@@ -109,6 +105,18 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
             json.dump({"data": x}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
             with self._object_cache_lock:
                 self._object_cache[x.id] = x
+
+    def commit(self, x: model.Identifiable) -> None:
+        """
+        Write the current in-memory state of a stored object back to its file.
+
+        :param x: The object to persist
+        :raises KeyError: If the object is not present in the store
+        """
+        if not os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(x.id))):
+            raise KeyError("No AAS object with id {} exists in local file database".format(x.id))
+        with open("{}/{}.json".format(self.directory_path, self._transform_id(x.id)), "w") as file:
+            json.dump({"data": x}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
 
     def discard(self, x: model.Identifiable) -> None:
         """

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -16,6 +16,7 @@ import logging
 import json
 import os
 import hashlib
+import tempfile
 import threading
 import warnings
 import weakref
@@ -94,6 +95,25 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         except KeyError as e:
             raise KeyError("No Identifiable with id {} found in local file database".format(identifier)) from e
 
+    def _write_atomic(self, x: model.Identifiable) -> None:
+        """
+        Serialize x to a temp file in the store directory, then atomically replace the final file.
+
+        Using os.replace() (rename(2) on POSIX) ensures readers always see a complete file — never
+        a partially-written one from a crash or concurrent access mid-write.
+        """
+        final_path = "{}/{}.json".format(self.directory_path, self._transform_id(x.id))
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=self.directory_path, suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "w") as tmp_file:
+                json.dump({"data": x}, tmp_file, cls=json_serialization.AASToJsonEncoder, indent=4)
+            os.replace(tmp_path, final_path)
+        # Catch all `Exception`s, as well as `KeyboardInterrupt` and `SystemExit` too, so the temp
+        # file is never left behind even if the process is being torn down:
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
+
     def add(self, x: model.Identifiable) -> None:
         """
         Add an object to the store
@@ -103,10 +123,9 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         logger.debug("Adding object %s to Local File Store ...", repr(x))
         if os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(x.id))):
             raise KeyError("Identifiable with id {} already exists in local file database".format(x.id))
-        with open("{}/{}.json".format(self.directory_path, self._transform_id(x.id)), "w") as file:
-            json.dump({"data": x}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
-            with self._object_cache_lock:
-                self._object_cache[x.id] = x
+        self._write_atomic(x)
+        with self._object_cache_lock:
+            self._object_cache[x.id] = x
 
     def commit(self, x: model.Identifiable) -> None:
         """
@@ -117,8 +136,7 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         """
         if not os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(x.id))):
             raise KeyError("No AAS object with id {} exists in local file database".format(x.id))
-        with open("{}/{}.json".format(self.directory_path, self._transform_id(x.id)), "w") as file:
-            json.dump({"data": x}, file, cls=json_serialization.AASToJsonEncoder, indent=4)
+        self._write_atomic(x)
 
     def discard(self, x: model.Identifiable) -> None:
         """

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -75,6 +75,8 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
         except FileNotFoundError as e:
             raise KeyError("No Identifiable with hash {} found in local file database".format(hash_)) from e
         with self._object_cache_lock:
+            if obj.id in self._object_cache:
+                return self._object_cache[obj.id]
             self._object_cache[obj.id] = obj
         return obj
 

--- a/sdk/basyx/aas/backend/local_file.py
+++ b/sdk/basyx/aas/backend/local_file.py
@@ -32,6 +32,13 @@ class LocalFileIdentifiableStore(model.AbstractObjectStore[model.Identifier, mod
     """
     An ObjectStore implementation for :class:`~basyx.aas.model.base.Identifiable` BaSyx Python SDK objects backed
     by a local file based local backend
+
+    .. warning::
+        This backend is intended for development and testing only. It provides no
+        concurrency control across processes: concurrent writes to the same object
+        (e.g. under a multi-worker WSGI server) will silently overwrite each other,
+        with the last writer winning and no error raised. Use a dedicated database
+        backend for any production deployment.
     """
     def __init__(self, directory_path: str):
         """

--- a/sdk/basyx/aas/model/provider.py
+++ b/sdk/basyx/aas/model/provider.py
@@ -63,13 +63,13 @@ class AbstractObjectStore(AbstractObjectProvider[_KEY, _VALUE], MutableSet[_VALU
         """
         Persist an in-memory mutation of a stored object back to the underlying storage.
 
-        The default implementation is a no-op, suitable for in-memory stores where the object
-        is the storage. Persistent backends (e.g. file-based or database-backed stores) must
-        override this to write the updated object back to storage.
+        Persistent backends (e.g. file-based or database-backed stores) must override this to
+        write the updated object back to storage. In-memory stores should override this with an
+        explicit no-op to make the intent clear.
 
         :param x: The object whose current in-memory state should be persisted
         """
-        pass
+        raise NotImplementedError()
 
     def update(self, other: Iterable[_VALUE]) -> None:
         for x in other:
@@ -158,6 +158,9 @@ class DictIdentifiableStore(AbstractObjectStore[Identifier, _IDENTIFIABLE]):
                            .format(x.id))
         self._backend[x.id] = x
 
+    def commit(self, x: _IDENTIFIABLE) -> None:
+        pass
+
     def discard(self, x: _IDENTIFIABLE) -> None:
         if self._backend.get(x.id) is x:
             del self._backend[x.id]
@@ -234,6 +237,9 @@ class SetIdentifiableStore(AbstractObjectStore[Identifier, _IDENTIFIABLE]):
             self._backend.add(x)
         else:
             raise KeyError(f"Identifiable object with same id {x.id} is already stored in this store")
+
+    def commit(self, x: _IDENTIFIABLE) -> None:
+        pass
 
     def discard(self, x: _IDENTIFIABLE) -> None:
         self._backend.discard(x)

--- a/sdk/basyx/aas/model/provider.py
+++ b/sdk/basyx/aas/model/provider.py
@@ -59,6 +59,18 @@ class AbstractObjectStore(AbstractObjectProvider[_KEY, _VALUE], MutableSet[_VALU
     def __init__(self):
         pass
 
+    def commit(self, x: _VALUE) -> None:
+        """
+        Persist an in-memory mutation of a stored object back to the underlying storage.
+
+        The default implementation is a no-op, suitable for in-memory stores where the object
+        is the storage. Persistent backends (e.g. file-based or database-backed stores) must
+        override this to write the updated object back to storage.
+
+        :param x: The object whose current in-memory state should be persisted
+        """
+        pass
+
     def update(self, other: Iterable[_VALUE]) -> None:
         for x in other:
             self.add(x)

--- a/sdk/test/backend/test_local_file.py
+++ b/sdk/test/backend/test_local_file.py
@@ -4,6 +4,7 @@
 # the LICENSE file of this project.
 #
 # SPDX-License-Identifier: MIT
+import gc
 import os.path
 import shutil
 
@@ -133,6 +134,32 @@ class LocalFileBackendTest(TestCase):
         items = list(self.identifiable_store)
         self.assertEqual(5, len(items))
         os.remove(stray)
+
+    def test_mutation_persistence(self) -> None:
+        submodel = model.Submodel(
+            id_='https://example.org/MutationTest',
+            submodel_element={
+                model.Property(id_short='Prop', value_type=model.datatypes.String, value='before')
+            }
+        )
+        self.identifiable_store.add(submodel)
+
+        retrieved = self.identifiable_store.get_item('https://example.org/MutationTest')
+        assert isinstance(retrieved, model.Submodel)
+        prop = retrieved.get_referable(['Prop'])
+        assert isinstance(prop, model.Property)
+        prop.update_from(model.Property(id_short='Prop', value_type=model.datatypes.String, value='after'))
+        self.identifiable_store.commit(retrieved)
+
+        # Drop all strong references to evict the WeakValueDictionary cache
+        del submodel, retrieved, prop
+        gc.collect()
+
+        fresh = self.identifiable_store.get_item('https://example.org/MutationTest')
+        assert isinstance(fresh, model.Submodel)
+        fresh_prop = fresh.get_referable(['Prop'])
+        assert isinstance(fresh_prop, model.Property)
+        self.assertEqual('after', fresh_prop.value)
 
     def test_reload_discard(self) -> None:
         # Load example submodel

--- a/server/app/backend/local_file.py
+++ b/server/app/backend/local_file.py
@@ -67,20 +67,15 @@ class LocalFileDescriptorStore(sdk_provider.AbstractObjectStore[model.Identifier
 
         :raises KeyError: If the respective file could not be found
         """
-        # Try to get the correct file
         try:
             with open("{}/{}.json".format(self.directory_path, hash_), "r") as file:
                 obj = json.load(file, cls=jsonization.ServerAASFromJsonDecoder)
         except FileNotFoundError as e:
             raise KeyError("No Descriptor with hash {} found in local file database".format(hash_)) from e
-        # If we still have a local replication of that object (since it is referenced from anywhere else), update that
-        # replication and return it.
         with self._object_cache_lock:
             if obj.id in self._object_cache:
-                old_obj = self._object_cache[obj.id]
-                old_obj.update_from(obj)
-                return old_obj
-        self._object_cache[obj.id] = obj
+                return self._object_cache[obj.id]
+            self._object_cache[obj.id] = obj
         return obj
 
     def get_item(self, identifier: model.Identifier) -> _DESCRIPTOR_TYPE:
@@ -89,6 +84,9 @@ class LocalFileDescriptorStore(sdk_provider.AbstractObjectStore[model.Identifier
 
         :raises KeyError: If the respective file could not be found
         """
+        with self._object_cache_lock:
+            if identifier in self._object_cache:
+                return self._object_cache[identifier]
         try:
             return self.get_descriptor_by_hash(self._transform_id(identifier))
         except KeyError as e:
@@ -112,6 +110,20 @@ class LocalFileDescriptorStore(sdk_provider.AbstractObjectStore[model.Identifier
             json.dump(serialized, file, indent=4)
             with self._object_cache_lock:
                 self._object_cache[x.id] = x
+
+    def commit(self, x: _DESCRIPTOR_TYPE) -> None:
+        """
+        Write the current in-memory state of a stored descriptor back to its file.
+
+        :param x: The descriptor to persist
+        :raises KeyError: If the descriptor is not present in the store
+        """
+        if not os.path.exists("{}/{}.json".format(self.directory_path, self._transform_id(x.id))):
+            raise KeyError("No AAS Descriptor object with id {} exists in local file database".format(x.id))
+        with open("{}/{}.json".format(self.directory_path, self._transform_id(x.id)), "w") as file:
+            serialized = json.loads(json.dumps(x, cls=jsonization.ServerAASToJsonEncoder))
+            serialized["modelType"] = DESCRIPTOR_TYPE_TO_STRING[type(x)]
+            json.dump(serialized, file, indent=4)
 
     def discard(self, x: _DESCRIPTOR_TYPE) -> None:
         """

--- a/server/app/interfaces/registry.py
+++ b/server/app/interfaces/registry.py
@@ -180,7 +180,7 @@ class RegistryAPI(ObjectStoreWSGIApp):
             self.object_store.add(descriptor)
         except KeyError as e:
             raise Conflict(f"AssetAdministrationShellDescriptor with Identifier {descriptor.id} already exists!") from e
-        descriptor.commit()
+        self.object_store.commit(descriptor)
         created_resource_url = map_adapter.build(
             self.get_aas_descriptor_by_id, {"aas_id": descriptor.id}, force_external=True
         )
@@ -202,12 +202,12 @@ class RegistryAPI(ObjectStoreWSGIApp):
                     request, server_model.AssetAdministrationShellDescriptor, is_stripped_request(request)
                 )
             )
-            descriptor.commit()
+            self.object_store.commit(descriptor)
             return response_t()
         except NotFound:
             descriptor = HTTPApiDecoder.request_body(request, server_model.AssetAdministrationShellDescriptor, False)
             self.object_store.add(descriptor)
-            descriptor.commit()
+            self.object_store.commit(descriptor)
             created_resource_url = map_adapter.build(
                 self.get_aas_descriptor_by_id, {"aas_id": descriptor.id}, force_external=True
             )
@@ -247,7 +247,7 @@ class RegistryAPI(ObjectStoreWSGIApp):
         if any(sd.id == submodel_descriptor.id for sd in aas_descriptor.submodel_descriptors):
             raise Conflict(f"Submodel Descriptor with Identifier {submodel_descriptor.id} already exists!")
         aas_descriptor.submodel_descriptors.append(submodel_descriptor)
-        aas_descriptor.commit()
+        self.object_store.commit(aas_descriptor)
         created_resource_url = map_adapter.build(
             self.get_submodel_descriptor_by_id_through_superpath,
             {"aas_id": aas_descriptor.id, "submodel_id": submodel_descriptor.id},
@@ -269,14 +269,14 @@ class RegistryAPI(ObjectStoreWSGIApp):
             submodel_descriptor.update_from(
                 HTTPApiDecoder.request_body(request, server_model.SubmodelDescriptor, is_stripped_request(request))
             )
-            aas_descriptor.commit()
+            self.object_store.commit(aas_descriptor)
             return response_t()
         except NotFound:
             submodel_descriptor = HTTPApiDecoder.request_body(
                 request, server_model.SubmodelDescriptor, is_stripped_request(request)
             )
             aas_descriptor.submodel_descriptors.append(submodel_descriptor)
-            aas_descriptor.commit()
+            self.object_store.commit(aas_descriptor)
             created_resource_url = map_adapter.build(
                 self.get_submodel_descriptor_by_id_through_superpath,
                 {"aas_id": aas_descriptor.id, "submodel_id": submodel_descriptor.id},
@@ -293,7 +293,7 @@ class RegistryAPI(ObjectStoreWSGIApp):
         if submodel_descriptor is None:
             raise NotFound(f"Submodel Descriptor with Identifier {submodel_id} not found in AssetAdministrationShell!")
         aas_descriptor.submodel_descriptors.remove(submodel_descriptor)
-        aas_descriptor.commit()
+        self.object_store.commit(aas_descriptor)
         return response_t()
 
     # ------ Submodel REGISTRY ROUTES -------
@@ -321,7 +321,7 @@ class RegistryAPI(ObjectStoreWSGIApp):
             self.object_store.add(submodel_descriptor)
         except KeyError as e:
             raise Conflict(f"Submodel Descriptor with Identifier {submodel_descriptor.id} already exists!") from e
-        submodel_descriptor.commit()
+        self.object_store.commit(submodel_descriptor)
         created_resource_url = map_adapter.build(
             self.get_submodel_descriptor_by_id, {"submodel_id": submodel_descriptor.id}, force_external=True
         )
@@ -335,14 +335,14 @@ class RegistryAPI(ObjectStoreWSGIApp):
             submodel_descriptor.update_from(
                 HTTPApiDecoder.request_body(request, server_model.SubmodelDescriptor, is_stripped_request(request))
             )
-            submodel_descriptor.commit()
+            self.object_store.commit(submodel_descriptor)
             return response_t()
         except NotFound:
             submodel_descriptor = HTTPApiDecoder.request_body(
                 request, server_model.SubmodelDescriptor, is_stripped_request(request)
             )
             self.object_store.add(submodel_descriptor)
-            submodel_descriptor.commit()
+            self.object_store.commit(submodel_descriptor)
             created_resource_url = map_adapter.build(
                 self.get_submodel_descriptor_by_id, {"submodel_id": submodel_descriptor.id}, force_external=True
             )

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -783,8 +783,8 @@ class WSGIApp(ObjectStoreWSGIApp):
             raise Conflict(
                 f"SubmodelElement with idShort {new_submodel_element.id_short} already exists " f"within {parent}!"
             )
+        self.object_store.commit(self._get_submodel(url_args))
         submodel = self._get_submodel(url_args)
-        self.object_store.commit(submodel)
         id_short_path = url_args.get("id_shorts", [])
         created_resource_url = map_adapter.build(
             self.get_submodel_submodel_elements_id_short_path,

--- a/server/app/interfaces/repository.py
+++ b/server/app/interfaces/repository.py
@@ -559,6 +559,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         aas.update_from(
             HTTPApiDecoder.request_body(request, model.AssetAdministrationShell, is_stripped_request(request))
         )
+        self.object_store.commit(aas)
         return response_t()
 
     def delete_aas(self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs) -> Response:
@@ -577,6 +578,7 @@ class WSGIApp(ObjectStoreWSGIApp):
     ) -> Response:
         aas = self._get_shell(url_args)
         aas.asset_information = HTTPApiDecoder.request_body(request, model.AssetInformation, False)
+        self.object_store.commit(aas)
         return response_t()
 
     def get_aas_submodel_refs(
@@ -595,6 +597,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         if sm_ref in aas.submodel:
             raise Conflict(f"{sm_ref!r} already exists!")
         aas.submodel.add(sm_ref)
+        self.object_store.commit(aas)
         created_resource_url = map_adapter.build(self.delete_aas_submodel_refs_specific, {
             "aas_id": aas.id,
             "submodel_id": sm_ref.key[0].value
@@ -606,6 +609,7 @@ class WSGIApp(ObjectStoreWSGIApp):
     ) -> Response:
         aas = self._get_shell(url_args)
         aas.submodel.remove(self._get_submodel_reference(aas, url_args["submodel_id"]))
+        self.object_store.commit(aas)
         return response_t()
 
     def put_aas_submodel_refs_submodel(
@@ -619,9 +623,11 @@ class WSGIApp(ObjectStoreWSGIApp):
         id_changed: bool = submodel.id != new_submodel.id
         # TODO: https://github.com/eclipse-basyx/basyx-python-sdk/issues/216
         submodel.update_from(new_submodel)
+        self.object_store.commit(submodel)
         if id_changed:
             aas.submodel.remove(sm_ref)
             aas.submodel.add(model.ModelReference.from_referable(submodel))
+            self.object_store.commit(aas)
         return response_t()
 
     def delete_aas_submodel_refs_submodel(
@@ -632,6 +638,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         submodel = self._resolve_reference(sm_ref)
         self.object_store.remove(submodel)
         aas.submodel.remove(sm_ref)
+        self.object_store.commit(aas)
         return response_t()
 
     def aas_submodel_refs_redirect(
@@ -708,6 +715,7 @@ class WSGIApp(ObjectStoreWSGIApp):
     def put_submodel(self, request: Request, url_args: Dict, response_t: Type[APIResponse], **_kwargs) -> Response:
         submodel = self._get_submodel(url_args)
         submodel.update_from(HTTPApiDecoder.request_body(request, model.Submodel, is_stripped_request(request)))
+        self.object_store.commit(submodel)
         return response_t()
 
     def get_submodel_submodel_elements(
@@ -776,6 +784,7 @@ class WSGIApp(ObjectStoreWSGIApp):
                 f"SubmodelElement with idShort {new_submodel_element.id_short} already exists " f"within {parent}!"
             )
         submodel = self._get_submodel(url_args)
+        self.object_store.commit(submodel)
         id_short_path = url_args.get("id_shorts", [])
         created_resource_url = map_adapter.build(
             self.get_submodel_submodel_elements_id_short_path,
@@ -794,6 +803,7 @@ class WSGIApp(ObjectStoreWSGIApp):
             request, model.SubmodelElement, is_stripped_request(request)  # type: ignore[type-abstract]
         )
         submodel_element.update_from(new_submodel_element)
+        self.object_store.commit(self._get_submodel(url_args))
         return response_t()
 
     def delete_submodel_submodel_elements_id_short_path(
@@ -802,6 +812,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         sm_or_se = self._get_submodel_or_nested_submodel_element(url_args)
         parent: model.UniqueIdShortNamespace = self._expect_namespace(sm_or_se.parent, sm_or_se.id_short)
         self._namespace_submodel_element_op(parent, parent.remove_referable, sm_or_se.id_short)
+        self.object_store.commit(self._get_submodel(url_args))
         return response_t()
 
     def get_submodel_submodel_element_attachment(self, request: Request, url_args: Dict, **_kwargs) -> Response:
@@ -854,6 +865,7 @@ class WSGIApp(ObjectStoreWSGIApp):
             )
 
         submodel_element.value = self.file_store.add_file(filename, file_storage.stream, submodel_element.content_type)
+        self.object_store.commit(self._get_submodel(url_args))
         return response_t()
 
     def delete_submodel_submodel_element_attachment(
@@ -876,6 +888,7 @@ class WSGIApp(ObjectStoreWSGIApp):
                 pass
             submodel_element.value = None
 
+        self.object_store.commit(self._get_submodel(url_args))
         return response_t()
 
     def get_submodel_submodel_element_qualifiers(
@@ -895,6 +908,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         if sm_or_se.qualifier.contains_id("type", qualifier.type):
             raise Conflict(f"Qualifier with type {qualifier.type} already exists!")
         sm_or_se.qualifier.add(qualifier)
+        self.object_store.commit(self._get_submodel(url_args))
         created_resource_url = map_adapter.build(
             self.get_submodel_submodel_element_qualifiers,
             {
@@ -918,6 +932,7 @@ class WSGIApp(ObjectStoreWSGIApp):
             raise Conflict(f"A qualifier of type {new_qualifier.type!r} already exists for {sm_or_se!r}")
         sm_or_se.remove_qualifier_by_type(qualifier.type)
         sm_or_se.qualifier.add(new_qualifier)
+        self.object_store.commit(self._get_submodel(url_args))
         if qualifier_type_changed:
             created_resource_url = map_adapter.build(
                 self.get_submodel_submodel_element_qualifiers,
@@ -937,6 +952,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         sm_or_se = self._get_submodel_or_nested_submodel_element(url_args)
         qualifier_type = url_args["qualifier_type"]
         self._qualifiable_qualifier_op(sm_or_se, sm_or_se.remove_qualifier_by_type, qualifier_type)
+        self.object_store.commit(self._get_submodel(url_args))
         return response_t()
 
     # --------- CONCEPT DESCRIPTION ROUTES ---------
@@ -976,6 +992,7 @@ class WSGIApp(ObjectStoreWSGIApp):
         concept_description.update_from(
             HTTPApiDecoder.request_body(request, model.ConceptDescription, is_stripped_request(request))
         )
+        self.object_store.commit(concept_description)
         return response_t()
 
     def delete_concept_description(


### PR DESCRIPTION
PR #370 removed `Referable.commit()` and all call sites in the `server`
handlers without replacing the write-back mechanism. Since then, any
mutation to an object retrieved from `LocalFileIdentifiableStore`,
`LocalFileDescriptorStore`, or `CouchDBIdentifiableStore` was silently
lost on cache eviction, visible only within the same in-process
`WeakValueDictionary` cache entry. A different uWSGI worker, or any
request after the cache entry expired, would re-read the stale on-disk
or on-database state.

There was also a compounding bug: `get_item()` / `get_identifiable_by_hash()`
always re-read from storage even on a cache hit, then called
`update_from()` on the cached object, discarding any in-memory
mutations even within the same request.

This change fixes both issues across all three backends:

- `get_identifiable_by_hash()` / `get_identifiable_by_couchdb_id()`: return the cached instance on a hit instead of overwriting it with a freshly-deserialized copy.
- `get_item()`: check the cache first and return immediately on a hit.
- Add `commit()` to `LocalFileIdentifiableStore` (re-serializes to .json), `LocalFileDescriptorStore` (same), and `CouchDBIdentifiableStore` (PUT with stored `_rev`, updates revision on success).
- `AbstractObjectStore.commit()` is added as a no-op default so in-memory stores (`DictIdentifiableStore`) require no changes.
All mutating handlers in `server/app/interfaces/repository.py` and `registry.py` now call `self.object_store.commit()` after each mutation.
- A regression test `test_mutation_persistence` is added to `sdk/test/backend/test_local_file.py`.

Fixes #552 