### PR TITLE
Extend ObjectStore tests to both implementations

### DIFF
--- a/sdk/test/model/test_provider.py
+++ b/sdk/test/model/test_provider.py
@@ -11,6 +11,8 @@ from basyx.aas import model
 
 
 class ProvidersTest(unittest.TestCase):
+    _STORE_CLASSES = (model.DictIdentifiableStore, model.SetIdentifiableStore)
+
     def setUp(self) -> None:
         self.aas1 = model.AssetAdministrationShell(
             model.AssetInformation(global_asset_id="http://example.org/TestAsset1/"), "urn:x-test:aas1")
@@ -20,58 +22,76 @@ class ProvidersTest(unittest.TestCase):
         self.submodel2 = model.Submodel("urn:x-test:submodel2")
 
     def test_store_retrieve(self) -> None:
-        identifiable_store: model.DictIdentifiableStore[model.AssetAdministrationShell] = model.DictIdentifiableStore()
-        identifiable_store.add(self.aas1)
-        identifiable_store.add(self.aas2)
-        self.assertIn(self.aas1, identifiable_store)
-        property = model.Property('test', model.datatypes.String)
-        self.assertFalse(property in identifiable_store)
-        aas3 = model.AssetAdministrationShell(model.AssetInformation(global_asset_id="http://example.org/TestAsset/"),
-                                              "urn:x-test:aas1")
-        with self.assertRaises(KeyError) as cm:
-            identifiable_store.add(aas3)
-        self.assertEqual("'Identifiable object with same id urn:x-test:aas1 is already "
-                         "stored in this store'", str(cm.exception))
-        self.assertEqual(2, len(identifiable_store))
-        self.assertIs(self.aas1,
-                      identifiable_store.get_item("urn:x-test:aas1"))
-        self.assertIs(self.aas1,
-                      identifiable_store.get("urn:x-test:aas1"))
-        identifiable_store.discard(self.aas1)
-        identifiable_store.discard(self.aas1)
-        with self.assertRaises(KeyError) as cm:
-            identifiable_store.get_item("urn:x-test:aas1")
-        self.assertIsNone(identifiable_store.get("urn:x-test:aas1"))
-        self.assertEqual("'urn:x-test:aas1'", str(cm.exception))
-        self.assertIs(self.aas2, identifiable_store.pop())
-        self.assertEqual(0, len(identifiable_store))
+        for store_class in self._STORE_CLASSES:
+            with self.subTest(store=store_class.__name__):
+                store = store_class([self.aas1])
+                store.add(self.aas2)
+
+                store.add(self.aas1)
+                self.assertEqual(2, len(store))
+
+                self.assertIn(self.aas1, store)
+                self.assertIn("urn:x-test:aas1", store)
+                self.assertNotIn("urn:x-test:missing", store)
+                property = model.Property('test', model.datatypes.String)
+                self.assertFalse(property in store)
+                aas3 = model.AssetAdministrationShell(
+                    model.AssetInformation(global_asset_id="http://example.org/TestAsset/"), "urn:x-test:aas1")
+                with self.assertRaises(KeyError) as cm:
+                    store.add(aas3)
+                self.assertEqual("'Identifiable object with same id urn:x-test:aas1 is already "
+                                 "stored in this store'", str(cm.exception))
+                self.assertEqual(2, len(store))
+                self.assertIs(self.aas1, store.get_item("urn:x-test:aas1"))
+                self.assertIs(self.aas1, store.get("urn:x-test:aas1"))
+                store.discard(self.aas1)
+                store.discard(self.aas1)
+                with self.assertRaises(KeyError) as cm:
+                    store.get_item("urn:x-test:aas1")
+                self.assertIsNone(store.get("urn:x-test:aas1"))
+                self.assertEqual("'urn:x-test:aas1'", str(cm.exception))
+                self.assertIs(self.aas2, store.pop())
+                self.assertEqual(0, len(store))
 
     def test_store_update(self) -> None:
-        identifiable_store1: model.DictIdentifiableStore[model.AssetAdministrationShell] = model.DictIdentifiableStore()
-        identifiable_store1.add(self.aas1)
-        identifiable_store2: model.DictIdentifiableStore[model.AssetAdministrationShell] = model.DictIdentifiableStore()
-        identifiable_store2.add(self.aas2)
-        identifiable_store1.update(identifiable_store2)
-        self.assertIsInstance(identifiable_store1, model.DictIdentifiableStore)
-        self.assertIn(self.aas2, identifiable_store1)
+        for store_class in self._STORE_CLASSES:
+            with self.subTest(store=store_class.__name__):
+                store1 = store_class()
+                store1.add(self.aas1)
+                store2 = store_class()
+                store2.add(self.aas2)
+                store1.update(store2)
+                self.assertIsInstance(store1, store_class)
+                self.assertIn(self.aas2, store1)
 
     def test_store_sync(self) -> None:
-        aas_identifiable_store: model.DictIdentifiableStore[model.Identifiable] = model.DictIdentifiableStore()
+        for store_class in self._STORE_CLASSES:
+            with self.subTest(store=store_class.__name__):
+                store = store_class()
+                self.assertEqual(store.sync([self.aas1, self.aas2], overwrite=False), (2, 0, 0))
+                self.assertIn(self.aas1, store)
+                self.assertIn(self.aas2, store)
 
-        self.assertEqual(aas_identifiable_store.sync([self.aas1, self.aas2], overwrite=False), (2, 0, 0))
-        self.assertIn(self.aas1, aas_identifiable_store)
-        self.assertIn(self.aas2, aas_identifiable_store)
+                self.assertEqual(store.sync([self.aas1], overwrite=False), (0, 0, 1))
 
-        self.assertEqual(aas_identifiable_store.sync([self.aas1], overwrite=False), (0, 0, 1))
+                self.assertEqual(store.sync([self.aas1], overwrite=True), (0, 1, 0))
+                self.assertIn(self.aas1, store)
 
-        self.assertEqual(aas_identifiable_store.sync([self.aas1], overwrite=True), (0, 1, 0))
-        self.assertIn(self.aas1, aas_identifiable_store)
+                self.assertEqual(store.sync([self.aas1, self.submodel1], overwrite=True), (1, 1, 0))
 
-        self.assertEqual(aas_identifiable_store.sync([self.aas1, self.submodel1], overwrite=True), (1, 1, 0))
+                self.assertEqual(store.sync([self.aas1, self.submodel2], overwrite=False), (1, 0, 1))
 
-        self.assertEqual(aas_identifiable_store.sync([self.aas1, self.submodel2], overwrite=False), (1, 0, 1))
+                self.assertEqual(store.sync([], overwrite=False), (0, 0, 0))
 
-        self.assertEqual(aas_identifiable_store.sync([], overwrite=False), (0, 0, 0))
+    def test_store_remove(self) -> None:
+        for store_class in self._STORE_CLASSES:
+            with self.subTest(store=store_class.__name__):
+                store = store_class()
+                store.add(self.aas1)
+                store.remove(self.aas1)
+                self.assertEqual(0, len(store))
+                with self.assertRaises(KeyError):
+                    store.remove(self.aas1)
 
     def test_provider_multiplexer(self) -> None:
         aas_identifiable_store: model.DictIdentifiableStore[model.Identifiable] = (

--- a/sdk/test/model/test_provider.py
+++ b/sdk/test/model/test_provider.py
@@ -24,7 +24,7 @@ class ProvidersTest(unittest.TestCase):
     def test_store_retrieve(self) -> None:
         for store_class in self._STORE_CLASSES:
             with self.subTest(store=store_class.__name__):
-                store = store_class([self.aas1])
+                store: model.AbstractObjectStore[model.Identifier, model.Identifiable] = store_class([self.aas1])
                 store.add(self.aas2)
 
                 store.add(self.aas1)
@@ -56,9 +56,9 @@ class ProvidersTest(unittest.TestCase):
     def test_store_update(self) -> None:
         for store_class in self._STORE_CLASSES:
             with self.subTest(store=store_class.__name__):
-                store1 = store_class()
+                store1: model.AbstractObjectStore[model.Identifier, model.Identifiable] = store_class()
                 store1.add(self.aas1)
-                store2 = store_class()
+                store2: model.AbstractObjectStore[model.Identifier, model.Identifiable] = store_class()
                 store2.add(self.aas2)
                 store1.update(store2)
                 self.assertIsInstance(store1, store_class)
@@ -67,7 +67,7 @@ class ProvidersTest(unittest.TestCase):
     def test_store_sync(self) -> None:
         for store_class in self._STORE_CLASSES:
             with self.subTest(store=store_class.__name__):
-                store = store_class()
+                store: model.AbstractObjectStore[model.Identifier, model.Identifiable] = store_class()
                 self.assertEqual(store.sync([self.aas1, self.aas2], overwrite=False), (2, 0, 0))
                 self.assertIn(self.aas1, store)
                 self.assertIn(self.aas2, store)
@@ -86,7 +86,7 @@ class ProvidersTest(unittest.TestCase):
     def test_store_remove(self) -> None:
         for store_class in self._STORE_CLASSES:
             with self.subTest(store=store_class.__name__):
-                store = store_class()
+                store: model.AbstractObjectStore[model.Identifier, model.Identifiable] = store_class()
                 store.add(self.aas1)
                 store.remove(self.aas1)
                 self.assertEqual(0, len(store))


### PR DESCRIPTION
Previously, only the `DictIdentifiableStore` was tested in the unittests.

This extends the unittests by adding a `_STORE_CLASSES` class variable 
and consolidates duplicated test methods into `subTest` loops, covering 
both `Dict` and `Set` store implementations.

Before:
`basyx/aas/model/provider.py                            119     37     32      0    68%   34, 60, 174-180, [...]`

After:
`basyx/aas/model/provider.py                                      125     11     32      0    93%   34, 60, 72, [...]`