### PR TITLE
adapter: Allow optional contentType in Blob and File

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -692,8 +692,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_blob(cls, dct: Dict[str, object], object_class=model.Blob) -> model.Blob:
+        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
         ret = object_class(id_short=None,
-                           content_type=_get_ts(dct, "contentType", str))
+                           content_type=content_type)
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct:
             ret.value = base64.b64decode(_get_ts(dct, 'value', str))
@@ -701,9 +702,10 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_file(cls, dct: Dict[str, object], object_class=model.File) -> model.File:
+        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
         ret = object_class(id_short=None,
                            value=None,
-                           content_type=_get_ts(dct, "contentType", str))
+                           content_type=content_type)
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct and dct['value'] is not None:
             ret.value = _get_ts(dct, 'value', str)

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -691,10 +691,12 @@ class AASFromJsonDecoder(json.JSONDecoder):
         return ret
 
     @classmethod
+    @classmethod
     def _construct_blob(cls, dct: Dict[str, object], object_class=model.Blob) -> model.Blob:
-        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
-        ret = object_class(id_short=None,
-                           content_type=content_type)
+        ret = object_class(
+            id_short=None,
+            content_type=_get_ts(dct, "contentType", str) if 'contentType' in dct else None
+        )
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct:
             ret.value = base64.b64decode(_get_ts(dct, 'value', str))
@@ -702,10 +704,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_file(cls, dct: Dict[str, object], object_class=model.File) -> model.File:
-        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
         ret = object_class(id_short=None,
                            value=None,
-                           content_type=content_type)
+                           content_type=_get_ts(dct, "contentType", str) if 'contentType' in dct else None)
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct and dct['value'] is not None:
             ret.value = _get_ts(dct, 'value', str)

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -804,7 +804,7 @@ class AASFromXmlDecoder:
     def construct_blob(cls, element: etree._Element, object_class=model.Blob, **_kwargs: Any) -> model.Blob:
         blob = object_class(
             None,
-            _child_text_mandatory(element, NS_AAS + "contentType")
+            _get_text_or_none(element.find(NS_AAS + "contentType"))
         )
         value = _get_text_or_none(element.find(NS_AAS + "value"))
         if value is not None:
@@ -851,7 +851,7 @@ class AASFromXmlDecoder:
     def construct_file(cls, element: etree._Element, object_class=model.File, **_kwargs: Any) -> model.File:
         file = object_class(
             None,
-            _child_text_mandatory(element, NS_AAS + "contentType")
+            _get_text_or_none(element.find(NS_AAS + "contentType"))
         )
         value = _get_text_or_none(element.find(NS_AAS + "value"))
         if value is not None:


### PR DESCRIPTION
Currently, the JSON and XMOL deserializiers raise an error when parsing Blob or File submodels that do not include a contentType

The contentType attribute has a cardinality of 0..1 for both classes and should therefore be optional. The implementation now aligns with this specification and defaults to None if the field is absent in the data.

Fixes #561