### PR TITLE
Update pyproject.toml name of compliance-tool

### DIFF
--- a/compliance_tool/pyproject.toml
+++ b/compliance_tool/pyproject.toml
@@ -20,7 +20,7 @@ root = ".."  # Defines the path to the root of the repository
 version_file = "aas_compliance_tool/version.py"
 
 [project]
-name = "aas_compliance_tool"
+name = "basyx-compliance-tool"
 dynamic = ["version"]
 description = "AAS compliance checker based on the Eclipse BaSyx Python SDK"
 authors = [


### PR DESCRIPTION
Previously, the compliance-tool package name still reflected the time we kept it separate from the basyx-python-sdk repository and published it ourselves.

As we now prepare to officially publish it via the Eclipse PyPI account, we update the name to reflect its affiliation with Eclipse BaSyx via: `basyx-compliance-tool` in the compliance-tool's `pyproject.toml`.