### PR TITLE
SDK: Add tutorial_navigate_aas.py to Unit Tests

### DIFF
--- a/sdk/test/examples/test_tutorials.py
+++ b/sdk/test/examples/test_tutorials.py
@@ -46,7 +46,10 @@ class TutorialTest(unittest.TestCase):
             from basyx.aas.examples import tutorial_aasx
             pass
         # The tutorial already includes assert statements for the relevant points. So no further checks are required.
-
+        
+    def test_tutorial_navigate_aas(self):
+        from basyx.aas.examples import tutorial_navigate_aas
+        # The tutorial already includes assert statements for the relevant points. So no further checks are required
 
 @contextmanager
 def temporary_workingdirectory():

--- a/sdk/test/examples/test_tutorials.py
+++ b/sdk/test/examples/test_tutorials.py
@@ -46,10 +46,11 @@ class TutorialTest(unittest.TestCase):
             from basyx.aas.examples import tutorial_aasx
             pass
         # The tutorial already includes assert statements for the relevant points. So no further checks are required.
-        
+
     def test_tutorial_navigate_aas(self):
         from basyx.aas.examples import tutorial_navigate_aas
         # The tutorial already includes assert statements for the relevant points. So no further checks are required
+
 
 @contextmanager
 def temporary_workingdirectory():


### PR DESCRIPTION
Previously, tutorial_navigate_aas.py was not covered by Unit Tests.

Unit Test is added.