### PR TITLE
model.datatypes: Improve BCE date error message

### DIFF
--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -604,7 +604,8 @@ def _parse_xsd_date(value: str) -> Date:
     if not match:
         raise ValueError("Value is not a valid XSD date string")
     if match[1]:
-        raise ValueError("Negative Dates are not supported by Python")
+        raise NotImplementedError("Negative dates are not supported: Python stdlib datetime requires year >= 1. "
+                                  "Report at https://github.com/eclipse-basyx/basyx-python-sdk/issues")
     return Date(int(match[2]), int(match[3]), int(match[4]), _parse_xsd_date_tzinfo(match[5]))
 
 
@@ -613,7 +614,8 @@ def _parse_xsd_datetime(value: str) -> DateTime:
     if not match:
         raise ValueError("Value is not a valid XSD datetime string")
     if match[1]:
-        raise ValueError("Negative Dates are not supported by Python")
+        raise NotImplementedError("Negative dates are not supported: Python stdlib datetime requires year >= 1. "
+                                  "Report at https://github.com/eclipse-basyx/basyx-python-sdk/issues")
     microseconds = int(float(match[8]) * 1e6) if match[8] else 0
     return DateTime(int(match[2]), int(match[3]), int(match[4]), int(match[5]), int(match[6]), int(match[7]),
                     microseconds, _parse_xsd_date_tzinfo(match[9]))

--- a/sdk/test/model/test_datatypes.py
+++ b/sdk/test/model/test_datatypes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 the Eclipse BaSyx Authors
+# Copyright (c) 2026 the Eclipse BaSyx Authors
 #
 # This program and the accompanying materials are made available under the terms of the MIT License, available in
 # the LICENSE file of this project.

--- a/sdk/test/model/test_datatypes.py
+++ b/sdk/test/model/test_datatypes.py
@@ -143,6 +143,8 @@ class TestDateTimeTypes(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             model.datatypes.from_xsd("2020-01-24+11", model.datatypes.Date)
         self.assertEqual("Value is not a valid XSD date string", str(cm.exception))
+        with self.assertRaises(NotImplementedError):
+            model.datatypes.from_xsd("-2020-01-24", model.datatypes.Date)
 
     def test_serialize_date(self) -> None:
         self.assertEqual("2020-01-24", model.datatypes.xsd_repr(model.datatypes.Date(2020, 1, 24)))
@@ -211,6 +213,8 @@ class TestDateTimeTypes(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             model.datatypes.from_xsd("--2020-01-24T15:25:17-00:20", model.datatypes.DateTime)
         self.assertEqual("Value is not a valid XSD datetime string", str(cm.exception))
+        with self.assertRaises(NotImplementedError):
+            model.datatypes.from_xsd("-2020-01-24T15:25:17+01:00", model.datatypes.DateTime)
 
     def test_serialize_datetime(self) -> None:
         self.assertEqual("2020-01-24T15:25:17",


### PR DESCRIPTION
Fixes #565 

Previously `_parse_xsd_date()` and `_parse_xsd_datetime()` raised `ValueError("Negative Dates are not supported by Python")` when given an XSD value with a leading `-` (BCE year). This was technically false as input is not malformed, only not supported.

This change raises `NotImplementedError` instead, allowing callers to distinguish "invalid input" from "known SDK limitation.". Additionally pointing users to https://github.com/eclipse-basyx/basyx-python-sdk/issues to report the lack of implementation.