### PR TITLE
adapter.json: Remove duplicate `@classmethod`

### DIFF
--- a/sdk/basyx/aas/adapter/json/json_deserialization.py
+++ b/sdk/basyx/aas/adapter/json/json_deserialization.py
@@ -693,7 +693,6 @@ class AASFromJsonDecoder(json.JSONDecoder):
         return ret
 
     @classmethod
-    @classmethod
     def _construct_blob(cls, dct: Dict[str, object], object_class=model.Blob) -> model.Blob:
         ret = object_class(
             id_short=None,


### PR DESCRIPTION
Previously, `_construct_blob` in `json_deserialization.py` was decorated with `@classmethod` twice, producing a
`classmethod(classmethod(func))` wrapper.

On Python 3.10 and 3.12 (used in CI) this went unnoticed, because `classmethod` chained through the inner descriptor and still resolved to a callable bound method. Python 3.13 removed that descriptor chaining, so accessing `cls._construct_blob` now yields a raw, non-callable `classmethod` object. As a result, deserializing any `Blob` raised `TypeError: 'classmethod' object is not callable`, breaking JSON deserialization and the AASX round-trip tests on 3.13.

This change removes the redundant decorator so `_construct_blob` behaves like all other constructor methods.

This finding motivated #594.