### PR TITLE
CI: Build docker images for all services and archs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  TARGET_PLATFORM: "linux/amd64,linux/arm/v7,linux/arm64"
+
 jobs:
   sdk-publish:
     # This job publishes the package to PyPI
@@ -59,7 +62,7 @@ jobs:
         with:
           password: ${{ secrets.PYPI_ORG_TOKEN }}
 
-  server-publish:
+  server-repository-publish:
     # This job publishes the server docker image to DockerHub
     runs-on: ubuntu-latest
     defaults:
@@ -73,14 +76,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: eclipsebasyx/basyx-python-server
+          images: eclipsebasyx/basyx-python-repository
           # This fetches the latest git tag and adds an additional "latest" to it, so e.g. `2.1.0,latest`
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
           labels: |
-            org.opencontainers.image.title=BaSyx Python Server
-            org.opencontainers.image.description=Eclipse BaSyx Python SDK - HTTP Server
+            org.opencontainers.image.title=BaSyx Python Repository Service
+            org.opencontainers.image.description=Eclipse BaSyx Python SDK - Repository HTTP Server
             org.opencontainers.image.source=https://github.com/eclipse-basyx/basyx-python-sdk/tree/main/server
             org.opencontainers.image.licenses=MIT
 
@@ -90,11 +93,112 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and Push Docker Image
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and Push Repository Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./server/Dockerfile  # Todo: Update paths
+          file: ./server/docker/repository/Dockerfile
+          platforms: ${{ env.TARGET_PLATFORM }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  server-discovery-publish:
+    # This job publishes the server docker image to DockerHub
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./server
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Extract Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: eclipsebasyx/basyx-python-discovery
+          # This fetches the latest git tag and adds an additional "latest" to it, so e.g. `2.1.0,latest`
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=BaSyx Python Discovery Service
+            org.opencontainers.image.description=Eclipse BaSyx Python SDK - Discovery HTTP Server
+            org.opencontainers.image.source=https://github.com/eclipse-basyx/basyx-python-sdk/tree/main/server
+            org.opencontainers.image.licenses=MIT
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and Push Repository Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/docker/discovery/Dockerfile
+          platforms: ${{ env.TARGET_PLATFORM }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  server-registry-publish:
+    # This job publishes the server docker image to DockerHub
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./server
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Extract Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: eclipsebasyx/basyx-python-registry
+          # This fetches the latest git tag and adds an additional "latest" to it, so e.g. `2.1.0,latest`
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=BaSyx Python Registry Service
+            org.opencontainers.image.description=Eclipse BaSyx Python SDK - Registry HTTP Server
+            org.opencontainers.image.source=https://github.com/eclipse-basyx/basyx-python-sdk/tree/main/server
+            org.opencontainers.image.licenses=MIT
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and Push Repository Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/docker/registry/Dockerfile
+          platforms: ${{ env.TARGET_PLATFORM }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
After refactoring the server package, the CI for building and publishing the `Docker` image to Dockerhub did not longer work, as the `Dockerfile` paths changed. Additionally the registry and discovery services were not published.

These changes fix the build in the release CI for the repository service and add the missing ones. Builds are now executed using QEMU emulation to support building armv7 and arm64 in order to create a multi-platform image.

The following image names are used:
 - Repository Service -> `eclipsebasyx/basyx-python-repository`
 - Discovery Service -> `eclipsebasyx/basyx-python-discovery`
 - Registry Service -> `eclipsebasyx/basyx-python-registry`

Fix #555