### PR TITLE
Reintroduce the original logo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Eclipse BaSyx Python SDK
+<p align="center">
+  <img src="etc/logo.svg" alt="Eclipse BaSyx Python SDK logo" width="150">
+</p>
+
+<h1 align="center">Eclipse BaSyx Python SDK</h1>
 
 The Eclipse BaSyx Python project focuses on providing a Python implementation of the Asset Administration Shell (AAS) 
 for Industry 4.0 Systems.

--- a/etc/logo.svg
+++ b/etc/logo.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Eclipse BaSyx Python SDK logo, originally the PyI40AAS logo.
+  Copyright (c) 2019 Michael Thies <m.thies@plt.rwth-aachen.de>
+  Dedicated to the public domain under CC0 1.0:
+  https://creativecommons.org/publicdomain/zero/1.0/
+-->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 16.933334 16.933333" version="1.1" id="svg8">
+  <title id="title1062">Eclipse BaSyx Python SDK logo</title>
+  <defs id="defs2">
+    <linearGradient id="linearGradient1092">
+      <stop id="stop1088" offset="0" style="stop-color:#ffd647;stop-opacity:1" />
+      <stop id="stop1090" offset="1" style="stop-color:#ffd344;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient id="linearGradient1080">
+      <stop style="stop-color:#3770a1;stop-opacity:1" offset="0" id="stop1076" />
+      <stop style="stop-color:#3771a1;stop-opacity:0.05660377" offset="1" id="stop1078" />
+    </linearGradient>
+    <linearGradient id="linearGradient969">
+      <stop style="stop-color:#dcdcdc;stop-opacity:1" offset="0" id="stop965" />
+      <stop style="stop-color:#aeaeae;stop-opacity:1" offset="1" id="stop967" />
+    </linearGradient>
+    <linearGradient id="linearGradient961">
+      <stop style="stop-color:#b6b6b6;stop-opacity:1" offset="0" id="stop957" />
+      <stop style="stop-color:#818181;stop-opacity:1" offset="1" id="stop959" />
+    </linearGradient>
+    <linearGradient id="linearGradient11301">
+      <stop style="stop-color:#ffe052;stop-opacity:1" offset="0" id="stop11303" />
+      <stop style="stop-color:#ffc331;stop-opacity:1" offset="1" id="stop11305" />
+    </linearGradient>
+    <linearGradient id="linearGradient9515">
+      <stop style="stop-color:#387eb8;stop-opacity:1" offset="0" id="stop9517" />
+      <stop style="stop-color:#366994;stop-opacity:1" offset="1" id="stop9519" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient9515" id="linearGradient9521" x1="55.549179" y1="77.070274" x2="110.14919" y2="131.85291" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.09509387,0,0,0.09509387,-3.2035686,274.28414)" />
+    <linearGradient xlink:href="#linearGradient11301" id="linearGradient11307-7" x1="89.136749" y1="111.92053" x2="147.77737" y2="168.1012" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.28959046,0,0,-0.28959046,-21.27744,51.348669)" />
+    <linearGradient xlink:href="#linearGradient11301" id="linearGradient887" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07662081,0,0,-0.07662081,13.236154,295.22566)" x1="-41.898056" y1="167.72594" x2="-14.70578" y2="94.721718" />
+    <linearGradient xlink:href="#linearGradient9515" id="linearGradient893" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.09509387,0,0,0.09509387,-3.2035686,274.28414)" x1="55.549179" y1="77.070274" x2="110.14919" y2="131.85291" />
+    <linearGradient xlink:href="#linearGradient11301" id="linearGradient895" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.07662081,0,0,-0.07662081,13.236154,295.22566)" x1="-41.898056" y1="167.72594" x2="-14.70578" y2="94.721718" />
+    <linearGradient xlink:href="#linearGradient961" id="linearGradient963" x1="6.7155633" y1="291.85007" x2="7.0580635" y2="295.36996" gradientUnits="userSpaceOnUse" />
+    <linearGradient xlink:href="#linearGradient969" id="linearGradient971" x1="5.1433692" y1="293.3678" x2="5.1433692" y2="293.85223" gradientUnits="userSpaceOnUse" />
+    <linearGradient gradientTransform="matrix(3.7539844,0,0,3.7340549,-20.589225,-1089.6226)" xlink:href="#linearGradient961" id="linearGradient963-6" x1="6.7155633" y1="291.85007" x2="7.0580635" y2="295.36996" gradientUnits="userSpaceOnUse" />
+    <linearGradient xlink:href="#linearGradient961" id="linearGradient1041" gradientUnits="userSpaceOnUse" x1="6.7155633" y1="291.85007" x2="7.0580635" y2="295.36996" gradientTransform="matrix(1.0945985,0,0,1,-0.48476743,-0.42600996)" />
+    <radialGradient xlink:href="#linearGradient1080" id="radialGradient1082" cx="11.931281" cy="293.53543" fx="11.931281" fy="293.53543" r="3.1466597" gradientTransform="matrix(-1.3692452,-1.2531542e-5,2.9809826e-5,-3.2571379,21.322132,1241.8522)" gradientUnits="userSpaceOnUse" />
+    <radialGradient xlink:href="#linearGradient1092" id="radialGradient1086" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3692452,-1.2531542e-5,-2.9809826e-5,-3.2571379,-4.4218559,1241.8522)" cx="11.931281" cy="293.53543" fx="11.931281" fy="293.53543" r="3.1466597" />
+  </defs>
+  <metadata id="metadata5">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>PyAAS Logo</dc:title>
+        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:date>2019-11-13</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Michael Thies &lt;m.thies@plt.rwth-aachen.de&gt;</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1" transform="translate(0,-280.06667)">
+    <g id="g1096">
+      <path id="path1066" d="M 14.443431,284.39677 2.1733631,284.95201 V 297 H 14.443431 Z" style="fill:url(#radialGradient1082);fill-opacity:1;stroke:none;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.419" />
+      <path style="opacity:0.419;fill:url(#radialGradient1086);fill-opacity:1;stroke:none;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 2.4568451,284.39677 12.2700739,0.55524 V 297 H 2.4568451 Z" id="path1084" />
+    </g>
+    <g id="g891" transform="translate(-0.385865)">
+      <path style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient893);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458335;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" d="m 5.0963538,282.13586 0.00297,0.91771 h 2.2885999 v 0.35957 H 2.7754539 c 0,0 -1.7057464,-0.19344 -1.7057464,2.49622 0,2.68965 0.43048,8.505 0.43048,8.505 h 1.9468668 v -7.15883 c 0,0 -0.047894,-1.48881 1.46504,-1.48881 1.3134842,-4e-5 2.6269685,10e-6 3.9404527,10e-5 l -3e-7,-1.37005 v -2.30305 c 0,0 -0.081698,-0.73697 -1.8537191,-0.73697 -1.7720219,0 -1.9024738,0.77911 -1.9024738,0.77911 z m 1.1172829,-0.35066 c 0.2530857,0 0.4576393,0.20456 0.4576393,0.45765 0,0.25308 -0.2045536,0.45763 -0.4576393,0.45763 -0.2530857,0 -0.4576392,-0.20455 -0.4576392,-0.45763 0,-0.25309 0.2045535,-0.45765 0.4576392,-0.45765 z" id="path8615" />
+      <path id="path860" d="m 12.608739,282.13586 -0.003,0.91771 H 10.31714 v 0.35957 h 4.612469 c 0,0 1.705747,-0.19344 1.705747,2.49622 0,2.68965 -0.430481,8.505 -0.430481,8.505 h -1.946866 v -7.15883 c 0,0 0.04789,-1.48881 -1.46504,-1.48881 -1.313474,-4e-5 -2.626948,10e-6 -3.940422,10e-5 l -3e-7,-1.37005 v -2.30305 c 0,0 0.0817,-0.73697 1.8537193,-0.73697 1.772022,0 1.902473,0.77911 1.902473,0.77911 z m -1.117282,-0.35066 c -0.253086,0 -0.45764,0.20456 -0.45764,0.45765 0,0.25308 0.204554,0.45763 0.45764,0.45763 0.253085,0 0.457639,-0.20455 0.457639,-0.45763 0,-0.25309 -0.204554,-0.45765 -0.457639,-0.45765 z" style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient895);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458335;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    </g>
+    <g id="g943" transform="matrix(1.1892079,0,0,1.1828945,-1.2232941,-53.944846)" style="stroke:#666666;stroke-width:0.84313697">
+      <rect ry="0" y="293.3678" x="4.2530103" height="0.48443604" width="7.7904754" id="rect899" style="opacity:1;vector-effect:none;fill:url(#linearGradient971);fill-opacity:1;stroke:#999999;stroke-width:0.04996992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <rect ry="0.59058779" y="291.85007" x="5.5279016" height="3.5199034" width="6.0476193" id="rect897" style="opacity:1;vector-effect:none;fill:url(#linearGradient963);fill-opacity:1;stroke:#666666;stroke-width:0.0722779;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <path style="fill:none;stroke:#666666;stroke-width:0.11153999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 6.3733262,292.51156 H 10.991722" id="path903" />
+      <path style="fill:none;stroke:#666666;stroke-width:0.11153999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 6.3733262,294.70848 H 10.991722" id="path905" />
+      <path id="path913" d="M 6.3733262,293.61002 H 10.991722" style="fill:none;stroke:#666666;stroke-width:0.11153999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect y="295.36996" x="8.1383009" height="0.56701064" width="2.7521396" id="rect927" style="opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:#666666;stroke-width:0.0722779;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <path style="fill:none;stroke:#666666;stroke-width:0.11153999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 6.3733262,295.42113 H 10.991722" id="path915" />
+      <path id="path917" d="M 6.3733262,291.7989 H 10.991722" style="fill:none;stroke:#666666;stroke-width:0.11153999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect style="opacity:1;vector-effect:none;fill:url(#linearGradient1041);fill-opacity:1;stroke:#666666;stroke-width:0.0722779;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" id="rect973" width="0.91119701" height="4.2561884" x="5.1765022" y="291.48193" ry="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Previously, the SDK had no logo in its documentation. The original PyI40AAS logo was left behind when the project moved to the Eclipse Foundation, so the README carried no visual identity. This change restores it for recognition value.

The logo is taken from the archived ACPLT PyI40AAS repository and added as `etc/logo.svg`, stripped of the Inkscape and sodipodi editor attributes, including an export path that leaked the original author's home directory. The CC0 dedication and the attribution to Michael Thies are kept.

The `README.md` shows the logo centered above the title. GitHub draws a full-width rule under every `h1`, which would cut straight through a logo placed beside the heading, so the logo goes above it instead. The title is written as an `<h1 align="center">` tag rather than as a Markdown heading, because centering needs the `align` attribute.

A separate dark variant of the logo is not needed, as it stays legible on both the light and the dark GitHub theme.

Fixes #230