### PR TITLE
adapter.json: Tighten `dataSpecification` ref type

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -278,7 +278,8 @@ class AASFromJsonDecoder(json.JSONDecoder):
                         # TODO: remove the following type: ignore comment when mypy supports abstract types for Type[T]
                         # see https://github.com/python/mypy/issues/5374
                         model.EmbeddedDataSpecification(
-                            data_specification=cls._construct_reference(_get_ts(dspec, 'dataSpecification', dict)),
+                            data_specification=cls._construct_external_reference(
+                                _get_ts(dspec, 'dataSpecification', dict)),
                             data_specification_content=_get_ts(dspec, 'dataSpecificationContent',
                                                                model.DataSpecificationContent)  # type: ignore
                         )


### PR DESCRIPTION
Previously, JSON deserialization accepted both `ModelReference` and `ExternalReference` for the `dataSpecification` field of `EmbeddedDataSpecification`. As the spec (constraint AASc-3a-050) requires `EmbeddedDataSpecification.dataSpecification` to be an `ExternalReference`, JSON deserialization was tightened to only accept `ExternalReference`. It now matches the requirement and the current behavior of XML deserialization.

Fixes #567