### PR TITLE
Create `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,6 +4,6 @@
 # To ignore the commits, you can configure your git to automatically use this file with any git blame command:
 # git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-# Commit 112290a - 23.07.2026 - Introduce ruff as linter and formatter
-# This commit had no effect on the functionality but touched and reformated 10k lines
+# Commit 2026-07-23: Introduce ruff as linter and formatter
+# This commit had no effect on the functionality but touched and reformatted 10k lines
 112290a101f681030b7f895ded63a544764c073a

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# This file features commits that should be taken out of the git blame chain as they would clutter it with formatting
+# changes otherwise.
+
+# To ignore the commits, you can configure your git to automatically use this file with any git blame command:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Commit 112290a - 23.07.2026 - Introduce ruff as linter and formatter
+# This commit had no effect on the functionality but touched and reformated 10k lines
+112290a101f681030b7f895ded63a544764c073a


### PR DESCRIPTION
After the ruff linter introduction the git blame is mostly cluttered by the resulting changes. This file is introduced to generally feature commits that should be taken out of the git blame chain and quick setup instructions. The mentioned ruff commit being added as well.