### PR TITLE
model.datatypes: Fix gYear/gYearMonth validation

### DIFF
--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -638,10 +638,10 @@ def _parse_xsd_bool(value: str) -> Boolean:
         raise ValueError("Invalid literal for XSD bool type")
 
 
-GYEAR_RE = re.compile(r'^(\d\d\d\d)([+\-]\d\d:\d\d|Z)?$')
+GYEAR_RE = re.compile(r'^(-?)(\d{4,})([+\-]\d\d:\d\d|Z)?$')
 GMONTH_RE = re.compile(r'^--(\d\d)([+\-]\d\d:\d\d|Z)?$')
 GDAY_RE = re.compile(r'^---(\d\d)([+\-]\d\d:\d\d|Z)?$')
-GYEARMONTH_RE = re.compile(r'^(\d\d\d\d)-(\d\d)([+\-]\d\d:\d\d|Z)?$')
+GYEARMONTH_RE = re.compile(r'^(-?)(\d{4,})-(\d\d)([+\-]\d\d:\d\d|Z)?$')
 GMONTHDAY_RE = re.compile(r'^--(\d\d)-(\d\d)([+\-]\d\d:\d\d|Z)?$')
 
 
@@ -649,7 +649,10 @@ def _parse_xsd_gyear(value: str) -> GYear:
     match = GYEAR_RE.match(value)
     if not match:
         raise ValueError("Value is not a valid XSD GYear string")
-    return GYear(int(match[1]), _parse_xsd_date_tzinfo(match[2]))
+    year = int(match[2])
+    if match[1]:
+        year = -year
+    return GYear(year, _parse_xsd_date_tzinfo(match[3]))
 
 
 def _parse_xsd_gmonth(value: str) -> GMonth:
@@ -670,7 +673,10 @@ def _parse_xsd_gyearmonth(value: str) -> GYearMonth:
     match = GYEARMONTH_RE.match(value)
     if not match:
         raise ValueError("Value is not a valid XSD GYearMonth string")
-    return GYearMonth(int(match[1]), int(match[2]), _parse_xsd_date_tzinfo(match[3]))
+    year = int(match[2])
+    if match[1]:
+        year = -year
+    return GYearMonth(year, int(match[3]), _parse_xsd_date_tzinfo(match[4]))
 
 
 def _parse_xsd_gmonthday(value: str) -> GMonthDay:

--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -110,8 +110,13 @@ class GYearMonth:
 
     @classmethod
     def from_date(cls, date: datetime.date) -> "GYearMonth":
-        tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
-        return cls(date.year, date.month, tzinfo)
+        try:
+            tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
+            return cls(date.year, date.month, tzinfo)
+        except ValueError as e:
+            if date.year < 0:
+                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
+            raise e
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, GYearMonth):
@@ -135,8 +140,13 @@ class GYear:
 
     @classmethod
     def from_date(cls, date: datetime.date) -> "GYear":
-        tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
-        return cls(date.year, tzinfo)
+        try:
+            tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
+            return cls(date.year, tzinfo)
+        except ValueError as e:
+            if date.year < 0:
+                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
+            raise e
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, GYear):
@@ -166,7 +176,7 @@ class GMonthDay:
     @classmethod
     def from_date(cls, date: datetime.date) -> "GMonthDay":
         tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
-        return cls(date.month, date.year, tzinfo)
+        return cls(date.month, date.day, tzinfo)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, GMonthDay):

--- a/sdk/basyx/aas/model/datatypes.py
+++ b/sdk/basyx/aas/model/datatypes.py
@@ -106,17 +106,17 @@ class GYearMonth:
         self.tzinfo: Optional[datetime.tzinfo] = tzinfo
 
     def into_date(self, day: int = 1) -> Date:
-        return Date(self.year, self.month, day, self.tzinfo)
+        try:
+            return Date(self.year, self.month, day, self.tzinfo)
+        except ValueError as e:
+            if self.year < 0:
+                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
+            raise e
 
     @classmethod
     def from_date(cls, date: datetime.date) -> "GYearMonth":
-        try:
-            tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
-            return cls(date.year, date.month, tzinfo)
-        except ValueError as e:
-            if date.year < 0:
-                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
-            raise e
+        tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
+        return cls(date.year, date.month, tzinfo)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, GYearMonth):
@@ -136,17 +136,17 @@ class GYear:
         self.tzinfo: Optional[datetime.tzinfo] = tzinfo
 
     def into_date(self, month: int = 1, day: int = 1) -> Date:
-        return Date(self.year, month, day, self.tzinfo)
+        try:
+            return Date(self.year, month, day, self.tzinfo)
+        except ValueError as e:
+            if self.year < 0:
+                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
+            raise e
 
     @classmethod
     def from_date(cls, date: datetime.date) -> "GYear":
-        try:
-            tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
-            return cls(date.year, tzinfo)
-        except ValueError as e:
-            if date.year < 0:
-                raise ValueError("Negative years are not supported by Python's `datetime` library.") from e
-            raise e
+        tzinfo = date.tzinfo if hasattr(date, 'tzinfo') else None  # type: ignore
+        return cls(date.year, tzinfo)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, GYear):

--- a/sdk/test/model/test_datatypes.py
+++ b/sdk/test/model/test_datatypes.py
@@ -156,10 +156,18 @@ class TestDateTimeTypes(unittest.TestCase):
     def test_parse_partial_dates(self) -> None:
         self.assertEqual(model.datatypes.GYear(2019),
                          model.datatypes.from_xsd("2019", model.datatypes.GYear))
+        self.assertEqual(model.datatypes.GYear(-2001),
+                         model.datatypes.from_xsd("-2001", model.datatypes.GYear))
+        self.assertEqual(model.datatypes.GYear(20000),
+                         model.datatypes.from_xsd("20000", model.datatypes.GYear))
         self.assertEqual(model.datatypes.GMonth(7),
                          model.datatypes.from_xsd("--07", model.datatypes.GMonth))
         self.assertEqual(model.datatypes.GYearMonth(2020, 5),
                          model.datatypes.from_xsd("2020-05", model.datatypes.GYearMonth))
+        self.assertEqual(model.datatypes.GYearMonth(-2001, 10),
+                         model.datatypes.from_xsd("-2001-10", model.datatypes.GYearMonth))
+        self.assertEqual(model.datatypes.GYearMonth(20000, 5),
+                         model.datatypes.from_xsd("20000-05", model.datatypes.GYearMonth))
         self.assertEqual(model.datatypes.GMonthDay(12, 6),
                          model.datatypes.from_xsd("--12-06", model.datatypes.GMonthDay))
         self.assertEqual(model.datatypes.GDay(23),

--- a/sdk/test/model/test_datatypes.py
+++ b/sdk/test/model/test_datatypes.py
@@ -188,6 +188,14 @@ class TestDateTimeTypes(unittest.TestCase):
             model.datatypes.from_xsd("10-10", model.datatypes.GYearMonth)
         self.assertEqual("Value is not a valid XSD GYearMonth string", str(cm.exception))
 
+    def test_partial_dates_negative_year_into_date(self) -> None:
+        # Python's `datetime` library does not support negative years. Converting a G-Class with a negative year into a
+        # `Date` must therefore fail with a clear error message instead of the cryptic "year -2001 is out of range".
+        for value in (model.datatypes.GYear(-2001), model.datatypes.GYearMonth(-2001, 5)):
+            with self.assertRaises(ValueError) as cm:
+                value.into_date()
+            self.assertEqual("Negative years are not supported by Python's `datetime` library.", str(cm.exception))
+
     def test_copy_date(self) -> None:
         date = model.datatypes.Date(2020, 1, 24)
         date_copy_shallow = copy.copy(date)


### PR DESCRIPTION
Previously, `GYEAR_RE` and `GYEARMONTH_RE` only matched exactly four digits and did not allow a leading minus sign. This rejected valid XSD values such as years with more than four digits (e.g. "20000") and negative years (e.g. "-2001"), even though the XSD spec permits both.

Additionally, `GMonthDay.from_date(...)` passed `date.year` instead of `date.day` to the constructor, and `into_date(...)` on `GYear`/`GYearMonth` raised Python's cryptic "year -2001 is out of range" error for negative years, since `datetime.date` does not support them.

This change widens the regular expressions to accept any number of digits and an optional leading minus sign, fixes the `GMonthDay. from_date(...)` argument order bug, and makes `into_date(...)` raise a clear `ValueError` when called on a G-Class with a negative year.

Fixes #566
