### PR TITLE
model.base: Fix MultiLanguageNameType value length to 128

### DIFF
--- a/sdk/basyx/aas/model/_string_constraints.py
+++ b/sdk/basyx/aas/model/_string_constraints.py
@@ -21,7 +21,6 @@ The following types aliased in the :mod:`~basyx.aas.model.base` module are const
 - :class:`~basyx.aas.model.base.NameType`
 - :class:`~basyx.aas.model.base.PathType`
 - :class:`~basyx.aas.model.base.RevisionType`
-- :class:`~basyx.aas.model.base.ShortNameType`
 - :class:`~basyx.aas.model.base.QualifierType`
 - :class:`~basyx.aas.model.base.VersionType`
 - :class:`~basyx.aas.model.base.ValueTypeIEC61360`
@@ -95,10 +94,6 @@ def check_revision_type(value: str, type_name: str = "RevisionType") -> None:
     return check(value, type_name, 1, 4, re.compile(r"([0-9]|[1-9][0-9]*)"))
 
 
-def check_short_name_type(value: str, type_name: str = "ShortNameType") -> None:
-    return check(value, type_name, 1, 64)
-
-
 def check_value_type_iec61360(value: str, type_name: str = "ValueTypeIEC61360") -> None:
     return check(value, type_name, 1, 2048)
 
@@ -116,7 +111,7 @@ def create_check_function(min_length: int = 0, max_length: Optional[int] = None,
     This is the type-independent alternative to :func:`~.check_content_type`, :func:`~.check_identifier`, etc. It is
     used for the definition of the :class:`ConstrainedLangStringSets <basyx.aas.model.base.ConstrainedLangStringSet>`,
     as a "Basic" constrained string type only exists for :class:`~basyx.aas.model.base.MultiLanguageNameType`, where all
-    values are :class:`ShortNames <basyx.aas.model.base.ShortNameType>`. All other
+    values are :class:`NameTypes <basyx.aas.model.base.NameType>`. All other
     :class:`:class:`ConstrainedLangStringSets <basyx.aas.model.base.ConstrainedLangStringSet>` use custom constraints.
     """
     def check_fn(value: str, type_name: str) -> None:
@@ -175,10 +170,6 @@ def constrain_qualifier_type(pub_attr_name: str) -> Callable[[Type[_T]], Type[_T
 
 def constrain_revision_type(pub_attr_name: str) -> Callable[[Type[_T]], Type[_T]]:
     return constrain_attr(pub_attr_name, check_revision_type)
-
-
-def constrain_short_name_type(pub_attr_name: str) -> Callable[[Type[_T]], Type[_T]]:
-    return constrain_attr(pub_attr_name, check_short_name_type)
 
 
 def constrain_version_type(pub_attr_name: str) -> Callable[[Type[_T]], Type[_T]]:

--- a/sdk/basyx/aas/model/_string_constraints.py
+++ b/sdk/basyx/aas/model/_string_constraints.py
@@ -105,14 +105,12 @@ def check_version_type(value: str, type_name: str = "VersionType") -> None:
 def create_check_function(min_length: int = 0, max_length: Optional[int] = None, pattern: Optional[re.Pattern] = None) \
         -> Callable[[str, str], None]:
     """
-    Returns a new ``check_type`` function with mandatory ``type_name`` for the given min_length, max_length and pattern
-    constraints.
+     Returns a ``check_type`` function for the given constraints.
 
-    This is the type-independent alternative to :func:`~.check_content_type`, :func:`~.check_identifier`, etc. It is
-    used for the definition of the :class:`ConstrainedLangStringSets <basyx.aas.model.base.ConstrainedLangStringSet>`,
-    as a "Basic" constrained string type only exists for :class:`~basyx.aas.model.base.MultiLanguageNameType`, where all
-    values are :class:`NameTypes <basyx.aas.model.base.NameType>`. All other
-    :class:`:class:`ConstrainedLangStringSets <basyx.aas.model.base.ConstrainedLangStringSet>` use custom constraints.
+    Use this instead of the named :func:`~.check_content_type`, :func:`~.check_identifier`, etc. when the
+    constraints do not correspond to a predefined constrained string type — for example, in
+    :class:`ConstrainedLangStringSets <basyx.aas.model.base.ConstrainedLangStringSet>` that define their own
+    length and pattern rules.
     """
     def check_fn(value: str, type_name: str) -> None:
         return check(value, type_name, min_length, max_length, pattern)

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -383,11 +383,11 @@ class ConstrainedLangStringSet(LangStringSet, metaclass=abc.ABCMeta):
 
 class MultiLanguageNameType(ConstrainedLangStringSet):
     """
-    A :class:`~.ConstrainedLangStringSet` where each value is a :class:`ShortNameType`.
-    See also: :func:`basyx.aas.model._string_constraints.check_short_name_type`
+    A :class:`~.ConstrainedLangStringSet` where each value is a :class:`NameType`.
+    See also: :func:`basyx.aas.model._string_constraints.check_name_type`
     """
     def __init__(self, dict_: Dict[str, str]):
-        super().__init__(dict_, _string_constraints.check_short_name_type)
+        super().__init__(dict_, _string_constraints.check_name_type)
 
 
 class MultiLanguageTextType(ConstrainedLangStringSet):

--- a/sdk/test/model/test_base.py
+++ b/sdk/test/model/test_base.py
@@ -1286,15 +1286,15 @@ class LangStringSetTest(unittest.TestCase):
 
     def test_text_constraints(self) -> None:
         with self.assertRaises(ValueError) as cm:
-            model.MultiLanguageNameType({"fo": "o" * 65})
+            model.MultiLanguageNameType({"fo": "o" * 129})
         self.assertEqual("The text for the language tag 'fo' is invalid: MultiLanguageNameType has a maximum length of "
-                         "64! (length: 65)", str(cm.exception))
-        mlnt = model.MultiLanguageNameType({"fo": "o" * 64})
+                         "128! (length: 129)", str(cm.exception))
+        mlnt = model.MultiLanguageNameType({"fo": "o" * 128})
         with self.assertRaises(ValueError) as cm:
             mlnt["fo"] = ""
         self.assertEqual("The text for the language tag 'fo' is invalid: MultiLanguageNameType has a minimum length of "
                          "1! (length: 0)", str(cm.exception))
-        self.assertEqual(mlnt["fo"], "o" * 64)
+        self.assertEqual(mlnt["fo"], "o" * 128)
         mlnt["fo"] = "o"
         self.assertEqual(mlnt["fo"], "o")
 


### PR DESCRIPTION
Until now, each value of a MultiLanguageNameType was constrained to a maximum length of 64 via check_short_name_type. This never matched the specification: LangStringNameType/text has had a maximum length of 128 characters since AAS Part 1 Metamodel V3.0, identical to NameType.

MultiLanguageNameType now uses check_name_type instead. The now-unused check_short_name_type and constrain_short_name_type functions are removed accordingly.

Fixes #576 