### PR TITLE
adapter: allow optional `valueId` in `ValueReferencePair` for JSON and XML

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -425,8 +425,10 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_value_reference_pair(cls, dct: Dict[str, object],
                                         object_class=model.ValueReferencePair) -> model.ValueReferencePair:
+        value_id_dict = dct.get('valueId')
+        value_id = cls._construct_reference(value_id_dict) if value_id_dict is not None else None
         return object_class(value=_get_ts(dct, 'value', str),
-                            value_id=cls._construct_reference(_get_ts(dct, 'valueId', dict)))
+                            value_id=value_id)
 
     # #############################################################################
     # Direct Constructor Methods (for classes with `modelType`) starting from here

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -425,10 +425,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
     @classmethod
     def _construct_value_reference_pair(cls, dct: Dict[str, object],
                                         object_class=model.ValueReferencePair) -> model.ValueReferencePair:
-        value_id_dict = dct.get('valueId')
-        value_id = cls._construct_reference(value_id_dict) if value_id_dict is not None else None
         return object_class(value=_get_ts(dct, 'value', str),
-                            value_id=value_id)
+                            value_id=cls._construct_reference(_get_ts(dct, 'valueId', dict))
+                            if 'valueId' in dct else None)
 
     # #############################################################################
     # Direct Constructor Methods (for classes with `modelType`) starting from here

--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -692,8 +692,9 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_blob(cls, dct: Dict[str, object], object_class=model.Blob) -> model.Blob:
+        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
         ret = object_class(id_short=None,
-                           content_type=_get_ts(dct, "contentType", str))
+                           content_type=content_type)
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct:
             ret.value = base64.b64decode(_get_ts(dct, 'value', str))
@@ -701,9 +702,10 @@ class AASFromJsonDecoder(json.JSONDecoder):
 
     @classmethod
     def _construct_file(cls, dct: Dict[str, object], object_class=model.File) -> model.File:
+        content_type = _get_ts(dct, "contentType", str) if 'contentType' in dct else None
         ret = object_class(id_short=None,
                            value=None,
-                           content_type=_get_ts(dct, "contentType", str))
+                           content_type=content_type)
         cls._amend_abstract_attributes(ret, dct)
         if 'value' in dct and dct['value'] is not None:
             ret.value = _get_ts(dct, 'value', str)

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -804,7 +804,7 @@ class AASFromXmlDecoder:
     def construct_blob(cls, element: etree._Element, object_class=model.Blob, **_kwargs: Any) -> model.Blob:
         blob = object_class(
             None,
-            _child_text_mandatory(element, NS_AAS + "contentType")
+            _get_text_or_none(element.find(NS_AAS + "contentType"))
         )
         value = _get_text_or_none(element.find(NS_AAS + "value"))
         if value is not None:
@@ -851,7 +851,7 @@ class AASFromXmlDecoder:
     def construct_file(cls, element: etree._Element, object_class=model.File, **_kwargs: Any) -> model.File:
         file = object_class(
             None,
-            _child_text_mandatory(element, NS_AAS + "contentType")
+            _get_text_or_none(element.find(NS_AAS + "contentType"))
         )
         value = _get_text_or_none(element.find(NS_AAS + "value"))
         if value is not None:

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1063,9 +1063,10 @@ class AASFromXmlDecoder:
     @classmethod
     def construct_value_reference_pair(cls, element: etree._Element, object_class=model.ValueReferencePair,
                                        **_kwargs: Any) -> model.ValueReferencePair:
+        value_id_element = element.find(NS_AAS + "valueId")
+        value_id = cls.construct_reference(value_id_element, **_kwargs) if value_id_element is not None else None 
         return object_class(_child_text_mandatory(element, NS_AAS + "value"),
-                            _child_construct_mandatory(element, NS_AAS + "valueId", cls.construct_reference))
-
+                            value_id)
     @classmethod
     def construct_value_list(cls, element: etree._Element, **_kwargs: Any) -> model.ValueList:
         """

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1067,7 +1067,7 @@ class AASFromXmlDecoder:
         value_id = cls.construct_reference(value_id_element, **_kwargs) if value_id_element is not None else None
         return object_class(_child_text_mandatory(element, NS_AAS + "value"),
                             value_id)
-        
+
     @classmethod
     def construct_value_list(cls, element: etree._Element, **_kwargs: Any) -> model.ValueList:
         """

--- a/sdk/basyx/aas/adapter/xml/xml_deserialization.py
+++ b/sdk/basyx/aas/adapter/xml/xml_deserialization.py
@@ -1064,9 +1064,10 @@ class AASFromXmlDecoder:
     def construct_value_reference_pair(cls, element: etree._Element, object_class=model.ValueReferencePair,
                                        **_kwargs: Any) -> model.ValueReferencePair:
         value_id_element = element.find(NS_AAS + "valueId")
-        value_id = cls.construct_reference(value_id_element, **_kwargs) if value_id_element is not None else None 
+        value_id = cls.construct_reference(value_id_element, **_kwargs) if value_id_element is not None else None
         return object_class(_child_text_mandatory(element, NS_AAS + "value"),
                             value_id)
+        
     @classmethod
     def construct_value_list(cls, element: etree._Element, **_kwargs: Any) -> model.ValueList:
         """


### PR DESCRIPTION
Previously, the JSON and XML deserializers raised a `KeyError` if a `ValueReferencePair` did not contain a `valueId`. 

However, according to the IDTA specification, `valueId` is explicitly optional (cardinality 0..1).

Fixes #562