### PR TITLE
model: Name the violating attribute in string constraint errors

### DIFF
--- a/sdk/basyx/aas/model/_string_constraints.py
+++ b/sdk/basyx/aas/model/_string_constraints.py
@@ -27,7 +27,7 @@ The following types aliased in the :mod:`~basyx.aas.model.base` module are const
 """
 
 import re
-from typing import Callable, Optional, Type, TypeVar
+from typing import Callable, Optional, Protocol, Type, TypeVar
 
 _T = TypeVar("_T")
 AASD130_RE = re.compile("[\x09\x0a\x0d\x20-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]*")
@@ -40,6 +40,17 @@ def _unicode_escape(value: str) -> str:
     return value.encode("unicode_escape").decode("utf-8")
 
 
+def _subject(type_name: str, attribute: Optional[str]) -> str:
+    """
+    Returns the subject of the error messages of :func:`~.check`.
+
+    The name of the constrained type alone (e.g. ``NameType``) is hard to relate to the attribute that was
+    actually assigned, as the constrained types are only aliases of ``str``. Thus, the name of the attribute is
+    prepended, whenever it is known.
+    """
+    return type_name if attribute is None else f"{attribute} ({type_name})"
+
+
 # Functions to verify the constraints for a given value.
 def check(
     value: str,
@@ -47,18 +58,33 @@ def check(
     min_length: int = 0,
     max_length: Optional[int] = None,
     pattern: Optional[re.Pattern] = None,
+    attribute: Optional[str] = None,
 ) -> None:
+    """
+    Verifies the given constraints for the given value.
+
+    :param value: The value to check
+    :param type_name: Name of the constrained type the value belongs to, e.g. ``NameType``
+    :param min_length: Minimum length of the value
+    :param max_length: Maximum length of the value
+    :param pattern: Pattern the value must match
+    :param attribute: Qualified name of the attribute the value was assigned to, e.g. ``Property.id_short``.
+        It is included in the error messages, as the name of the constrained type alone is often not enough to
+        identify the cause of the error.
+    :raises ValueError: If one of the constraints is violated
+    """
+    subject = _subject(type_name, attribute)
     if len(value) < min_length:
         raise ValueError(
-            f"{type_name} has a minimum length of {min_length}! (length: {len(value)})"
+            f"{subject} has a minimum length of {min_length}! (length: {len(value)})"
         )
     if max_length is not None and len(value) > max_length:
         raise ValueError(
-            f"{type_name} has a maximum length of {max_length}! (length: {len(value)})"
+            f"{subject} has a maximum length of {max_length}! (length: {len(value)})"
         )
     if pattern is not None and not pattern.fullmatch(value):
         raise ValueError(
-            f"{type_name} must match the pattern '{_unicode_escape(pattern.pattern)}'! "
+            f"{subject} must match the pattern '{_unicode_escape(pattern.pattern)}'! "
             f"(value: '{_unicode_escape(value)}')"
         )
     # Constraint AASd-130: an attribute with data type "string" shall consist of these characters only:
@@ -67,50 +93,85 @@ def check(
         # imported from `base` and the ConstrainedLangStringSet would need to except AASConstraintViolation errors
         # as well, while only re-raising ValueErrors. Thus, even if an AASConstraintViolation would be raised here,
         # in case of a ConstrainedLangStringSet it would be re-raised as a ValueError anyway.
+        prefix = "" if attribute is None else f"{subject}: "
         raise ValueError(
-            f"Every string must match the pattern '{_unicode_escape(AASD130_RE.pattern)}'! "
-            f"(value: '{_unicode_escape(value)}')"
+            f"{prefix}Every string must match the pattern "
+            f"'{_unicode_escape(AASD130_RE.pattern)}'! (value: '{_unicode_escape(value)}')"
         )
 
 
-def check_content_type(value: str, type_name: str = "ContentType") -> None:
-    return check(value, type_name, 1, 128)
+def check_content_type(
+    value: str, type_name: str = "ContentType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 128, attribute=attribute)
 
 
-def check_identifier(value: str, type_name: str = "Identifier") -> None:
-    return check(value, type_name, 1, 2048)
+def check_identifier(
+    value: str, type_name: str = "Identifier", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 2048, attribute=attribute)
 
 
-def check_label_type(value: str, type_name: str = "LabelType") -> None:
-    return check(value, type_name, 1, 64)
+def check_label_type(
+    value: str, type_name: str = "LabelType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 64, attribute=attribute)
 
 
-def check_message_topic_type(value: str, type_name: str = "MessageTopicType") -> None:
-    return check(value, type_name, 1, 255)
+def check_message_topic_type(
+    value: str, type_name: str = "MessageTopicType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 255, attribute=attribute)
 
 
-def check_name_type(value: str, type_name: str = "NameType") -> None:
-    return check(value, type_name, 1, 128)
+def check_name_type(
+    value: str, type_name: str = "NameType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 128, attribute=attribute)
 
 
-def check_path_type(value: str, type_name: str = "PathType") -> None:
-    return check(value, type_name, 1, 2048)
+def check_path_type(
+    value: str, type_name: str = "PathType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 2048, attribute=attribute)
 
 
-def check_qualifier_type(value: str, type_name: str = "QualifierType") -> None:
-    return check_name_type(value, type_name)
+def check_qualifier_type(
+    value: str, type_name: str = "QualifierType", attribute: Optional[str] = None
+) -> None:
+    return check_name_type(value, type_name, attribute=attribute)
 
 
-def check_revision_type(value: str, type_name: str = "RevisionType") -> None:
-    return check(value, type_name, 1, 4, re.compile(r"([0-9]|[1-9][0-9]*)"))
+def check_revision_type(
+    value: str, type_name: str = "RevisionType", attribute: Optional[str] = None
+) -> None:
+    return check(
+        value,
+        type_name,
+        1,
+        4,
+        re.compile(r"([0-9]|[1-9][0-9]*)"),
+        attribute=attribute,
+    )
 
 
-def check_value_type_iec61360(value: str, type_name: str = "ValueTypeIEC61360") -> None:
-    return check(value, type_name, 1, 2048)
+def check_value_type_iec61360(
+    value: str, type_name: str = "ValueTypeIEC61360", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 2048, attribute=attribute)
 
 
-def check_version_type(value: str, type_name: str = "VersionType") -> None:
-    return check(value, type_name, 1, 4, re.compile(r"([0-9]|[1-9][0-9]*)"))
+def check_version_type(
+    value: str, type_name: str = "VersionType", attribute: Optional[str] = None
+) -> None:
+    return check(
+        value,
+        type_name,
+        1,
+        4,
+        re.compile(r"([0-9]|[1-9][0-9]*)"),
+        attribute=attribute,
+    )
 
 
 def create_check_function(
@@ -127,15 +188,27 @@ def create_check_function(
     length and pattern rules.
     """
 
-    def check_fn(value: str, type_name: str) -> None:
-        return check(value, type_name, min_length, max_length, pattern)
+    def check_fn(value: str, type_name: str, attribute: Optional[str] = None) -> None:
+        return check(
+            value, type_name, min_length, max_length, pattern, attribute=attribute
+        )
 
     return check_fn
 
 
+class ConstraintCheckFunction(Protocol):
+    """
+    Type of the ``check_<type>()`` functions of this module, e.g. :func:`~.check_name_type`.
+    """
+
+    def __call__(
+        self, value: str, type_name: str = ..., attribute: Optional[str] = None
+    ) -> None: ...
+
+
 # Decorator functions to add getter/setter to classes for verification, whenever a value is updated.
 def constrain_attr(
-    pub_attr_name: str, constraint_check_fn: Callable[[str], None]
+    pub_attr_name: str, constraint_check_fn: ConstraintCheckFunction
 ) -> Callable[[Type[_T]], Type[_T]]:
     def decorator_fn(decorated_class: Type[_T]) -> Type[_T]:
         def _getter(self) -> Optional[str]:
@@ -144,7 +217,11 @@ def constrain_attr(
         def _setter(self, value: Optional[str]) -> None:
             # if value is None, skip checks. incorrect 'None' assignments are caught by the type checker anyway
             if value is not None:
-                constraint_check_fn(value)
+                # The type of self is used instead of the decorated class, so that the error message contains the
+                # name of the concrete class the attribute was assigned on, e.g. Property instead of Referable.
+                constraint_check_fn(
+                    value, attribute=f"{type(self).__name__}.{pub_attr_name}"
+                )
             setattr(self, "_" + pub_attr_name, value)
 
         if hasattr(decorated_class, pub_attr_name):

--- a/sdk/basyx/aas/model/aas.py
+++ b/sdk/basyx/aas/model/aas.py
@@ -114,7 +114,9 @@ class AssetInformation:
     @staticmethod
     def _validate_global_asset_id(global_asset_id: Optional[base.Identifier]) -> None:
         if global_asset_id is not None:
-            _string_constraints.check_identifier(global_asset_id)
+            _string_constraints.check_identifier(
+                global_asset_id, attribute="AssetInformation.global_asset_id"
+            )
 
     @staticmethod
     def _validate_aasd_131(
@@ -126,7 +128,9 @@ class AssetInformation:
                 "An AssetInformation has to have a globalAssetId or a specificAssetId",
             )
         if global_asset_id is not None:
-            _string_constraints.check_identifier(global_asset_id)
+            _string_constraints.check_identifier(
+                global_asset_id, attribute="AssetInformation.global_asset_id"
+            )
 
     def __repr__(self) -> str:
         return (

--- a/sdk/basyx/aas/model/aas.py
+++ b/sdk/basyx/aas/model/aas.py
@@ -111,11 +111,13 @@ class AssetInformation:
     ) -> None:
         self._validate_aasd_131(self.global_asset_id, len(old_list) > 1)
 
-    @staticmethod
-    def _validate_global_asset_id(global_asset_id: Optional[base.Identifier]) -> None:
+    @classmethod
+    def _validate_global_asset_id(
+        cls, global_asset_id: Optional[base.Identifier]
+    ) -> None:
         if global_asset_id is not None:
             _string_constraints.check_identifier(
-                global_asset_id, attribute="AssetInformation.global_asset_id"
+                global_asset_id, attribute=f"{cls.__name__}.global_asset_id"
             )
 
     @staticmethod
@@ -126,10 +128,6 @@ class AssetInformation:
             raise base.AASConstraintViolation(
                 131,
                 "An AssetInformation has to have a globalAssetId or a specificAssetId",
-            )
-        if global_asset_id is not None:
-            _string_constraints.check_identifier(
-                global_asset_id, attribute="AssetInformation.global_asset_id"
             )
 
     def __repr__(self) -> str:

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -491,7 +491,9 @@ class Key:
         """
         TODO: Add instruction what to do after construction
         """
-        _string_constraints.check_identifier(value, attribute="Key.value")
+        _string_constraints.check_identifier(
+            value, attribute=f"{type(self).__name__}.value"
+        )
         self.type: KeyTypes
         self.value: Identifier
         super().__setattr__("type", type_)
@@ -1474,7 +1476,7 @@ class AdministrativeInformation(HasDataSpecification):
             )
         if revision is not None:
             _string_constraints.check_revision_type(
-                revision, attribute="AdministrativeInformation.revision"
+                revision, attribute=f"{type(self).__name__}.revision"
             )
         self._revision = revision
 
@@ -2608,8 +2610,12 @@ class SpecificAssetId(HasSemantics):
         super().__init__()
         if value == "":
             raise ValueError("value is not allowed to be an empty string")
-        _string_constraints.check_label_type(name, attribute="SpecificAssetId.name")
-        _string_constraints.check_identifier(value, attribute="SpecificAssetId.value")
+        _string_constraints.check_label_type(
+            name, attribute=f"{type(self).__name__}.name"
+        )
+        _string_constraints.check_identifier(
+            value, attribute=f"{type(self).__name__}.value"
+        )
         self.name: LabelType
         self.value: Identifier
         self.external_subject_id: ExternalReference

--- a/sdk/basyx/aas/model/base.py
+++ b/sdk/basyx/aas/model/base.py
@@ -491,7 +491,7 @@ class Key:
         """
         TODO: Add instruction what to do after construction
         """
-        _string_constraints.check_identifier(value)
+        _string_constraints.check_identifier(value, attribute="Key.value")
         self.type: KeyTypes
         self.value: Identifier
         super().__setattr__("type", type_)
@@ -811,7 +811,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
         :raises ValueError: if the constraint is not fulfilled
         """
         if category is not None:
-            _string_constraints.check_name_type(category)
+            _string_constraints.check_name_type(
+                category, attribute=f"{type(self).__name__}.category"
+            )
         self._category = category
 
     def _get_category(self) -> Optional[NameType]:
@@ -882,7 +884,9 @@ class Referable(HasExtension, metaclass=abc.ABCMeta):
             (see :func:`~basyx.aas.model._string_constraints.check_name_type`).
         :raises AASConstraintViolation: If the id_short doesn't comply to Constraint AASd-002.
         """
-        _string_constraints.check_name_type(id_short)
+        _string_constraints.check_name_type(
+            id_short, attribute=f"{cls.__name__}.id_short"
+        )
         test_id_short: NameType = str(id_short)
         if not re.fullmatch("[A-Za-z0-9_-]*", test_id_short):
             raise AASConstraintViolation(
@@ -1469,7 +1473,9 @@ class AdministrativeInformation(HasDataSpecification):
                 "there is no revision neither. Please set version first.",
             )
         if revision is not None:
-            _string_constraints.check_revision_type(revision)
+            _string_constraints.check_revision_type(
+                revision, attribute="AdministrativeInformation.revision"
+            )
         self._revision = revision
 
     revision = property(_get_revision, _set_revision)
@@ -1757,7 +1763,9 @@ class Extension(HasSemantics):
 
     @name.setter
     def name(self, name: NameType) -> None:
-        _string_constraints.check_name_type(name)
+        _string_constraints.check_name_type(
+            name, attribute=f"{type(self).__name__}.name"
+        )
         if self.parent is not None:
             for set_ in self.parent.namespace_element_sets:
                 if set_.contains_id("name", name):
@@ -1913,7 +1921,9 @@ class Qualifier(HasSemantics):
 
     @type.setter
     def type(self, type_: QualifierType) -> None:
-        _string_constraints.check_qualifier_type(type_)
+        _string_constraints.check_qualifier_type(
+            type_, attribute=f"{type(self).__name__}.type"
+        )
         if self.parent is not None:
             for set_ in self.parent.namespace_element_sets:
                 if set_.contains_id("type", type_):
@@ -2598,8 +2608,8 @@ class SpecificAssetId(HasSemantics):
         super().__init__()
         if value == "":
             raise ValueError("value is not allowed to be an empty string")
-        _string_constraints.check_label_type(name)
-        _string_constraints.check_identifier(value)
+        _string_constraints.check_label_type(name, attribute="SpecificAssetId.name")
+        _string_constraints.check_identifier(value, attribute="SpecificAssetId.value")
         self.name: LabelType
         self.value: Identifier
         self.external_subject_id: ExternalReference

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1421,11 +1421,13 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
             self.entity_type, self.global_asset_id, len(old_list) > 1
         )
 
-    @staticmethod
-    def _validate_global_asset_id(global_asset_id: Optional[base.Identifier]) -> None:
+    @classmethod
+    def _validate_global_asset_id(
+        cls, global_asset_id: Optional[base.Identifier]
+    ) -> None:
         if global_asset_id is not None:
             _string_constraints.check_identifier(
-                global_asset_id, attribute="Entity.global_asset_id"
+                global_asset_id, attribute=f"{cls.__name__}.global_asset_id"
             )
 
     @staticmethod

--- a/sdk/basyx/aas/model/submodel.py
+++ b/sdk/basyx/aas/model/submodel.py
@@ -1424,7 +1424,9 @@ class Entity(SubmodelElement, base.UniqueIdShortNamespace):
     @staticmethod
     def _validate_global_asset_id(global_asset_id: Optional[base.Identifier]) -> None:
         if global_asset_id is not None:
-            _string_constraints.check_identifier(global_asset_id)
+            _string_constraints.check_identifier(
+                global_asset_id, attribute="Entity.global_asset_id"
+            )
 
     @staticmethod
     def _validate_aasd_014(

--- a/sdk/test/model/test_string_constraints.py
+++ b/sdk/test/model/test_string_constraints.py
@@ -91,13 +91,14 @@ class StringConstraintsDecoratorTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             self.DummyClass("")
         self.assertEqual(
-            "PathType has a minimum length of 1! (length: 0)", cm.exception.args[0]
+            "DummyClass.some_attr (PathType) has a minimum length of 1! (length: 0)",
+            cm.exception.args[0],
         )
         dc = self.DummyClass("a")
         with self.assertRaises(ValueError) as cm:
             dc.some_attr = "a" * 2049
         self.assertEqual(
-            "PathType has a maximum length of 2048! (length: 2049)",
+            "DummyClass.some_attr (PathType) has a maximum length of 2048! (length: 2049)",
             cm.exception.args[0],
         )
         self.assertEqual(dc.some_attr, "a")
@@ -132,3 +133,78 @@ class StringConstraintsDecoratorTest(unittest.TestCase):
         self.assertEqual(
             "DummyClass2 already has an attribute named 'bar'", cm.exception.args[0]
         )
+
+
+class StringConstraintsAttributeTest(unittest.TestCase):
+    """
+    Tests that constraint violations name the attribute that caused them, see issue #203
+    """
+
+    def test_check_function_attribute(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            _string_constraints.check_name_type("", attribute="Property.id_short")
+        self.assertEqual(
+            "Property.id_short (NameType) has a minimum length of 1! (length: 0)",
+            cm.exception.args[0],
+        )
+        with self.assertRaises(ValueError) as cm:
+            _string_constraints.check_version_type(
+                "v1", attribute="AdministrativeInformation.version"
+            )
+        self.assertEqual(
+            "AdministrativeInformation.version (VersionType) must match the pattern "
+            "'([0-9]|[1-9][0-9]*)'! (value: 'v1')",
+            cm.exception.args[0],
+        )
+        with self.assertRaises(ValueError) as cm:
+            _string_constraints.check_name_type("\0", attribute="Property.id_short")
+        self.assertEqual(
+            r"Property.id_short (NameType): Every string must match the pattern "
+            r"'[\t\n\r -\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]*'! (value: '\x00')",
+            cm.exception.args[0],
+        )
+
+    def test_metamodel_attributes(self) -> None:
+        # Note that the reported class is the class the attribute was assigned on, not the class the constraint
+        # was defined on: `category` and `id_short` are constrained in Referable, but reported as Property.
+        expected_messages = {
+            lambda: model.Property(
+                "a" * 129, model.datatypes.Int
+            ): "Property.id_short (NameType) has a maximum length of 128! (length: 129)",
+            lambda: model.Property(
+                "Prop", model.datatypes.Int, category="a" * 129
+            ): "Property.category (NameType) has a maximum length of 128! (length: 129)",
+            lambda: model.Submodel(
+                ""
+            ): "Submodel.id (Identifier) has a minimum length of 1! (length: 0)",
+            lambda: model.File(
+                "File", "a" * 129
+            ): "File.content_type (ContentType) has a maximum length of 128! (length: 129)",
+            lambda: model.Qualifier(
+                "", model.datatypes.Int
+            ): "Qualifier.type (QualifierType) has a minimum length of 1! (length: 0)",
+            lambda: model.Extension(
+                "a" * 129
+            ): "Extension.name (NameType) has a maximum length of 128! (length: 129)",
+            lambda: model.Key(
+                model.KeyTypes.SUBMODEL, ""
+            ): "Key.value (Identifier) has a minimum length of 1! (length: 0)",
+            lambda: model.AdministrativeInformation(
+                version="1", revision="a"
+            ): "AdministrativeInformation.revision (RevisionType) must match the pattern "
+            "'([0-9]|[1-9][0-9]*)'! (value: 'a')",
+            lambda: model.SpecificAssetId(
+                "a" * 65, "value"
+            ): "SpecificAssetId.name (LabelType) has a maximum length of 64! (length: 65)",
+            lambda: model.AssetInformation(
+                global_asset_id=""
+            ): "AssetInformation.global_asset_id (Identifier) has a minimum length of 1! (length: 0)",
+            lambda: model.Entity(
+                "Entity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id=""
+            ): "Entity.global_asset_id (Identifier) has a minimum length of 1! (length: 0)",
+        }
+        for construct, expected_message in expected_messages.items():
+            with self.subTest(expected_message):
+                with self.assertRaises(ValueError) as cm:
+                    construct()
+                self.assertEqual(expected_message, cm.exception.args[0])

--- a/sdk/test/model/test_string_constraints.py
+++ b/sdk/test/model/test_string_constraints.py
@@ -208,3 +208,24 @@ class StringConstraintsAttributeTest(unittest.TestCase):
                 with self.assertRaises(ValueError) as cm:
                     construct()
                 self.assertEqual(expected_message, cm.exception.args[0])
+
+    def test_subclasses(self) -> None:
+        # Subclasses defined outside of this repository are reported by their own name as well
+        class MyProperty(model.Property):
+            pass
+
+        class MyEntity(model.Entity):
+            pass
+
+        with self.assertRaises(ValueError) as cm:
+            MyProperty("a" * 129, model.datatypes.Int)
+        self.assertEqual(
+            "MyProperty.id_short (NameType) has a maximum length of 128! (length: 129)",
+            cm.exception.args[0],
+        )
+        with self.assertRaises(ValueError) as cm:
+            MyEntity("Entity", model.EntityType.SELF_MANAGED_ENTITY, global_asset_id="")
+        self.assertEqual(
+            "MyEntity.global_asset_id (Identifier) has a minimum length of 1! (length: 0)",
+            cm.exception.args[0],
+        )

--- a/server/app/interfaces/_string_constraints.py
+++ b/server/app/interfaces/_string_constraints.py
@@ -20,29 +20,39 @@ The following types aliased in the :mod:`~server.app.interfaces.base` module are
 - :class:`~server.app.interfaces.base.SchemeType`
 """
 
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
 from basyx.aas.model._string_constraints import _T, check, constrain_attr
 
 
-def check_code_type(value: str, type_name: str = "CodeType") -> None:
-    return check(value, type_name, 1, 32)
+def check_code_type(
+    value: str, type_name: str = "CodeType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 32, attribute=attribute)
 
 
-def check_short_id_type(value: str, type_name: str = "ShortIdType") -> None:
-    return check(value, type_name, 1, 128)
+def check_short_id_type(
+    value: str, type_name: str = "ShortIdType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 128, attribute=attribute)
 
 
-def check_locator_type(value: str, type_name: str = "LocatorType") -> None:
-    return check(value, type_name, 1, 2048)
+def check_locator_type(
+    value: str, type_name: str = "LocatorType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 2048, attribute=attribute)
 
 
-def check_text_type(value: str, type_name: str = "TextType") -> None:
-    return check(value, type_name, 1, 2048)
+def check_text_type(
+    value: str, type_name: str = "TextType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 2048, attribute=attribute)
 
 
-def check_scheme_type(value: str, type_name: str = "SchemeType") -> None:
-    return check(value, type_name, 1, 128)
+def check_scheme_type(
+    value: str, type_name: str = "SchemeType", attribute: Optional[str] = None
+) -> None:
+    return check(value, type_name, 1, 128, attribute=attribute)
 
 
 def constrain_code_type(pub_attr_name: str) -> Callable[[Type[_T]], Type[_T]]:


### PR DESCRIPTION
The constrained string types are aliases of `str`, so an error message
that only names the type is hard to relate to the assignment that caused
it. Two different attributes of the same class produce the very same
message, as both `Property.id_short` and `Property.category` are a
`NameType`:

```
ValueError: NameType has a maximum length of 128! (length: 129)
```

The check functions of the `_string_constraints` module take the
qualified name of the attribute now, which is prepended to the message:

```
ValueError: Property.id_short (NameType) has a maximum length of 128! (length: 129)
ValueError: Property.category (NameType) has a maximum length of 128! (length: 129)
ValueError: Submodel.id (Identifier) has a minimum length of 1! (length: 0)
ValueError: AdministrativeInformation.version (VersionType) must match the pattern '([0-9]|[1-9][0-9]*)'! (value: 'v1')
```

The name of the class is determined at runtime, so the class the
attribute was assigned on is reported, rather than the class the
constraint is defined on: `id_short` is constrained in `Referable`, but
reported as `Property`. Subclasses defined by users of the SDK are
reported by their own name as well.

The attribute is optional, thus `check_name_type("")` and the other
check functions still raise the previous message when called without it.
This is the case for the `ConstrainedLangStringSet`s, which are objects
of their own and therefore don't know the attribute they are assigned
to. They name the language tag of the offending text instead:

```
ValueError: The text for the language tag 'en' is invalid: MultiLanguageNameType has a maximum length of 128! (length: 200)
```

Two smaller changes came out of this:

- `AssetInformation._validate_global_asset_id()` and
  `Entity._validate_global_asset_id()` are classmethods instead of
  staticmethods, as the class is needed for the message.
- `AssetInformation._validate_aasd_131()` repeated the Identifier check
  of `_validate_global_asset_id()`, which is called right before it at
  every call site anyway. It only validates Constraint AASd-131 now,
  just like `Entity._validate_aasd_014()` does.

The idea of using `typing.NewType` for the aliases, as suggested in the
issue, was not pursued: it would make every plain string an error for
users of the SDK, as `NameType("Prop")` would be required instead of
just `"Prop"`. Rendering the aliases in the documentation as their own
name rather than `str` seems better addressed by `autodoc_type_aliases`,
which would be a separate change.

Fixes #203
